### PR TITLE
feat: reset form on clear all

### DIFF
--- a/src/app/core/trainee/trainee.service.spec.ts
+++ b/src/app/core/trainee/trainee.service.spec.ts
@@ -8,7 +8,7 @@ import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { environment } from "@environment";
 import { NgxsModule, Store } from "@ngxs/store";
-import { Observable, of } from "rxjs";
+import { BehaviorSubject, Observable, of } from "rxjs";
 import {
   ResetTraineesPaginator,
   SearchTrainees,
@@ -61,6 +61,8 @@ const mockResponse: IGetTraineesResponse = {
 };
 
 export class MockTraineeService {
+  public resetSearchForm$: BehaviorSubject<boolean> = new BehaviorSubject(null);
+
   public getTrainees(): Observable<any> {
     return of(mockResponse);
   }

--- a/src/app/core/trainee/trainee.service.ts
+++ b/src/app/core/trainee/trainee.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@angular/core";
 import { Router } from "@angular/router";
 import { environment } from "@environment";
 import { Store } from "@ngxs/store";
-import { Observable } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
 import { TraineesStateModel } from "../../trainees/state/trainees.state";
 import { IGetTraineesResponse, TraineesFilterType } from "./trainee.interfaces";
 
@@ -11,6 +11,8 @@ import { IGetTraineesResponse, TraineesFilterType } from "./trainee.interfaces";
   providedIn: "root"
 })
 export class TraineeService {
+  public resetSearchForm$: BehaviorSubject<boolean> = new BehaviorSubject(null);
+
   constructor(
     private http: HttpClient,
     private router: Router,

--- a/src/app/trainee/revalidation-history/revalidation-history.component.spec.ts
+++ b/src/app/trainee/revalidation-history/revalidation-history.component.spec.ts
@@ -1,4 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatSortModule } from "@angular/material/sort";
+import { MatTableModule } from "@angular/material/table";
 
 import { RevalidationHistoryComponent } from "./revalidation-history.component";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
@@ -20,6 +22,8 @@ describe("RevalidationHistoryComponent", () => {
         MaterialModule,
         RouterTestingModule,
         HttpClientTestingModule,
+        MatTableModule,
+        MatSortModule,
         NgxsModule.forRoot([RevalidationHistoryState])
       ],
       declarations: [RevalidationHistoryComponent],

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
@@ -54,10 +54,15 @@ describe("ResetTraineeListComponent", () => {
     expect(component).toBeTruthy();
   });
 
+  it("should emit `resetSearchForm$` event on resetTraineeList()", () => {
+    spyOn(traineeService.resetSearchForm$, "next");
+    component.resetTraineeList();
+    expect(traineeService.resetSearchForm$.next).toHaveBeenCalledWith(true);
+  });
+
   it("should dispatch relevant actions to reset trainee list", () => {
     spyOn(store, "dispatch").and.returnValue(of({}));
     spyOn(router, "navigate");
-    spyOn(traineeService, "updateTraineesRoute");
 
     component.resetTraineeList();
 
@@ -67,6 +72,11 @@ describe("ResetTraineeListComponent", () => {
     expect(store.dispatch).toHaveBeenCalledWith(new UnderNoticeFilter());
     expect(store.dispatch).toHaveBeenCalledWith(new ClearTraineesSearch());
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
+  });
+
+  it("should invoke `updateTraineesRoute()` on resetTraineeList()", () => {
+    spyOn(traineeService, "updateTraineesRoute");
+    component.resetTraineeList();
     expect(traineeService.updateTraineesRoute).toHaveBeenCalled();
   });
 });

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
@@ -24,6 +24,7 @@ export class ResetTraineeListComponent {
   constructor(private store: Store, private traineeService: TraineeService) {}
 
   public resetTraineeList(): void {
+    this.traineeService.resetSearchForm$.next(true);
     this.store.dispatch(new UnderNoticeFilter());
     this.store.dispatch(new ResetTraineesSort());
     this.store.dispatch(new ResetTraineesPaginator());

--- a/src/app/trainees/trainee-list/trainee-list.component.spec.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.spec.ts
@@ -1,7 +1,9 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { Sort } from "@angular/material/sort";
+import { MatSortModule, Sort } from "@angular/material/sort";
+import { MatTableModule } from "@angular/material/table";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
@@ -38,7 +40,10 @@ describe("TraineeListComponent", () => {
       imports: [
         RouterTestingModule,
         NgxsModule.forRoot([TraineesState]),
-        HttpClientTestingModule
+        HttpClientTestingModule,
+        MatTableModule,
+        MatSortModule,
+        NoopAnimationsModule
       ],
       providers: [
         {

--- a/src/app/trainees/trainee-search/trainee-search.component.html
+++ b/src/app/trainees/trainee-search/trainee-search.component.html
@@ -2,6 +2,7 @@
   class="d-grid trainee-search"
   (ngSubmit)="checkForm()"
   [formGroup]="form"
+  #ngForm="ngForm"
   autocomplete="off"
 >
   <mat-form-field>

--- a/src/app/trainees/trainee-search/trainee-search.component.spec.ts
+++ b/src/app/trainees/trainee-search/trainee-search.component.spec.ts
@@ -49,10 +49,16 @@ describe("TraineeSearchComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should invoke setupForm on `ngOnInit()`", () => {
+  it("should invoke setupForm() on `ngOnInit()`", () => {
     spyOn(component, "setupForm");
     component.ngOnInit();
     expect(component.setupForm).toHaveBeenCalled();
+  });
+
+  it("should invoke setupSubscription() on `ngOnInit()`", () => {
+    spyOn(component, "setupSubscription");
+    component.ngOnInit();
+    expect(component.setupSubscription).toHaveBeenCalled();
   });
 
   it("should create form, form control with value from query params", () => {
@@ -77,6 +83,15 @@ describe("TraineeSearchComponent", () => {
     };
     component.setupForm();
     expect(component.form.invalid).toBeTruthy();
+  });
+
+  it("should invoke resetForm() upon receiving `resetSearchForm$` event", () => {
+    spyOn(component.ngForm, "resetForm");
+
+    traineeService.resetSearchForm$.next(true);
+    component.setupSubscription();
+
+    expect(component.ngForm.resetForm).toHaveBeenCalled();
   });
 
   it("form is only submitted if valid", () => {
@@ -109,5 +124,11 @@ describe("TraineeSearchComponent", () => {
     expect(store.dispatch).toHaveBeenCalledWith(new ResetTraineesPaginator());
     expect(store.dispatch).toHaveBeenCalledWith(new GetTrainees());
     expect(traineeService.updateTraineesRoute).toHaveBeenCalled();
+  });
+
+  it("should unsubscribe from subscriptions upon `ngOnDestroy()`", () => {
+    spyOn(component.subscriptions, "unsubscribe");
+    component.ngOnDestroy();
+    expect(component.subscriptions.unsubscribe).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
In the scenario where there are validation errors on the trainee search form and the `Clear all` button is pressed then reset the search form.

- also fix material table related warnings in spec files