### PR TITLE
chore: cater for trainee details route

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,7 +15,7 @@ const routes: Routes = [
       import("./trainees/trainees.module").then((m) => m.TraineesModule)
   },
   {
-    path: "dashboard",
+    path: "trainees/:id",
     loadChildren: () =>
       import("./dashboard/dashboard.module").then((m) => m.DashboardModule)
   },

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -5,7 +5,7 @@ import { RevalidationHistoryComponent } from "./revalidation-history/revalidatio
 
 const routes: Routes = [
   {
-    path: "trainee/:id",
+    path: "",
     component: TraineeSummaryComponent,
     data: { title: "Trainee summary" },
     children: [

--- a/src/app/trainees/trainee-list/trainee-list.component.spec.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.spec.ts
@@ -135,7 +135,7 @@ describe("TraineeListComponent", () => {
 
     component.traineeDetails(mockEvent, mockTrainee);
     expect(router.navigate).toHaveBeenCalledWith([
-      "/dashboard/trainee",
+      "/trainees",
       mockTrainee.gmcReferenceNumber
     ]);
   });

--- a/src/app/trainees/trainee-list/trainee-list.component.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.ts
@@ -108,7 +108,7 @@ export class TraineeListComponent implements OnInit {
 
   public traineeDetails(event: Event, row: ITrainee): Promise<boolean> {
     event.stopPropagation();
-    return this.router.navigate(["/dashboard/trainee", row.gmcReferenceNumber]);
+    return this.router.navigate(["/trainees", row.gmcReferenceNumber]);
   }
 
   public sortTrainees(event: Sort): void {


### PR DESCRIPTION
TISNEW-4193

pr to ensure that 
- `/trainees` and `/trainees?active=<columnName>&direction=<direction>&pageIndex=<page>` lists trainees
- `/trainees/:id` shows trainee details