### PR TITLE
chore: store should route with ngzone

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,16 +1,15 @@
 import { NgModule } from "@angular/core";
 import { Routes, RouterModule } from "@angular/router";
-import { DEFAULT_ROUTE } from "./core/trainee/constants";
 import { PageNotFoundComponent } from "./shared/page-not-found/page-not-found.component";
 
 const routes: Routes = [
   {
     path: "",
-    redirectTo: DEFAULT_ROUTE,
+    redirectTo: "/trainees",
     pathMatch: "full"
   },
   {
-    path: "",
+    path: "trainees",
     loadChildren: () =>
       import("./trainees/trainees.module").then((m) => m.TraineesModule)
   },

--- a/src/app/core/trainee/constants.ts
+++ b/src/app/core/trainee/constants.ts
@@ -1,7 +1,6 @@
 import { Sort } from "@angular/material/sort";
 
-export const DEFAULT_ROUTE = "/trainees";
-export const DEFAULT_ROUTE_SORT: Sort = {
+export const DEFAULT_SORT: Sort = {
   active: "submissionDate",
   direction: "desc"
 };

--- a/src/app/shared/main-navigation/mat-main-nav/mat-main-nav.component.html
+++ b/src/app/shared/main-navigation/mat-main-nav/mat-main-nav.component.html
@@ -1,6 +1,6 @@
 <a
   class="nhsuk-skip-link mat-focus-indicator"
-  [routerLink]="defaultRoute"
+  [routerLink]="'/'"
   [fragment]="skipLinkSelector"
   >Skip to main content</a
 >
@@ -34,7 +34,7 @@
       <mat-toolbar-row class="mat-elevation-z2">
         <a
           mat-icon-button
-          [routerLink]="defaultRoute"
+          [routerLink]="'/'"
           aria-label="NHS Revalidation"
           class="logo-icon"
         >

--- a/src/app/shared/main-navigation/mat-main-nav/mat-main-nav.component.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/mat-main-nav.component.ts
@@ -4,7 +4,6 @@ import { MatIconRegistry } from "@angular/material/icon";
 import { Observable } from "rxjs";
 import { map, shareReplay } from "rxjs/operators";
 import { DomSanitizer } from "@angular/platform-browser";
-import { DEFAULT_ROUTE } from "../../../core/trainee/constants";
 
 @Component({
   selector: "app-mat-main-nav",
@@ -12,7 +11,6 @@ import { DEFAULT_ROUTE } from "../../../core/trainee/constants";
   styleUrls: ["./mat-main-nav.component.scss"]
 })
 export class MatMainNavComponent {
-  public defaultRoute: string = DEFAULT_ROUTE;
   isHandset$: Observable<boolean> = this.breakpointObserver
     .observe(Breakpoints.Handset)
     .pipe(

--- a/src/app/shared/page-not-found/page-not-found.component.html
+++ b/src/app/shared/page-not-found/page-not-found.component.html
@@ -5,7 +5,7 @@
     <p>If you pasted the web address, check you copied the entire address.</p>
     <p>If you think the address is correct, let us know.</p>
     <p>
-      <a [routerLink]="defaultRoute">Return to the homepage</a>
+      <a [routerLink]="'/'">Return to the homepage</a>
     </p>
   </div>
 </div>

--- a/src/app/shared/page-not-found/page-not-found.component.ts
+++ b/src/app/shared/page-not-found/page-not-found.component.ts
@@ -1,10 +1,7 @@
 import { Component } from "@angular/core";
-import { DEFAULT_ROUTE } from "../../core/trainee/constants";
 
 @Component({
   selector: "app-page-not-found",
   templateUrl: "./page-not-found.component.html"
 })
-export class PageNotFoundComponent {
-  public defaultRoute: string = DEFAULT_ROUTE;
-}
+export class PageNotFoundComponent {}

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
@@ -50,12 +50,11 @@ describe("ResetTraineeListComponent", () => {
 
     component.resetTraineeList();
 
-    expect(store.dispatch).toHaveBeenCalledWith([
-      new ResetTraineesSort(),
-      new ResetTraineesPaginator(),
-      new ClearTraineesFilter(),
-      new GetTrainees(),
-      new UpdateTraineesRoute()
-    ]);
+    expect(store.dispatch).toHaveBeenCalledTimes(5);
+    expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesSort());
+    expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesPaginator());
+    expect(store.dispatch).toHaveBeenCalledWith(new ClearTraineesFilter());
+    expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
+    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
   });
 });

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
@@ -2,6 +2,7 @@ import { Component } from "@angular/core";
 import { Sort } from "@angular/material/sort";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
+import { take } from "rxjs/operators";
 import {
   ClearTraineesFilter,
   GetTrainees,
@@ -21,12 +22,12 @@ export class ResetTraineeListComponent {
   constructor(private store: Store) {}
 
   public resetTraineeList(): void {
-    this.store.dispatch([
-      new ResetTraineesSort(),
-      new ResetTraineesPaginator(),
-      new ClearTraineesFilter(),
-      new GetTrainees(),
-      new UpdateTraineesRoute()
-    ]);
+    this.store.dispatch(new ResetTraineesSort());
+    this.store.dispatch(new ResetTraineesPaginator());
+    this.store.dispatch(new ClearTraineesFilter());
+    this.store
+      .dispatch(new GetTrainees())
+      .pipe(take(1))
+      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
   }
 }

--- a/src/app/trainees/state/trainees.state.spec.ts
+++ b/src/app/trainees/state/trainees.state.spec.ts
@@ -5,7 +5,7 @@ import { Params, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
-import { DEFAULT_ROUTE_SORT } from "../../core/trainee/constants";
+import { DEFAULT_SORT } from "../../core/trainee/constants";
 import { IGetTraineesResponse } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import { MaterialModule } from "../../shared/material/material.module";
@@ -112,10 +112,10 @@ describe("Trainees actions", () => {
 
   it("should dispatch 'SortTrainees' and update store", () => {
     store.dispatch(
-      new SortTrainees(DEFAULT_ROUTE_SORT.active, DEFAULT_ROUTE_SORT.direction)
+      new SortTrainees(DEFAULT_SORT.active, DEFAULT_SORT.direction)
     );
     const sort = store.selectSnapshot(TraineesState.sort);
-    expect(sort).toEqual(DEFAULT_ROUTE_SORT);
+    expect(sort).toEqual(DEFAULT_SORT);
   });
 
   it("should dispatch 'PaginateTrainees' and update store", () => {

--- a/src/app/trainees/state/trainees.state.ts
+++ b/src/app/trainees/state/trainees.state.ts
@@ -1,10 +1,10 @@
 import { HttpParams } from "@angular/common/http";
-import { Injectable } from "@angular/core";
+import { Injectable, NgZone } from "@angular/core";
 import { Sort } from "@angular/material/sort";
 import { Router } from "@angular/router";
 import { State, Action, StateContext, Selector } from "@ngxs/store";
 import { tap } from "rxjs/operators";
-import { DEFAULT_ROUTE_SORT } from "../../core/trainee/constants";
+import { DEFAULT_SORT } from "../../core/trainee/constants";
 import { ITrainee } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import {
@@ -39,8 +39,11 @@ export class TraineesStateModel {
 })
 @Injectable()
 export class TraineesState {
-  public defaultSort: Sort = DEFAULT_ROUTE_SORT;
-  constructor(private traineeService: TraineeService, private router: Router) {}
+  constructor(
+    private traineeService: TraineeService,
+    private router: Router,
+    private ngZone: NgZone
+  ) {}
 
   @Selector()
   public static trainees(state: TraineesStateModel) {
@@ -113,7 +116,7 @@ export class TraineesState {
     const state = ctx.getState();
     return ctx.setState({
       ...state,
-      sort: this.defaultSort
+      sort: DEFAULT_SORT
     });
   }
 
@@ -141,12 +144,14 @@ export class TraineesState {
   @Action(UpdateTraineesRoute)
   updateTraineesRoute(ctx: StateContext<TraineesStateModel>) {
     const state = ctx.getState();
-    return this.router.navigate(["/trainees"], {
-      queryParams: {
-        active: state.sort.active,
-        direction: state.sort.direction,
-        pageIndex: state.pageIndex
-      }
-    });
+    return this.ngZone.run(() =>
+      this.router.navigate(["/trainees"], {
+        queryParams: {
+          active: state.sort.active,
+          direction: state.sort.direction,
+          pageIndex: state.pageIndex
+        }
+      })
+    );
   }
 }

--- a/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.spec.ts
+++ b/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.spec.ts
@@ -5,6 +5,7 @@ import { MatPaginatorModule, PageEvent } from "@angular/material/paginator";
 import { ActivatedRoute, Params } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
+import { of } from "rxjs";
 import {
   GetTrainees,
   PaginateTrainees,
@@ -105,14 +106,15 @@ describe("TraineeListPaginatorComponent", () => {
       pageSize: 100,
       length: 20
     };
-    spyOn(store, "dispatch");
+    spyOn(store, "dispatch").and.returnValue(of({}));
 
     component.paginateTrainees(mockPageEvent);
 
-    expect(store.dispatch).toHaveBeenCalledWith([
-      new PaginateTrainees(mockPageEvent.pageIndex),
-      new GetTrainees(),
-      new UpdateTraineesRoute()
-    ]);
+    expect(store.dispatch).toHaveBeenCalledTimes(3);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new PaginateTrainees(mockPageEvent.pageIndex)
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
+    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
   });
 });

--- a/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
+++ b/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
@@ -3,6 +3,7 @@ import { PageEvent } from "@angular/material/paginator/paginator";
 import { ActivatedRoute, Params } from "@angular/router";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
+import { take } from "rxjs/operators";
 import {
   GetTrainees,
   PaginateTrainees,
@@ -37,10 +38,10 @@ export class TraineeListPaginatorComponent implements OnInit {
   }
 
   public paginateTrainees(event: PageEvent) {
-    this.store.dispatch([
-      new PaginateTrainees(event.pageIndex),
-      new GetTrainees(),
-      new UpdateTraineesRoute()
-    ]);
+    this.store.dispatch(new PaginateTrainees(event.pageIndex));
+    this.store
+      .dispatch(new GetTrainees())
+      .pipe(take(1))
+      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
   }
 }

--- a/src/app/trainees/trainee-list/trainee-list.component.spec.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.spec.ts
@@ -151,11 +151,12 @@ describe("TraineeListComponent", () => {
 
     component.sortTrainees(mockSortEvent);
 
-    expect(store.dispatch).toHaveBeenCalledWith([
-      new SortTrainees(mockSortEvent.active, mockSortEvent.direction),
-      new ResetTraineesPaginator(),
-      new GetTrainees(),
-      new UpdateTraineesRoute()
-    ]);
+    expect(store.dispatch).toHaveBeenCalledTimes(4);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new SortTrainees(mockSortEvent.active, mockSortEvent.direction)
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesPaginator());
+    expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
+    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
   });
 });

--- a/src/app/trainees/trainee-list/trainee-list.component.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.ts
@@ -3,6 +3,7 @@ import { Sort } from "@angular/material/sort";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
+import { take } from "rxjs/operators";
 import {
   ITrainee,
   ITraineeDataCell
@@ -112,11 +113,11 @@ export class TraineeListComponent implements OnInit {
   }
 
   public sortTrainees(event: Sort): void {
-    this.store.dispatch([
-      new SortTrainees(event.active, event.direction),
-      new ResetTraineesPaginator(),
-      new GetTrainees(),
-      new UpdateTraineesRoute()
-    ]);
+    this.store.dispatch(new SortTrainees(event.active, event.direction));
+    this.store.dispatch(new ResetTraineesPaginator());
+    this.store
+      .dispatch(new GetTrainees())
+      .pipe(take(1))
+      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
   }
 }

--- a/src/app/trainees/trainees-routing.module.ts
+++ b/src/app/trainees/trainees-routing.module.ts
@@ -4,7 +4,7 @@ import { TraineesComponent } from "./trainees.component";
 
 const routes: Routes = [
   {
-    path: "trainees",
+    path: "",
     component: TraineesComponent,
     data: { title: "Trainees list" }
   }


### PR DESCRIPTION
TISNEW-4194

- ensured store changes route with ngZone [fixes console warning]
- updated unit tests 
- ensured route change action is dispatched after GetTrainees has resolved
- dispatched actions in trainee-list, paginator and reset-trainee-list components individually as opposed to multiple actions in an array. this improves the stores development mode console logging and makes it much nicer to debug;

<img width="417" alt="Screenshot 2020-04-08 at 18 37 53" src="https://user-images.githubusercontent.com/1694202/78815410-263a5a80-79c8-11ea-9a5d-8091698268cb.png">
