### PR TITLE
refactor: make actions, state generic

### DIFF
--- a/src/app/concerns/concern-list/concern-list.component.spec.ts
+++ b/src/app/concerns/concern-list/concern-list.component.spec.ts
@@ -1,10 +1,9 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { NgxsModule, Store } from "@ngxs/store";
+import { NgxsModule } from "@ngxs/store";
 import { ConcernsState } from "../state/concerns.state";
 import { ConcernListComponent } from "./concern-list.component";
 
 describe("ConcernListComponent", () => {
-  let store: Store;
   let component: ConcernListComponent;
   let fixture: ComponentFixture<ConcernListComponent>;
 
@@ -13,7 +12,6 @@ describe("ConcernListComponent", () => {
       declarations: [ConcernListComponent],
       imports: [NgxsModule.forRoot([ConcernsState])]
     }).compileComponents();
-    store = TestBed.inject(Store);
   }));
 
   beforeEach(() => {

--- a/src/app/concerns/state/concerns.actions.ts
+++ b/src/app/concerns/state/concerns.actions.ts
@@ -1,3 +1,5 @@
+const label = `[Concerns]`;
+
 export class Get {
-  static readonly type = "[Concerns] Get";
+  static readonly type = `${label} Get`;
 }

--- a/src/app/core/trainee/trainee.service.spec.ts
+++ b/src/app/core/trainee/trainee.service.spec.ts
@@ -12,13 +12,13 @@ import { BehaviorSubject, Observable, of } from "rxjs";
 import {
   ResetPaginator,
   Search,
-  UnderNoticeFilter
+  Filter
 } from "../../trainees/state/trainees.actions";
 import {
   TraineesState,
   TraineesStateModel
 } from "../../trainees/state/trainees.state";
-import { IGetTraineesResponse } from "./trainee.interfaces";
+import { IGetTraineesResponse, TraineesFilterType } from "./trainee.interfaces";
 import { TraineeService } from "./trainee.service";
 
 const mockResponse: IGetTraineesResponse = {
@@ -112,7 +112,7 @@ describe("TraineeService", () => {
 
   it("`generateParams()` should generate and return HttpParams", () => {
     store.dispatch(new ResetPaginator());
-    store.dispatch(new UnderNoticeFilter());
+    store.dispatch(new Filter(TraineesFilterType.UNDER_NOTICE));
 
     const params: HttpParams = service.generateParams();
 
@@ -122,7 +122,7 @@ describe("TraineeService", () => {
   it("`generateParams()` should include search query if its set on store", () => {
     store.dispatch(new Search("lisa"));
     store.dispatch(new ResetPaginator());
-    store.dispatch(new UnderNoticeFilter());
+    store.dispatch(new Filter(TraineesFilterType.UNDER_NOTICE));
 
     const params: HttpParams = service.generateParams();
 

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.spec.ts
@@ -4,6 +4,7 @@ import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { of } from "rxjs";
+import { TraineesFilterType } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import { MockTraineeService } from "../../core/trainee/trainee.service.spec";
 import {
@@ -11,7 +12,7 @@ import {
   Get,
   ResetPaginator,
   ResetSort,
-  UnderNoticeFilter
+  Filter
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
@@ -69,7 +70,9 @@ describe("ResetTraineeListComponent", () => {
     expect(store.dispatch).toHaveBeenCalledTimes(5);
     expect(store.dispatch).toHaveBeenCalledWith(new ResetSort());
     expect(store.dispatch).toHaveBeenCalledWith(new ResetPaginator());
-    expect(store.dispatch).toHaveBeenCalledWith(new UnderNoticeFilter());
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new Filter(TraineesFilterType.UNDER_NOTICE)
+    );
     expect(store.dispatch).toHaveBeenCalledWith(new ClearSearch());
     expect(store.dispatch).toHaveBeenCalledWith(new Get());
   });

--- a/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
+++ b/src/app/trainees/reset-trainee-list/reset-trainee-list.component.ts
@@ -3,9 +3,10 @@ import { Sort } from "@angular/material/sort";
 import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
+import { TraineesFilterType } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import {
-  UnderNoticeFilter,
+  Filter,
   ClearSearch,
   Get,
   ResetPaginator,
@@ -25,7 +26,7 @@ export class ResetTraineeListComponent {
 
   public resetTraineeList(): void {
     this.traineeService.resetSearchForm$.next(true);
-    this.store.dispatch(new UnderNoticeFilter());
+    this.store.dispatch(new Filter(TraineesFilterType.UNDER_NOTICE));
     this.store.dispatch(new ResetSort());
     this.store.dispatch(new ResetPaginator());
     this.store.dispatch(new ClearSearch());

--- a/src/app/trainees/state/trainees.actions.ts
+++ b/src/app/trainees/state/trainees.actions.ts
@@ -1,52 +1,54 @@
 import { HttpErrorResponse } from "@angular/common/http";
 import { SortDirection } from "@angular/material/sort/sort-direction";
-import { IGetTraineesResponse } from "../../core/trainee/trainee.interfaces";
+import {
+  IGetTraineesResponse,
+  TraineesFilterType
+} from "../../core/trainee/trainee.interfaces";
+
+const label = `[Trainees]`;
 
 export class Get {
-  static readonly type = "[Trainees] Get";
+  static readonly type = `${label} Get`;
 }
 
 export class GetSuccess {
-  static readonly type = "[Trainees] Get Success";
+  static readonly type = `${label} Get Success`;
   constructor(public response: IGetTraineesResponse) {}
 }
 
 export class GetError {
-  static readonly type = "[Trainees] Get Error";
+  static readonly type = `${label} Get Error`;
   constructor(public error: HttpErrorResponse) {}
 }
 
 export class Sort {
-  static readonly type = "[Trainees] Sort";
+  static readonly type = `${label} Sort`;
   constructor(public column: string, public direction: SortDirection) {}
 }
 
 export class ResetSort {
-  static readonly type = "[Trainees] Reset Sort";
+  static readonly type = `${label} Reset Sort`;
 }
 
-export class AllDoctorsFilter {
-  static readonly type = "[Trainees] All Doctors Filter";
-}
-
-export class UnderNoticeFilter {
-  static readonly type = "[Trainees] Under Notice Filter";
+export class Filter {
+  static readonly type = `${label} Filter`;
+  constructor(public filter: TraineesFilterType) {}
 }
 
 export class Search {
-  static readonly type = "[Trainees] Search";
+  static readonly type = `${label} Search`;
   constructor(public searchQuery: string) {}
 }
 
 export class ClearSearch {
-  static readonly type = "[Trainees] Clear Search";
+  static readonly type = `${label} Clear Search`;
 }
 
 export class Paginate {
-  static readonly type = "[Trainees] Paginate";
+  static readonly type = `${label} Paginate`;
   constructor(public pageIndex: number) {}
 }
 
 export class ResetPaginator {
-  static readonly type = "[Trainees] Reset Paginator";
+  static readonly type = `${label} Reset Paginator`;
 }

--- a/src/app/trainees/state/trainees.state.spec.ts
+++ b/src/app/trainees/state/trainees.state.spec.ts
@@ -10,15 +10,14 @@ import { TraineeService } from "../../core/trainee/trainee.service";
 import { MockTraineeService } from "../../core/trainee/trainee.service.spec";
 import { MaterialModule } from "../../shared/material/material.module";
 import {
-  AllDoctorsFilter,
+  Filter,
   ClearSearch,
   Get,
   GetError,
   Paginate,
   ResetPaginator,
   Search,
-  Sort,
-  UnderNoticeFilter
+  Sort
 } from "./trainees.actions";
 import { TraineesState } from "./trainees.state";
 
@@ -61,7 +60,7 @@ describe("Trainees state", () => {
     spyOn(traineeService, "getTrainees").and.callThrough();
 
     store.dispatch(new Get());
-    const trainees = store.selectSnapshot(TraineesState.trainees);
+    const trainees = store.selectSnapshot(TraineesState.items);
 
     expect(trainees.length).toEqual(2);
     expect(trainees[0].doctorFirstName).toEqual("Bobby");
@@ -122,13 +121,13 @@ describe("Trainees state", () => {
   });
 
   it("should dispatch 'UnderNoticeFilter' and update store", () => {
-    store.dispatch(new UnderNoticeFilter());
+    store.dispatch(new Filter(TraineesFilterType.UNDER_NOTICE));
     const filter = store.selectSnapshot(TraineesState.filter);
     expect(filter).toEqual(TraineesFilterType.UNDER_NOTICE);
   });
 
   it("should dispatch 'AllDoctorsFilter' and update store", () => {
-    store.dispatch(new AllDoctorsFilter());
+    store.dispatch(new Filter(TraineesFilterType.ALL_DOCTORS));
     const filter = store.selectSnapshot(TraineesState.filter);
     expect(filter).toEqual(TraineesFilterType.ALL_DOCTORS);
   });

--- a/src/app/trainees/state/trainees.state.ts
+++ b/src/app/trainees/state/trainees.state.ts
@@ -11,8 +11,8 @@ import {
 } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import {
-  AllDoctorsFilter,
   ClearSearch,
+  Filter,
   Get,
   GetError,
   GetSuccess,
@@ -20,8 +20,7 @@ import {
   ResetPaginator,
   ResetSort,
   Search,
-  Sort,
-  UnderNoticeFilter
+  Sort
 } from "./trainees.actions";
 
 export class TraineesStateModel {
@@ -61,7 +60,7 @@ export class TraineesState {
   constructor(private traineeService: TraineeService) {}
 
   @Selector()
-  public static trainees(state: TraineesStateModel) {
+  public static items(state: TraineesStateModel) {
     return state.items;
   }
 
@@ -111,7 +110,7 @@ export class TraineesState {
   }
 
   @Action(Get)
-  getTrainees(ctx: StateContext<TraineesStateModel>) {
+  get(ctx: StateContext<TraineesStateModel>) {
     ctx.patchState({
       items: null,
       loading: true
@@ -139,10 +138,7 @@ export class TraineesState {
   }
 
   @Action(GetSuccess)
-  getTraineesSuccess(
-    ctx: StateContext<TraineesStateModel>,
-    action: GetSuccess
-  ) {
+  getSuccess(ctx: StateContext<TraineesStateModel>, action: GetSuccess) {
     return ctx.patchState({
       items: action.response.traineeInfo,
       countTotal: action.response.countTotal,
@@ -152,14 +148,14 @@ export class TraineesState {
   }
 
   @Action(GetError)
-  getTraineesError(ctx: StateContext<TraineesStateModel>, action: GetError) {
+  getError(ctx: StateContext<TraineesStateModel>, action: GetError) {
     return ctx.patchState({
       error: `Error: ${action.error.message}`
     });
   }
 
   @Action(Sort)
-  sortTrainees(ctx: StateContext<TraineesStateModel>, action: Sort) {
+  sort(ctx: StateContext<TraineesStateModel>, action: Sort) {
     return ctx.patchState({
       sort: {
         active: action.column,
@@ -169,51 +165,42 @@ export class TraineesState {
   }
 
   @Action(ResetSort)
-  resetTraineesSort(ctx: StateContext<TraineesStateModel>) {
+  resetSort(ctx: StateContext<TraineesStateModel>) {
     return ctx.patchState({
       sort: DEFAULT_SORT
     });
   }
 
   @Action(Paginate)
-  paginateTrainees(ctx: StateContext<TraineesStateModel>, action: Paginate) {
+  paginate(ctx: StateContext<TraineesStateModel>, action: Paginate) {
     return ctx.patchState({
       pageIndex: action.pageIndex
     });
   }
 
   @Action(ResetPaginator)
-  resetTraineesPaginator(ctx: StateContext<TraineesStateModel>) {
+  resetPaginator(ctx: StateContext<TraineesStateModel>) {
     return ctx.patchState({
       pageIndex: 0
     });
   }
 
   @Action(Search)
-  searchTrainees(ctx: StateContext<TraineesStateModel>, action: Search) {
+  search(ctx: StateContext<TraineesStateModel>, action: Search) {
     return ctx.patchState({
       searchQuery: action.searchQuery
     });
   }
 
   @Action(ClearSearch)
-  clearTraineesSearch(ctx: StateContext<TraineesStateModel>) {
+  clearSearch(ctx: StateContext<TraineesStateModel>) {
     return ctx.patchState({
       searchQuery: null
     });
   }
 
-  @Action(UnderNoticeFilter)
-  underNoticeFilter(ctx: StateContext<TraineesStateModel>) {
-    return ctx.patchState({
-      filter: TraineesFilterType.UNDER_NOTICE
-    });
-  }
-
-  @Action(AllDoctorsFilter)
-  allDoctorsFilter(ctx: StateContext<TraineesStateModel>) {
-    return ctx.patchState({
-      filter: TraineesFilterType.ALL_DOCTORS
-    });
+  @Action(Filter)
+  filter(ctx: StateContext<TraineesStateModel>, action: Filter) {
+    return ctx.patchState(action);
   }
 }

--- a/src/app/trainees/trainee-filters/trainee-filters.component.spec.ts
+++ b/src/app/trainees/trainee-filters/trainee-filters.component.spec.ts
@@ -2,15 +2,15 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
+import { TraineesFilterType } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import { MockTraineeService } from "../../core/trainee/trainee.service.spec";
 import {
-  AllDoctorsFilter,
+  Filter,
   ClearSearch,
   Get,
   ResetPaginator,
-  ResetSort,
-  UnderNoticeFilter
+  ResetSort
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
@@ -54,7 +54,9 @@ describe("TraineeFiltersComponent", () => {
   it("`filterByAllDoctors()` should dispatch `AllDoctorsFilter` event", () => {
     spyOn(store, "dispatch").and.callThrough();
     component.filterByAllDoctors();
-    expect(store.dispatch).toHaveBeenCalledWith(new AllDoctorsFilter());
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new Filter(TraineesFilterType.ALL_DOCTORS)
+    );
   });
 
   it("`filterByAllDoctors()` should invoke `getTrainees()`", () => {
@@ -66,7 +68,9 @@ describe("TraineeFiltersComponent", () => {
   it("`filterByUnderNotice()` should dispatch `UnderNoticeFilter` event", () => {
     spyOn(store, "dispatch").and.callThrough();
     component.filterByUnderNotice();
-    expect(store.dispatch).toHaveBeenCalledWith(new UnderNoticeFilter());
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new Filter(TraineesFilterType.UNDER_NOTICE)
+    );
   });
 
   it("`filterByUnderNotice()` should invoke `getTrainees()`", () => {

--- a/src/app/trainees/trainee-filters/trainee-filters.component.ts
+++ b/src/app/trainees/trainee-filters/trainee-filters.component.ts
@@ -5,12 +5,11 @@ import { take } from "rxjs/operators";
 import { TraineesFilterType } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import {
-  UnderNoticeFilter,
+  Filter,
   ClearSearch,
   Get,
   ResetPaginator,
-  ResetSort,
-  AllDoctorsFilter
+  ResetSort
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
@@ -27,12 +26,12 @@ export class TraineeFiltersComponent {
   constructor(private store: Store, private traineeService: TraineeService) {}
 
   public filterByAllDoctors(): void {
-    this.store.dispatch(new AllDoctorsFilter());
+    this.store.dispatch(new Filter(TraineesFilterType.ALL_DOCTORS));
     this.getTrainees();
   }
 
   public filterByUnderNotice(): void {
-    this.store.dispatch(new UnderNoticeFilter());
+    this.store.dispatch(new Filter(TraineesFilterType.UNDER_NOTICE));
     this.getTrainees();
   }
 

--- a/src/app/trainees/trainee-list/trainee-list.component.html
+++ b/src/app/trainees/trainee-list/trainee-list.component.html
@@ -15,35 +15,32 @@
 
   <ng-template #notLoading>
     <!--  error -->
-    <div
-      *ngIf="data.error; else trainees"
-      class="d-grid justify-content-center"
-    >
+    <div *ngIf="data.error; else items" class="d-grid justify-content-center">
       <mat-chip-list class="mat-chip-list-stacked" aria-orientation="vertical">
         <mat-chip selected color="warn">{{ data.error }}</mat-chip>
       </mat-chip-list>
     </div>
 
-    <!-- trainees -->
-    <ng-template #trainees>
+    <!-- Records list -->
+    <ng-template #items>
       <ng-container *ngIf="data.totalResults; else noResults">
         <div class="table-container">
           <table
             mat-table
             *ngIf="{
               sort: sort$ | async,
-              trainees: trainees$ | async
+              items: items$ | async
             } as data"
             class="w-100"
-            [dataSource]="data.trainees"
+            [dataSource]="data.items"
             matSort
             matSortDisableClear
-            (matSortChange)="sortTrainees($event)"
+            (matSortChange)="sort($event)"
             [matSortActive]="data.sort.active"
             [matSortDirection]="data.sort.direction"
           >
             <caption class="collapsed no-height">
-              Trainees list
+              Records list
             </caption>
             <ng-container
               *ngFor="let i of columnData"
@@ -85,9 +82,9 @@
             <tr
               mat-row
               *matRowDef="let row; columns: columnNames"
-              (click)="traineeDetails($event, row)"
-              (keyup.enter)="traineeDetails($event, row)"
-              (keyup.space)="traineeDetails($event, row)"
+              (click)="navigateToDetails($event, row)"
+              (keyup.enter)="navigateToDetails($event, row)"
+              (keyup.space)="navigateToDetails($event, row)"
               tabindex="0"
               role="button"
             ></tr>

--- a/src/app/trainees/trainee-list/trainee-list.component.spec.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.spec.ts
@@ -15,14 +15,13 @@ import {
 import { TraineeService } from "../../core/trainee/trainee.service";
 import { MockTraineeService } from "../../core/trainee/trainee.service.spec";
 import {
-  AllDoctorsFilter,
+  Filter,
   Get,
   Paginate,
   ResetPaginator,
   ResetSort,
   Search,
-  Sort,
-  UnderNoticeFilter
+  Sort
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 import { TraineeListComponent } from "./trainee-list.component";
@@ -154,8 +153,12 @@ describe("TraineeListComponent", () => {
     component.setupInitialFilter();
 
     expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(new AllDoctorsFilter());
-    expect(store.dispatch).not.toHaveBeenCalledWith(new UnderNoticeFilter());
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new Filter(TraineesFilterType.ALL_DOCTORS)
+    );
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      new Filter(TraineesFilterType.UNDER_NOTICE)
+    );
   });
 
   it("'setupInitialFilter()' should dispatch 'UnderNoticeFilter' if param does not exist", () => {
@@ -164,8 +167,12 @@ describe("TraineeListComponent", () => {
     component.setupInitialFilter();
 
     expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(new UnderNoticeFilter());
-    expect(store.dispatch).not.toHaveBeenCalledWith(new AllDoctorsFilter());
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new Filter(TraineesFilterType.UNDER_NOTICE)
+    );
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      new Filter(TraineesFilterType.ALL_DOCTORS)
+    );
   });
 
   it("'checkInitialSearchQuery()' should dispatch 'SearchTrainees' if param exists", () => {
@@ -201,7 +208,7 @@ describe("TraineeListComponent", () => {
     spyOn(mockEvent, "preventDefault");
     spyOn(router, "navigate");
 
-    component.traineeDetails(mockEvent, mockTrainee);
+    component.navigateToDetails(mockEvent, mockTrainee);
     expect(router.navigate).toHaveBeenCalledWith([
       "/trainee",
       mockTrainee.gmcReferenceNumber
@@ -218,7 +225,7 @@ describe("TraineeListComponent", () => {
     spyOn(router, "navigate");
     spyOn(traineeService, "updateTraineesRoute");
 
-    component.sortTrainees(mockSortEvent);
+    component.sort(mockSortEvent);
 
     expect(store.dispatch).toHaveBeenCalledTimes(3);
     expect(store.dispatch).toHaveBeenCalledWith(

--- a/src/app/trainees/trainee-list/trainee-list.component.ts
+++ b/src/app/trainees/trainee-list/trainee-list.component.ts
@@ -12,14 +12,13 @@ import {
 } from "../../core/trainee/trainee.interfaces";
 import { TraineeService } from "../../core/trainee/trainee.service";
 import {
-  AllDoctorsFilter,
+  Filter,
   Get,
   Paginate,
   ResetPaginator,
   ResetSort,
   Search,
-  Sort,
-  UnderNoticeFilter
+  Sort
 } from "../state/trainees.actions";
 import { TraineesState } from "../state/trainees.state";
 
@@ -30,7 +29,7 @@ import { TraineesState } from "../state/trainees.state";
 })
 export class TraineeListComponent implements OnInit {
   @Select(TraineesState.loading) loading$: Observable<boolean>;
-  @Select(TraineesState.trainees) trainees$: Observable<ITrainee[]>;
+  @Select(TraineesState.items) items$: Observable<ITrainee[]>;
   @Select(TraineesState.totalResults) totalResults$: Observable<number>;
   @Select(TraineesState.sort) sort$: Observable<ISort>;
   @Select(TraineesState.error) error$: Observable<string>;
@@ -138,9 +137,9 @@ export class TraineeListComponent implements OnInit {
       this.params.filter &&
       this.params.filter === TraineesFilterType.ALL_DOCTORS
     ) {
-      this.store.dispatch(new AllDoctorsFilter());
+      this.store.dispatch(new Filter(TraineesFilterType.ALL_DOCTORS));
     } else {
-      this.store.dispatch(new UnderNoticeFilter());
+      this.store.dispatch(new Filter(TraineesFilterType.UNDER_NOTICE));
     }
   }
 
@@ -150,12 +149,12 @@ export class TraineeListComponent implements OnInit {
     }
   }
 
-  public traineeDetails(event: Event, row: ITrainee): Promise<boolean> {
+  public navigateToDetails(event: Event, row: ITrainee): Promise<boolean> {
     event.stopPropagation();
     return this.router.navigate(["/trainee", row.gmcReferenceNumber]);
   }
 
-  public sortTrainees(event: ISort): void {
+  public sort(event: ISort): void {
     this.store.dispatch(new Sort(event.active, event.direction));
     this.store.dispatch(new ResetPaginator());
     this.store


### PR DESCRIPTION
TISNEW-4573

make actions, state generic so that common code can be leveraged and consumed by both trainees list and concerns list. so basically `AllDoctorsFilter` and `UnderNoticeFilter` have been replaced by a generic filter as `Filter` with a payload