### PR TITLE
fix: hotjar console error. added settings to window before script load

### DIFF
--- a/projects/hee-shared/src/lib/hotjar/hotjar.module.ts
+++ b/projects/hee-shared/src/lib/hotjar/hotjar.module.ts
@@ -54,6 +54,10 @@ export class HotJarModule {
     if (!this.hotJarScript && this.hotJarConfig.enabled) {
       const win = window as any;
       if (!win.hj) {
+        win._hjSettings = {
+          hjid: this.hotJarConfig.hotJarId,
+          hjsv: this.hotJarConfig.hotJarSv
+        };
         win.hj = (...args: any) => {
           ((window as any).hj.q = (window as any).hj.q || []).push(args);
         }; // FIX: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.


### PR DESCRIPTION
window._hjSettings undefined error in bootstrapping hotjar fix. object was not created
TISNEW-3849