### PR TITLE
feat: clear all params and filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:local": "npm run build:shared && npm run build:browsers",
     "build:shared": "ng build --project=hee-shared",
     "build:browsers": "node supported.browsers.node.ts",
-    "test": "ng test",
+    "test": "ng test --code-coverage=true",
     "test:ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage=true",
     "lint": "ng lint && npm run lint:styles",
     "lint:styles": "stylelint \"src/**/*.scss\"",

--- a/src/app/core/trainee/constants.ts
+++ b/src/app/core/trainee/constants.ts
@@ -1,1 +1,7 @@
+import { Sort } from "@angular/material/sort";
+
 export const DEFAULT_ROUTE = "/trainees";
+export const DEFAULT_ROUTE_SORT: Sort = {
+  active: "submissionDate",
+  direction: "asc"
+};

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.html
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.html
@@ -1,0 +1,1 @@
+<span class="cursor-pointer" (click)="resetTraineeList()">Clear all</span>

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
@@ -1,0 +1,33 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule } from "@ngxs/store";
+import { TraineesState } from "../state/trainees.state";
+
+import { ResetTraineeListComponent } from "./reset-trainee-list.component";
+
+describe("ResetTraineeListComponent", () => {
+  let component: ResetTraineeListComponent;
+  let fixture: ComponentFixture<ResetTraineeListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ResetTraineeListComponent],
+      imports: [
+        RouterTestingModule,
+        NgxsModule.forRoot([TraineesState]),
+        HttpClientTestingModule
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResetTraineeListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
@@ -1,0 +1,36 @@
+import { Component } from "@angular/core";
+import { Sort } from "@angular/material/sort";
+import { Router } from "@angular/router";
+import { Select, Store } from "@ngxs/store";
+import { Observable } from "rxjs";
+import { DEFAULT_ROUTE_SORT } from "../../core/trainee/constants";
+import {
+  ClearTraineesFilter,
+  GetTrainees,
+  ResetTraineesSort
+} from "../state/trainees.actions";
+import { TraineesState } from "../state/trainees.state";
+
+@Component({
+  selector: "app-reset-trainee-list",
+  templateUrl: "./reset-trainee-list.component.html"
+})
+export class ResetTraineeListComponent {
+  public defaultSort: Sort = DEFAULT_ROUTE_SORT;
+  @Select(TraineesState.sort) sort$: Observable<Sort>;
+  constructor(private store: Store, private router: Router) {}
+
+  public resetTraineeList(): void {
+    this.store
+      .dispatch([
+        new ResetTraineesSort(),
+        new ClearTraineesFilter(),
+        new GetTrainees()
+      ])
+      .subscribe(() =>
+        this.router.navigate(["/trainees"], {
+          queryParams: this.defaultSort
+        })
+      );
+  }
+}

--- a/src/app/trainees/state/trainees.actions.ts
+++ b/src/app/trainees/state/trainees.actions.ts
@@ -9,9 +9,17 @@ export class SortTrainees {
   constructor(public column: string, public direction: SortDirection) {}
 }
 
+export class ResetTraineesSort {
+  static readonly type = "[Trainees] Reset Sort";
+}
+
 export class FilterTrainees {
   static readonly type = "[Trainees] Filter";
   constructor(public filter: string) {}
+}
+
+export class ClearTraineesFilter {
+  static readonly type = "[Trainees] Clear Filter";
 }
 
 export class SearchTrainees {

--- a/src/app/trainees/state/trainees.state.ts
+++ b/src/app/trainees/state/trainees.state.ts
@@ -3,9 +3,14 @@ import { Injectable } from "@angular/core";
 import { Sort } from "@angular/material/sort";
 import { State, Action, StateContext, Selector } from "@ngxs/store";
 import { tap } from "rxjs/operators";
+import { DEFAULT_ROUTE_SORT } from "../../core/trainee/constants";
 import { ITrainee } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
-import { GetTrainees, SortTrainees } from "./trainees.actions";
+import {
+  GetTrainees,
+  ResetTraineesSort,
+  SortTrainees
+} from "./trainees.actions";
 
 export class TraineesStateModel {
   public items: ITrainee[];
@@ -28,6 +33,7 @@ export class TraineesStateModel {
 })
 @Injectable()
 export class TraineesState {
+  public defaultSort: Sort = DEFAULT_ROUTE_SORT;
   constructor(private traineeService: TraineeService) {}
 
   @Selector()
@@ -84,6 +90,17 @@ export class TraineesState {
         active: action.column,
         direction: action.direction
       }
+    });
+  }
+
+  @Action(ResetTraineesSort)
+  resetTraineesSort(ctx: StateContext<TraineesStateModel>) {
+    const state = ctx.getState();
+    return ctx.setState({
+      ...state,
+      items: null,
+      loading: true,
+      sort: this.defaultSort
     });
   }
 }

--- a/src/app/trainees/trainee-list/trainee-list.component.html
+++ b/src/app/trainees/trainee-list/trainee-list.component.html
@@ -5,6 +5,7 @@
     *ngIf="sort$ | async as sort"
     [dataSource]="trainees"
     matSort
+    matSortDisableClear
     (matSortChange)="sortTrainees($event)"
     [matSortActive]="sort.active"
     [matSortDirection]="sort.direction"

--- a/src/app/trainees/trainee-list/trainee-list.component.spec.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.spec.ts
@@ -35,7 +35,7 @@ describe("UnderNoticeComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should dispatch 'GetUnderNoticeTrainees' on init", () => {
+  it("should dispatch 'GetTrainees' on init", () => {
     spyOn(store, "dispatch");
     component.ngOnInit();
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());

--- a/src/app/trainees/trainee-list/trainee-list.component.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.ts
@@ -6,9 +6,13 @@ import {
   ITraineeDataCell
 } from "../../core/trainee/trainee.interfaces";
 import { Select, Store } from "@ngxs/store";
-import { GetTrainees, SortTrainees } from "../state/trainees.actions";
+import {
+  GetTrainees,
+  ResetTraineesSort,
+  SortTrainees
+} from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 
 @Component({
   selector: "app-trainee-list",
@@ -81,17 +85,23 @@ export class TraineeListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.emitTraineeListEvents();
+    this.setupInitialSorting();
+    this.store.dispatch(new GetTrainees());
   }
 
-  private emitTraineeListEvents(): void {
-    this.store.dispatch(
-      new SortTrainees(
-        this.route.snapshot.queryParams.active || null,
-        this.route.snapshot.queryParams.direction || null
-      )
-    );
-    this.store.dispatch(new GetTrainees());
+  /**
+   * Check if sorting query params exist
+   * Then dispatch appropriate event
+   * And update store accordingly
+   */
+  public setupInitialSorting(): void {
+    const params: Params = this.route.snapshot.queryParams;
+
+    if (params.active && params.direction) {
+      this.store.dispatch(new SortTrainees(params.active, params.direction));
+    } else {
+      this.store.dispatch(new ResetTraineesSort());
+    }
   }
 
   public traineeDetails(event: Event, row: ITrainee): void {
@@ -100,19 +110,18 @@ export class TraineeListComponent implements OnInit {
   }
 
   public sortTrainees(event: Sort): void {
-    if (event.direction.length) {
-      this.router
-        .navigate(["/trainees"], {
+    this.store
+      .dispatch([
+        new SortTrainees(event.active, event.direction),
+        new GetTrainees()
+      ])
+      .subscribe(() =>
+        this.router.navigate(["/trainees"], {
           queryParams: {
             active: event.active,
             direction: event.direction
           }
         })
-        .then(() => this.emitTraineeListEvents());
-    } else {
-      this.router
-        .navigate(["/trainees"])
-        .then(() => this.emitTraineeListEvents());
-    }
+      );
   }
 }

--- a/src/app/trainees/trainees.component.html
+++ b/src/app/trainees/trainees.component.html
@@ -1,1 +1,7 @@
-<router-outlet></router-outlet>
+<div class="d-grid justify-content-end p-15">
+  <app-reset-trainee-list class="pt-10 pb-10"></app-reset-trainee-list>
+</div>
+
+<div class="p-15">
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/trainees/trainees.module.ts
+++ b/src/app/trainees/trainees.module.ts
@@ -6,9 +6,14 @@ import { TraineesState } from "./state/trainees.state";
 import { TraineeListComponent } from "./trainee-list/trainee-list.component";
 import { TraineesRoutingModule } from "./trainees-routing.module";
 import { TraineesComponent } from "./trainees.component";
+import { ResetTraineeListComponent } from "./reset-trainee-list/reset-trainee-list.component";
 
 @NgModule({
-  declarations: [TraineesComponent, TraineeListComponent],
+  declarations: [
+    TraineesComponent,
+    TraineeListComponent,
+    ResetTraineeListComponent
+  ],
   imports: [
     MaterialModule,
     SharedModule,

--- a/src/scss/utilities/_index.scss
+++ b/src/scss/utilities/_index.scss
@@ -1,2 +1,3 @@
 @import "utilities";
 @import "layout";
+@import "spacing-helpers";

--- a/src/scss/utilities/_spacing-helpers.scss
+++ b/src/scss/utilities/_spacing-helpers.scss
@@ -1,0 +1,28 @@
+// margin and padding values array
+$space-values: (0, 3, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50) !default;
+
+// margin and padding shorthands
+$space-prefixes: (
+  p: padding,
+  pt: padding-top,
+  pr: padding-right,
+  pb: padding-bottom,
+  pl: padding-left,
+  m: margin,
+  mt: margin-top,
+  mr: margin-right,
+  mb: margin-bottom,
+  ml: margin-left
+) !default;
+
+@mixin make-spaces() {
+  @each $attr-short, $attr-long in $space-prefixes {
+    @each $value in $space-values {
+      .#{$attr-short}-#{$value} {
+        #{$attr-long}: #{$value}#{"px"};
+      }
+    }
+  }
+}
+
+@include make-spaces();

--- a/src/scss/utilities/_utilities.scss
+++ b/src/scss/utilities/_utilities.scss
@@ -5,6 +5,10 @@
   color: inherit;
 }
 
+.cursor-pointer {
+  cursor: pointer;
+}
+
 .w-100 {
   width: 100%;
 }


### PR DESCRIPTION
TISNEW-4176

- created new `reset-trainee-list` component to clear sorting params and filters
- added margins and padding helper scss file
- added default sorting col and direction to constants file and re-used in multiple places
- fixed issue with default sorting column not highlighting when trainee list is viewed without any query params