### PR TITLE
chore: move route change out from store

### DIFF
--- a/src/app/core/trainee/trainee.service.spec.ts
+++ b/src/app/core/trainee/trainee.service.spec.ts
@@ -1,0 +1,64 @@
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { environment } from "@environment";
+import { NgxsModule, Store } from "@ngxs/store";
+import {
+  TraineesState,
+  TraineesStateModel
+} from "../../trainees/state/trainees.state";
+import { TraineeService } from "./trainee.service";
+
+describe("TraineeService", () => {
+  let service: TraineeService;
+  let http: HttpTestingController;
+  let router: Router;
+  let store: Store;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        NgxsModule.forRoot([TraineesState])
+      ],
+      providers: [TraineeService]
+    });
+    service = TestBed.inject(TraineeService);
+    http = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    store = TestBed.inject(Store);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("`getTrainees()` should call api", () => {
+    service.getTrainees().subscribe();
+
+    const mockHttp = http.expectOne(`${environment.appUrls.getTrainees}`);
+    expect(mockHttp.request.method).toBe("GET");
+
+    http.verify();
+  });
+
+  it("`updateTraineesRoute()` should navigate to `/trainees`", () => {
+    spyOn(router, "navigate");
+
+    const snapshot: TraineesStateModel = store.snapshot().trainees;
+    service.updateTraineesRoute();
+
+    expect(router.navigate).toHaveBeenCalledWith(["/trainees"], {
+      queryParams: {
+        active: snapshot.sort.active,
+        direction: snapshot.sort.direction,
+        pageIndex: snapshot.pageIndex
+      }
+    });
+  });
+});

--- a/src/app/core/trainee/trainee.service.ts
+++ b/src/app/core/trainee/trainee.service.ts
@@ -1,19 +1,38 @@
-import { Injectable } from "@angular/core";
 import { HttpClient, HttpParams } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Router } from "@angular/router";
 import { environment } from "@environment";
+import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
+import { TraineesStateModel } from "../../trainees/state/trainees.state";
 import { IGetTraineesResponse } from "./trainee.interfaces";
 
 @Injectable({
   providedIn: "root"
 })
 export class TraineeService {
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private router: Router,
+    private store: Store
+  ) {}
 
   public getTrainees(params?: HttpParams): Observable<IGetTraineesResponse> {
     return this.http.get<IGetTraineesResponse>(
       `${environment.appUrls.getTrainees}`,
       { params }
     );
+  }
+
+  public updateTraineesRoute(): Promise<boolean> {
+    const snapshot: TraineesStateModel = this.store.snapshot().trainees;
+
+    return this.router.navigate(["/trainees"], {
+      queryParams: {
+        active: snapshot.sort.active,
+        direction: snapshot.sort.direction,
+        pageIndex: snapshot.pageIndex
+      }
+    });
   }
 }

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
@@ -3,24 +3,35 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
+import { TraineeService } from "../../core/trainee/trainee.service";
 import {
   ClearTraineesFilter,
   ClearTraineesSearch,
   GetTrainees,
   ResetTraineesPaginator,
-  ResetTraineesSort,
-  UpdateTraineesRoute
+  ResetTraineesSort
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
 import { ResetTraineeListComponent } from "./reset-trainee-list.component";
+
+class MockTraineeService {
+  public getTrainees(): Observable<any> {
+    return of({});
+  }
+
+  public updateTraineesRoute(): Observable<any> {
+    return of({});
+  }
+}
 
 describe("ResetTraineeListComponent", () => {
   let store: Store;
   let component: ResetTraineeListComponent;
   let fixture: ComponentFixture<ResetTraineeListComponent>;
   let router: Router;
+  let traineeService: TraineeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -29,10 +40,17 @@ describe("ResetTraineeListComponent", () => {
         RouterTestingModule,
         NgxsModule.forRoot([TraineesState]),
         HttpClientTestingModule
+      ],
+      providers: [
+        {
+          provide: TraineeService,
+          useClass: MockTraineeService
+        }
       ]
     }).compileComponents();
     store = TestBed.inject(Store);
     router = TestBed.inject(Router);
+    traineeService = TestBed.inject(TraineeService);
   }));
 
   beforeEach(() => {
@@ -48,15 +66,16 @@ describe("ResetTraineeListComponent", () => {
   it("should dispatch relevant actions to reset trainee list", () => {
     spyOn(store, "dispatch").and.returnValue(of({}));
     spyOn(router, "navigate");
+    spyOn(traineeService, "updateTraineesRoute");
 
     component.resetTraineeList();
 
-    expect(store.dispatch).toHaveBeenCalledTimes(6);
+    expect(store.dispatch).toHaveBeenCalledTimes(5);
     expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesSort());
     expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesPaginator());
     expect(store.dispatch).toHaveBeenCalledWith(new ClearTraineesFilter());
     expect(store.dispatch).toHaveBeenCalledWith(new ClearTraineesSearch());
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
-    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
+    expect(traineeService.updateTraineesRoute).toHaveBeenCalled();
   });
 });

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
@@ -3,13 +3,13 @@ import { Sort } from "@angular/material/sort";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
+import { TraineeService } from "../../core/trainee/trainee.service";
 import {
   ClearTraineesFilter,
   ClearTraineesSearch,
   GetTrainees,
   ResetTraineesPaginator,
-  ResetTraineesSort,
-  UpdateTraineesRoute
+  ResetTraineesSort
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
@@ -20,7 +20,8 @@ import { TraineesState } from "../state/trainees.state";
 export class ResetTraineeListComponent {
   @Select(TraineesState.sort) sort$: Observable<Sort>;
   @Select(TraineesState.pageIndex) pageIndex$: Observable<number>;
-  constructor(private store: Store) {}
+
+  constructor(private store: Store, private traineeService: TraineeService) {}
 
   public resetTraineeList(): void {
     this.store.dispatch(new ResetTraineesSort());
@@ -30,6 +31,6 @@ export class ResetTraineeListComponent {
     this.store
       .dispatch(new GetTrainees())
       .pipe(take(1))
-      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
+      .subscribe(() => this.traineeService.updateTraineesRoute());
   }
 }

--- a/src/app/trainees/state/trainees.actions.ts
+++ b/src/app/trainees/state/trainees.actions.ts
@@ -36,10 +36,6 @@ export class PaginateTrainees {
   constructor(public pageIndex: number) {}
 }
 
-export class UpdateTraineesRoute {
-  static readonly type = "[Trainees] Update Route";
-}
-
 export class ResetTraineesPaginator {
   static readonly type = "[Trainees] Reset Paginator";
 }

--- a/src/app/trainees/state/trainees.state.ts
+++ b/src/app/trainees/state/trainees.state.ts
@@ -1,8 +1,7 @@
 import { HttpParams } from "@angular/common/http";
-import { Injectable, NgZone } from "@angular/core";
+import { Injectable } from "@angular/core";
 import { Sort } from "@angular/material/sort";
-import { Router } from "@angular/router";
-import { State, Action, StateContext, Selector } from "@ngxs/store";
+import { Action, Selector, State, StateContext } from "@ngxs/store";
 import { tap } from "rxjs/operators";
 import { DEFAULT_SORT } from "../../core/trainee/constants";
 import { ITrainee } from "../../core/trainee/trainee.interfaces";
@@ -14,8 +13,7 @@ import {
   ResetTraineesPaginator,
   ResetTraineesSort,
   SearchTrainees,
-  SortTrainees,
-  UpdateTraineesRoute
+  SortTrainees
 } from "./trainees.actions";
 
 export class TraineesStateModel {
@@ -43,11 +41,7 @@ export class TraineesStateModel {
 })
 @Injectable()
 export class TraineesState {
-  constructor(
-    private traineeService: TraineeService,
-    private router: Router,
-    private ngZone: NgZone
-  ) {}
+  constructor(private traineeService: TraineeService) {}
 
   @Selector()
   public static trainees(state: TraineesStateModel) {
@@ -81,13 +75,12 @@ export class TraineesState {
 
   @Action(GetTrainees)
   getTrainees(ctx: StateContext<TraineesStateModel>) {
-    const state = ctx.getState();
-    ctx.setState({
-      ...state,
+    ctx.patchState({
       items: null,
       loading: true
     });
 
+    const state = ctx.getState();
     let params = new HttpParams().set("pageNumber", state.pageIndex.toString());
 
     if (state.sort.direction) {
@@ -102,8 +95,7 @@ export class TraineesState {
 
     return this.traineeService.getTrainees(params).pipe(
       tap((result) => {
-        ctx.setState({
-          ...state,
+        ctx.patchState({
           items: result.traineeInfo,
           countTotal: result.countTotal,
           loading: false
@@ -152,21 +144,6 @@ export class TraineesState {
       ...state,
       pageIndex: 0
     });
-  }
-
-  @Action(UpdateTraineesRoute)
-  updateTraineesRoute(ctx: StateContext<TraineesStateModel>) {
-    const state = ctx.getState();
-    return this.ngZone.run(() =>
-      this.router.navigate(["/trainees"], {
-        queryParams: {
-          active: state.sort.active,
-          direction: state.sort.direction,
-          pageIndex: state.pageIndex,
-          ...(state.searchQuery && { searchQuery: state.searchQuery })
-        }
-      })
-    );
   }
 
   @Action(SearchTrainees)

--- a/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.spec.ts
+++ b/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.spec.ts
@@ -4,20 +4,28 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatPaginatorModule, PageEvent } from "@angular/material/paginator";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
-import { of } from "rxjs";
-import {
-  GetTrainees,
-  PaginateTrainees,
-  UpdateTraineesRoute
-} from "../state/trainees.actions";
+import { Observable, of } from "rxjs";
+import { TraineeService } from "../../core/trainee/trainee.service";
+import { GetTrainees, PaginateTrainees } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
 import { TraineeListPaginatorComponent } from "./trainee-list-paginator.component";
+
+class MockTraineeService {
+  public getTrainees(): Observable<any> {
+    return of({});
+  }
+
+  public updateTraineesRoute(): Observable<any> {
+    return of({});
+  }
+}
 
 describe("TraineeListPaginatorComponent", () => {
   let store: Store;
   let component: TraineeListPaginatorComponent;
   let fixture: ComponentFixture<TraineeListPaginatorComponent>;
+  let traineeService: TraineeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -27,10 +35,17 @@ describe("TraineeListPaginatorComponent", () => {
         NgxsModule.forRoot([TraineesState]),
         HttpClientTestingModule
       ],
+      providers: [
+        {
+          provide: TraineeService,
+          useClass: MockTraineeService
+        }
+      ],
       declarations: [TraineeListPaginatorComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
     store = TestBed.inject(Store);
+    traineeService = TestBed.inject(TraineeService);
   }));
 
   beforeEach(() => {
@@ -51,14 +66,15 @@ describe("TraineeListPaginatorComponent", () => {
       length: 20
     };
     spyOn(store, "dispatch").and.returnValue(of({}));
+    spyOn(traineeService, "updateTraineesRoute");
 
     component.paginateTrainees(mockPageEvent);
 
-    expect(store.dispatch).toHaveBeenCalledTimes(3);
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
     expect(store.dispatch).toHaveBeenCalledWith(
       new PaginateTrainees(mockPageEvent.pageIndex)
     );
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
-    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
+    expect(traineeService.updateTraineesRoute).toHaveBeenCalled();
   });
 });

--- a/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
+++ b/src/app/trainees/trainee-list-paginator/trainee-list-paginator.component.ts
@@ -3,10 +3,10 @@ import { PageEvent } from "@angular/material/paginator/paginator";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
+import { TraineeService } from "../../core/trainee/trainee.service";
 import {
   GetTrainees,
-  PaginateTrainees,
-  UpdateTraineesRoute
+  PaginateTrainees
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
@@ -18,13 +18,13 @@ export class TraineeListPaginatorComponent {
   @Select(TraineesState.countTotal) countTotal$: Observable<number>;
   @Select(TraineesState.pageIndex) pageIndex$: Observable<number>;
 
-  constructor(private store: Store) {}
+  constructor(private store: Store, private traineeService: TraineeService) {}
 
   public paginateTrainees(event: PageEvent) {
     this.store.dispatch(new PaginateTrainees(event.pageIndex));
     this.store
       .dispatch(new GetTrainees())
       .pipe(take(1))
-      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
+      .subscribe(() => this.traineeService.updateTraineesRoute());
   }
 }

--- a/src/app/trainees/trainee-list/trainee-list.component.spec.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.spec.ts
@@ -5,25 +5,36 @@ import { Sort } from "@angular/material/sort";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
 import { ITrainee } from "../../core/trainee/trainee.interfaces";
+import { TraineeService } from "../../core/trainee/trainee.service";
 import {
   GetTrainees,
   PaginateTrainees,
   ResetTraineesPaginator,
   ResetTraineesSort,
   SearchTrainees,
-  SortTrainees,
-  UpdateTraineesRoute
+  SortTrainees
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 import { TraineeListComponent } from "./trainee-list.component";
+
+class MockTraineeService {
+  public getTrainees(): Observable<any> {
+    return of({});
+  }
+
+  public updateTraineesRoute(): Observable<any> {
+    return of({});
+  }
+}
 
 describe("TraineeListComponent", () => {
   let store: Store;
   let component: TraineeListComponent;
   let fixture: ComponentFixture<TraineeListComponent>;
   let router: Router;
+  let traineeService: TraineeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -33,10 +44,17 @@ describe("TraineeListComponent", () => {
         NgxsModule.forRoot([TraineesState]),
         HttpClientTestingModule
       ],
+      providers: [
+        {
+          provide: TraineeService,
+          useClass: MockTraineeService
+        }
+      ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
     store = TestBed.inject(Store);
     router = TestBed.inject(Router);
+    traineeService = TestBed.inject(TraineeService);
   }));
 
   beforeEach(() => {
@@ -178,15 +196,16 @@ describe("TraineeListComponent", () => {
 
     spyOn(store, "dispatch").and.returnValue(of({}));
     spyOn(router, "navigate");
+    spyOn(traineeService, "updateTraineesRoute");
 
     component.sortTrainees(mockSortEvent);
 
-    expect(store.dispatch).toHaveBeenCalledTimes(4);
+    expect(store.dispatch).toHaveBeenCalledTimes(3);
     expect(store.dispatch).toHaveBeenCalledWith(
       new SortTrainees(mockSortEvent.active, mockSortEvent.direction)
     );
     expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesPaginator());
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
-    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
+    expect(traineeService.updateTraineesRoute).toHaveBeenCalled();
   });
 });

--- a/src/app/trainees/trainee-list/trainee-list.component.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.ts
@@ -8,14 +8,14 @@ import {
   ITrainee,
   ITraineeDataCell
 } from "../../core/trainee/trainee.interfaces";
+import { TraineeService } from "../../core/trainee/trainee.service";
 import {
   GetTrainees,
   PaginateTrainees,
   ResetTraineesPaginator,
   ResetTraineesSort,
   SearchTrainees,
-  SortTrainees,
-  UpdateTraineesRoute
+  SortTrainees
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
@@ -80,13 +80,15 @@ export class TraineeListComponent implements OnInit {
       enableSort: true
     }
   ];
+
   public columnLabels: string[] = this.columnData.map((i) => i.label);
   public params: Params = this.route.snapshot.queryParams;
 
   constructor(
     private store: Store,
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private traineeService: TraineeService
   ) {}
 
   /**
@@ -136,6 +138,6 @@ export class TraineeListComponent implements OnInit {
     this.store
       .dispatch(new GetTrainees())
       .pipe(take(1))
-      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
+      .subscribe(() => this.traineeService.updateTraineesRoute());
   }
 }

--- a/src/app/trainees/trainee-search/trainee-search.component.spec.ts
+++ b/src/app/trainees/trainee-search/trainee-search.component.spec.ts
@@ -5,12 +5,9 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
+import { TraineeService } from "../../core/trainee/trainee.service";
 import { MaterialModule } from "../../shared/material/material.module";
-import {
-  GetTrainees,
-  SearchTrainees,
-  UpdateTraineesRoute
-} from "../state/trainees.actions";
+import { GetTrainees, SearchTrainees } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
 import { TraineeSearchComponent } from "./trainee-search.component";
@@ -19,6 +16,7 @@ describe("TraineeSearchComponent", () => {
   let store: Store;
   let component: TraineeSearchComponent;
   let fixture: ComponentFixture<TraineeSearchComponent>;
+  let traineeService: TraineeService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -33,6 +31,7 @@ describe("TraineeSearchComponent", () => {
       ]
     }).compileComponents();
     store = TestBed.inject(Store);
+    traineeService = TestBed.inject(TraineeService);
   }));
 
   beforeEach(() => {
@@ -64,12 +63,12 @@ describe("TraineeSearchComponent", () => {
   it("should create form, form control with default value", () => {
     component.params = {};
     component.setupForm();
-    expect(component.form.value.searchQuery).toBeNull();
+    expect(component.form.value.searchQuery).toEqual("");
   });
 
-  it("form should be invalid if min length validation fails", () => {
+  it("form should be invalid if no characters entered", () => {
     component.params = {
-      searchQuery: "9"
+      searchQuery: ""
     };
     component.setupForm();
     expect(component.form.invalid).toBeTruthy();
@@ -89,6 +88,7 @@ describe("TraineeSearchComponent", () => {
 
   it("should dispatch relevant actions on valid form submission", () => {
     spyOn(store, "dispatch").and.returnValue(of({}));
+    spyOn(traineeService, "updateTraineesRoute");
 
     component.params = {
       searchQuery: "87723113"
@@ -96,11 +96,11 @@ describe("TraineeSearchComponent", () => {
     component.setupForm();
     component.submitForm(component.params.searchQuery);
 
-    expect(store.dispatch).toHaveBeenCalledTimes(3);
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
     expect(store.dispatch).toHaveBeenCalledWith(
       new SearchTrainees(component.params.searchQuery)
     );
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
-    expect(store.dispatch).toHaveBeenCalledWith(new UpdateTraineesRoute());
+    expect(traineeService.updateTraineesRoute).toHaveBeenCalled();
   });
 });

--- a/src/app/trainees/trainee-search/trainee-search.component.ts
+++ b/src/app/trainees/trainee-search/trainee-search.component.ts
@@ -4,11 +4,8 @@ import { ActivatedRoute, Params } from "@angular/router";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
-import {
-  GetTrainees,
-  SearchTrainees,
-  UpdateTraineesRoute
-} from "../state/trainees.actions";
+import { TraineeService } from "../../core/trainee/trainee.service";
+import { GetTrainees, SearchTrainees } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
 @Component({
@@ -23,7 +20,8 @@ export class TraineeSearchComponent implements OnInit {
   constructor(
     private formBuilder: FormBuilder,
     private store: Store,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private traineeService: TraineeService
   ) {}
 
   ngOnInit() {
@@ -53,6 +51,6 @@ export class TraineeSearchComponent implements OnInit {
     this.store
       .dispatch(new GetTrainees())
       .pipe(take(1))
-      .subscribe(() => this.store.dispatch(new UpdateTraineesRoute()));
+      .subscribe(() => this.traineeService.updateTraineesRoute());
   }
 }


### PR DESCRIPTION
moved `/trainees` route change out of store as recommended by Femi to a service in order to ensure state management focuses on state

- removed `UpdateTraineesRoute` action as no longer needed
- small code refactor including tests
- added tests for `TraineeService`