### PR TITLE
feat: trainee list search

### DIFF
--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
@@ -6,6 +6,7 @@ import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
 import {
   ClearTraineesFilter,
+  ClearTraineesSearch,
   GetTrainees,
   ResetTraineesPaginator,
   ResetTraineesSort,
@@ -50,10 +51,11 @@ describe("ResetTraineeListComponent", () => {
 
     component.resetTraineeList();
 
-    expect(store.dispatch).toHaveBeenCalledTimes(5);
+    expect(store.dispatch).toHaveBeenCalledTimes(6);
     expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesSort());
     expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesPaginator());
     expect(store.dispatch).toHaveBeenCalledWith(new ClearTraineesFilter());
+    expect(store.dispatch).toHaveBeenCalledWith(new ClearTraineesSearch());
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
     expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
   });

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
@@ -5,6 +5,7 @@ import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
 import {
   ClearTraineesFilter,
+  ClearTraineesSearch,
   GetTrainees,
   ResetTraineesPaginator,
   ResetTraineesSort,
@@ -25,6 +26,7 @@ export class ResetTraineeListComponent {
     this.store.dispatch(new ResetTraineesSort());
     this.store.dispatch(new ResetTraineesPaginator());
     this.store.dispatch(new ClearTraineesFilter());
+    this.store.dispatch(new ClearTraineesSearch());
     this.store
       .dispatch(new GetTrainees())
       .pipe(take(1))

--- a/src/app/trainees/state/trainees.actions.ts
+++ b/src/app/trainees/state/trainees.actions.ts
@@ -24,7 +24,11 @@ export class ClearTraineesFilter {
 
 export class SearchTrainees {
   static readonly type = "[Trainees] Search";
-  constructor(public query: string) {}
+  constructor(public searchQuery: string) {}
+}
+
+export class ClearTraineesSearch {
+  static readonly type = "[Trainees] Clear Search";
 }
 
 export class PaginateTrainees {

--- a/src/app/trainees/state/trainees.state.ts
+++ b/src/app/trainees/state/trainees.state.ts
@@ -8,10 +8,12 @@ import { DEFAULT_SORT } from "../../core/trainee/constants";
 import { ITrainee } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import {
+  ClearTraineesSearch,
   GetTrainees,
   PaginateTrainees,
   ResetTraineesPaginator,
   ResetTraineesSort,
+  SearchTrainees,
   SortTrainees,
   UpdateTraineesRoute
 } from "./trainees.actions";
@@ -22,6 +24,7 @@ export class TraineesStateModel {
   public loading: boolean;
   public sort: Sort;
   public pageIndex: number;
+  public searchQuery: string;
 }
 
 @State<TraineesStateModel>({
@@ -34,7 +37,8 @@ export class TraineesStateModel {
       active: null,
       direction: null
     },
-    pageIndex: 0
+    pageIndex: 0,
+    searchQuery: null
   }
 })
 @Injectable()
@@ -70,6 +74,11 @@ export class TraineesState {
     return state.pageIndex;
   }
 
+  @Selector()
+  public static searchQuery(state: TraineesStateModel) {
+    return state.searchQuery;
+  }
+
   @Action(GetTrainees)
   getTrainees(ctx: StateContext<TraineesStateModel>) {
     const state = ctx.getState();
@@ -85,6 +94,10 @@ export class TraineesState {
       params = params
         .append("sortColumn", state.sort.active)
         .append("sortOrder", state.sort.direction);
+    }
+
+    if (state.searchQuery) {
+      params = params.append("searchQuery", state.searchQuery);
     }
 
     return this.traineeService.getTrainees(params).pipe(
@@ -149,9 +162,27 @@ export class TraineesState {
         queryParams: {
           active: state.sort.active,
           direction: state.sort.direction,
-          pageIndex: state.pageIndex
+          pageIndex: state.pageIndex,
+          ...(state.searchQuery && { searchQuery: state.searchQuery })
         }
       })
     );
+  }
+
+  @Action(SearchTrainees)
+  searchTrainees(
+    ctx: StateContext<TraineesStateModel>,
+    action: SearchTrainees
+  ) {
+    return ctx.patchState({
+      searchQuery: action.searchQuery
+    });
+  }
+
+  @Action(ClearTraineesSearch)
+  clearTraineesSearch(ctx: StateContext<TraineesStateModel>) {
+    return ctx.patchState({
+      searchQuery: null
+    });
   }
 }

--- a/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.spec.ts
+++ b/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.spec.ts
@@ -2,33 +2,22 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatPaginatorModule, PageEvent } from "@angular/material/paginator";
-import { ActivatedRoute, Params } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
 import {
   GetTrainees,
   PaginateTrainees,
-  ResetTraineesPaginator,
   UpdateTraineesRoute
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
 import { TraineeListPaginatorComponent } from "./trainee-list-paginator.component";
 
-class MockActivatedRoute {
-  snapshot = {
-    get queryParams(): Params {
-      return {};
-    }
-  };
-}
-
 describe("TraineeListPaginatorComponent", () => {
   let store: Store;
   let component: TraineeListPaginatorComponent;
   let fixture: ComponentFixture<TraineeListPaginatorComponent>;
-  let route: ActivatedRoute;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -38,17 +27,10 @@ describe("TraineeListPaginatorComponent", () => {
         NgxsModule.forRoot([TraineesState]),
         HttpClientTestingModule
       ],
-      providers: [
-        {
-          provide: ActivatedRoute,
-          useClass: MockActivatedRoute
-        }
-      ],
       declarations: [TraineeListPaginatorComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
     store = TestBed.inject(Store);
-    route = TestBed.inject(ActivatedRoute);
   }));
 
   beforeEach(() => {
@@ -59,44 +41,6 @@ describe("TraineeListPaginatorComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
-  });
-
-  it("should dispatch 'PaginateTrainees' if pageIndex exists", () => {
-    const mockQueryParams: Params = {
-      pageIndex: 6
-    };
-
-    spyOnProperty(route.snapshot, "queryParams").and.returnValue(
-      mockQueryParams
-    );
-    spyOn(store, "dispatch");
-
-    component.ngOnInit();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new ResetTraineesPaginator()
-    );
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new PaginateTrainees(mockQueryParams.pageIndex)
-    );
-  });
-
-  it("should dispatch 'ResetTraineesPaginator' if pageIndex does not exist", () => {
-    const mockQueryParams: Params = {};
-
-    spyOnProperty(route.snapshot, "queryParams").and.returnValue(
-      mockQueryParams
-    );
-    spyOn(store, "dispatch");
-
-    component.ngOnInit();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new PaginateTrainees(mockQueryParams.pageIndex)
-    );
-    expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesPaginator());
   });
 
   it("should dispatch relevant actions on 'paginateTrainees()'", () => {

--- a/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
+++ b/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
@@ -1,13 +1,11 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { PageEvent } from "@angular/material/paginator/paginator";
-import { ActivatedRoute, Params } from "@angular/router";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
 import {
   GetTrainees,
   PaginateTrainees,
-  ResetTraineesPaginator,
   UpdateTraineesRoute
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
@@ -16,26 +14,11 @@ import { TraineesState } from "../state/trainees.state";
   selector: "app-trainee-list-paginator",
   templateUrl: "./trainee-list-paginator.component.html"
 })
-export class TraineeListPaginatorComponent implements OnInit {
+export class TraineeListPaginatorComponent {
   @Select(TraineesState.countTotal) countTotal$: Observable<number>;
   @Select(TraineesState.pageIndex) pageIndex$: Observable<number>;
 
-  constructor(private store: Store, private route: ActivatedRoute) {}
-
-  /**
-   * Check if pageIndex query param exists
-   * Then dispatch appropriate event
-   * And update store accordingly
-   */
-  ngOnInit(): void {
-    const params: Params = this.route.snapshot.queryParams;
-
-    if (params.pageIndex) {
-      this.store.dispatch(new PaginateTrainees(params.pageIndex));
-    } else {
-      this.store.dispatch(new ResetTraineesPaginator());
-    }
-  }
+  constructor(private store: Store) {}
 
   public paginateTrainees(event: PageEvent) {
     this.store.dispatch(new PaginateTrainees(event.pageIndex));

--- a/src/app/trainees/trainee-list/trainee-list.component.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.ts
@@ -10,8 +10,10 @@ import {
 } from "../../core/trainee/trainee.interfaces";
 import {
   GetTrainees,
+  PaginateTrainees,
   ResetTraineesPaginator,
   ResetTraineesSort,
+  SearchTrainees,
   SortTrainees,
   UpdateTraineesRoute
 } from "../state/trainees.actions";
@@ -78,8 +80,8 @@ export class TraineeListComponent implements OnInit {
       enableSort: true
     }
   ];
-
   public columnLabels: string[] = this.columnData.map((i) => i.label);
+  public params: Params = this.route.snapshot.queryParams;
 
   constructor(
     private store: Store,
@@ -87,23 +89,39 @@ export class TraineeListComponent implements OnInit {
     private route: ActivatedRoute
   ) {}
 
+  /**
+   * Check if query params exist
+   * Then dispatch appropriate events
+   * And update store accordingly
+   */
   ngOnInit(): void {
     this.setupInitialSorting();
+    this.setupInitialPagination();
+    this.checkInitialSearchQuery();
     this.store.dispatch(new GetTrainees());
   }
 
-  /**
-   * Check if sorting query params exist
-   * Then dispatch appropriate event
-   * And update store accordingly
-   */
   public setupInitialSorting(): void {
-    const params: Params = this.route.snapshot.queryParams;
-
-    if (params.active && params.direction) {
-      this.store.dispatch(new SortTrainees(params.active, params.direction));
+    if (this.params.active && this.params.direction) {
+      this.store.dispatch(
+        new SortTrainees(this.params.active, this.params.direction)
+      );
     } else {
       this.store.dispatch(new ResetTraineesSort());
+    }
+  }
+
+  public setupInitialPagination(): void {
+    if (this.params.pageIndex) {
+      this.store.dispatch(new PaginateTrainees(this.params.pageIndex));
+    } else {
+      this.store.dispatch(new ResetTraineesPaginator());
+    }
+  }
+
+  public checkInitialSearchQuery(): void {
+    if (this.params.searchQuery) {
+      this.store.dispatch(new SearchTrainees(this.params.searchQuery));
     }
   }
 

--- a/src/app/trainees/trainee-search/trainee-search.component.html
+++ b/src/app/trainees/trainee-search/trainee-search.component.html
@@ -1,0 +1,14 @@
+<form (ngSubmit)="checkForm()" [formGroup]="form" autocomplete="off">
+  <mat-form-field>
+    <input
+      matInput
+      placeholder="Enter name / GMC no"
+      [formControlName]="'searchQuery'"
+      [value]="searchQuery$ | async"
+    />
+    <mat-error *ngIf="form.invalid">No search terms entered</mat-error>
+  </mat-form-field>
+  <button mat-button type="submit">
+    <mat-icon>search</mat-icon>
+  </button>
+</form>

--- a/src/app/trainees/trainee-search/trainee-search.component.spec.ts
+++ b/src/app/trainees/trainee-search/trainee-search.component.spec.ts
@@ -1,0 +1,106 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { of } from "rxjs";
+import { MaterialModule } from "../../shared/material/material.module";
+import {
+  GetTrainees,
+  SearchTrainees,
+  UpdateTraineesRoute
+} from "../state/trainees.actions";
+import { TraineesState } from "../state/trainees.state";
+
+import { TraineeSearchComponent } from "./trainee-search.component";
+
+describe("TraineeSearchComponent", () => {
+  let store: Store;
+  let component: TraineeSearchComponent;
+  let fixture: ComponentFixture<TraineeSearchComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TraineeSearchComponent],
+      imports: [
+        MaterialModule,
+        NgxsModule.forRoot([TraineesState]),
+        RouterTestingModule,
+        HttpClientTestingModule,
+        ReactiveFormsModule,
+        NoopAnimationsModule
+      ]
+    }).compileComponents();
+    store = TestBed.inject(Store);
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TraineeSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should invoke setupForm on `ngOnInit()`", () => {
+    spyOn(component, "setupForm");
+    component.ngOnInit();
+    expect(component.setupForm).toHaveBeenCalled();
+  });
+
+  it("should create form, form control with value from query params", () => {
+    component.params = {
+      searchQuery: "john"
+    };
+    component.setupForm();
+    expect(component.form.value.searchQuery).toEqual(
+      component.params.searchQuery
+    );
+  });
+
+  it("should create form, form control with default value", () => {
+    component.params = {};
+    component.setupForm();
+    expect(component.form.value.searchQuery).toBeNull();
+  });
+
+  it("form should be invalid if min length validation fails", () => {
+    component.params = {
+      searchQuery: "9"
+    };
+    component.setupForm();
+    expect(component.form.invalid).toBeTruthy();
+  });
+
+  it("form is only submitted if valid", () => {
+    spyOn(component, "submitForm");
+    component.params = {
+      searchQuery: "john"
+    };
+    component.setupForm();
+    component.checkForm();
+    expect(component.submitForm).toHaveBeenCalledWith(
+      component.params.searchQuery
+    );
+  });
+
+  it("should dispatch relevant actions on valid form submission", () => {
+    spyOn(store, "dispatch").and.returnValue(of({}));
+
+    component.params = {
+      searchQuery: "87723113"
+    };
+    component.setupForm();
+    component.submitForm(component.params.searchQuery);
+
+    expect(store.dispatch).toHaveBeenCalledTimes(3);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new SearchTrainees(component.params.searchQuery)
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
+    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
+  });
+});

--- a/src/app/trainees/trainee-search/trainee-search.component.ts
+++ b/src/app/trainees/trainee-search/trainee-search.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit } from "@angular/core";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
+import { ActivatedRoute, Params } from "@angular/router";
+import { Select, Store } from "@ngxs/store";
+import { Observable } from "rxjs";
+import { take } from "rxjs/operators";
+import {
+  GetTrainees,
+  SearchTrainees,
+  UpdateTraineesRoute
+} from "../state/trainees.actions";
+import { TraineesState } from "../state/trainees.state";
+
+@Component({
+  selector: "app-trainee-search",
+  templateUrl: "./trainee-search.component.html"
+})
+export class TraineeSearchComponent implements OnInit {
+  @Select(TraineesState.searchQuery) searchQuery$: Observable<string>;
+  public form: FormGroup;
+  public params: Params = this.route.snapshot.queryParams;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private store: Store,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    this.setupForm();
+  }
+
+  public setupForm(): void {
+    this.form = this.formBuilder.group({
+      searchQuery: [this.params.searchQuery || "", [Validators.required]]
+    });
+  }
+
+  /**
+   * If form is valid then trim leading and trailing whitespaces from query
+   * So that search cannot be invoked with just blank spaces
+   */
+  public checkForm(): void {
+    const searchQuery = this.form.value.searchQuery.trim();
+
+    if (searchQuery.length && this.form.valid) {
+      this.submitForm(searchQuery);
+    }
+  }
+
+  public submitForm(searchQuery: string): void {
+    this.store.dispatch(new SearchTrainees(searchQuery));
+    this.store
+      .dispatch(new GetTrainees())
+      .pipe(take(1))
+      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
+  }
+}

--- a/src/app/trainees/trainees.component.html
+++ b/src/app/trainees/trainees.component.html
@@ -1,5 +1,8 @@
 <div class="d-grid justify-content-end p-15">
-  <app-reset-trainee-list class="pt-10 pb-10"></app-reset-trainee-list>
+  <app-trainee-search></app-trainee-search>
+  <app-reset-trainee-list
+    class="pt-10 pb-10 justify-self-end"
+  ></app-reset-trainee-list>
 </div>
 
 <div class="p-15">

--- a/src/app/trainees/trainees.module.ts
+++ b/src/app/trainees/trainees.module.ts
@@ -8,13 +8,15 @@ import { TraineesRoutingModule } from "./trainees-routing.module";
 import { TraineesComponent } from "./trainees.component";
 import { ResetTraineeListComponent } from "./reset-trainee-list/reset-trainee-list.component";
 import { TraineeListPaginatorComponent } from "./trainee-list-paginator/trainee-list-paginator.component";
+import { TraineeSearchComponent } from "./trainee-search/trainee-search.component";
 
 @NgModule({
   declarations: [
     TraineesComponent,
     TraineeListComponent,
     ResetTraineeListComponent,
-    TraineeListPaginatorComponent
+    TraineeListPaginatorComponent,
+    TraineeSearchComponent
   ],
   imports: [
     MaterialModule,


### PR DESCRIPTION
TISNEW-4054

- added new search feature for trainees
- includes form validation
- includes unit tests
- ensured `searchQuery` is appended to api call
- ensured reset trainees list `Clear All` also resets search
- moved pagination query params check within `trainee-list` to ensure all query params are checked in same component upon ngOnInit life cycle