### PR TITLE
illustrate ngOnInit doesnt fire on same route change - please do not merge

### DIFF
--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -13,8 +13,7 @@ import { PageNotFoundComponent } from "./page-not-found/page-not-found.component
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
-    NgxsReduxDevtoolsPluginModule.forRoot({ disabled: environment.production }),
-    NgxsLoggerPluginModule.forRoot({ disabled: environment.production })
+    NgxsReduxDevtoolsPluginModule.forRoot({ disabled: environment.production })
   ],
   exports: [CommonModule, ReactiveFormsModule]
 })

--- a/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
+++ b/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
@@ -27,6 +27,10 @@ export class TraineeListPaginatorComponent implements OnInit {
    * And update store accordingly
    */
   ngOnInit(): void {
+    console.log(
+      "%c TraineeListPaginatorComponent ngOnInit fired ",
+      "background: orange; color: black"
+    );
     const params: Params = this.route.snapshot.queryParams;
 
     if (params.pageIndex) {

--- a/src/app/trainees/trainee-list/trainee-list.component.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.ts
@@ -87,6 +87,10 @@ export class TraineeListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    console.log(
+      "%c TraineeListComponent ngOnInit fired ",
+      "background: green; color: black"
+    );
     this.setupInitialSorting();
     this.store.dispatch(new GetTrainees());
   }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -11,7 +11,7 @@ export const environment: IEnvironment = {
   appUrls: {
     login: ``,
     authRedirect: ``,
-    getTrainees: `5e8b4e522d0000271a1a4ea5?mocky-delay=700ms`
+    getTrainees: `5e8d6eea310000be90429898?mocky-delay=700ms`
   }
 };
 


### PR DESCRIPTION
please do not merge, pr to illustrate ngOnInit doesnt fire on same route change

- ngxs console logs disabled and coloured console logs added to paginator and trainee list components ngOnInit
- notice when navigating to same route via clicking on sorting, paginator or clear all elements no ngOnInit's fire and therefore no new console logs