### PR TITLE
fix: missing sorting icon

### DIFF
--- a/src/app/trainees/trainee-list/trainee-list.component.html
+++ b/src/app/trainees/trainee-list/trainee-list.component.html
@@ -55,8 +55,9 @@
                   *matHeaderCellDef
                   [mat-sort-header]="i.name"
                   scope="col"
-                  [innerHTML]="i.label"
-                ></th>
+                >
+                  {{ i.label }}
+                </th>
               </ng-container>
               <ng-template #disabledSort>
                 <th
@@ -64,9 +65,10 @@
                   *matHeaderCellDef
                   [mat-sort-header]="i.name"
                   scope="col"
-                  [innerHTML]="i.label"
                   disabled
-                ></th>
+                >
+                  {{ i.label }}
+                </th>
               </ng-template>
 
               <!-- mat cell -->


### PR DESCRIPTION
angular's `innerHtml` was causing material's `mat-header-cell` html to not render and therefore the sorting icon and hover state was not visible