### PR TITLE
fix: console error and unit test warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7787,6 +7787,12 @@
             "path-is-inside": "^1.0.1"
           }
         },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -9593,6 +9599,14 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "got": {
@@ -12904,12 +12918,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -21049,16 +21057,18 @@
         "which-module": "^2.0.0",
         "y18n": "^3.2.1 || ^4.0.0",
         "yargs-parser": "^11.1.1"
-      }
-    },
-    "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "yauzl": {

--- a/src/app/trainee/revalidation-table/revalidation-table.component.html
+++ b/src/app/trainee/revalidation-table/revalidation-table.component.html
@@ -1,83 +1,124 @@
 <div class="table-container">
-    <table mat-table [dataSource]="revalidationHistory" multiTemplateDataRows class="w-100">
-        <caption class="collapsed no-height">
-            Trainee revalidation historical details
-        </caption>
-        <ng-container matColumnDef="revalidationType">
-            <th mat-header-cell scope="col" *matHeaderCellDef>Recommendation</th>
-            <td mat-cell *matCellDef="let element">
-                {{ revalidationType[element.revalidationType] }}
-            </td>
-        </ng-container>
-        <ng-container matColumnDef="gmcOutcome">
-            <th mat-header-cell scope="col" *matHeaderCellDef>Outcome</th>
-            <td mat-cell *matCellDef="let element">
-                <div class="outcome" [ngSwitch]="element.gmcOutcome">
-                    <mat-icon *ngSwitchCase="revalidationGmcOutcome.APPROVED" aria-hidden="true" class="icon-green">
-                        done_all
-                    </mat-icon>
-                    <mat-icon *ngSwitchCase="revalidationGmcOutcome.REJECTED" aria-hidden="true" class="icon-red">
-                        error_outline
-                    </mat-icon>
-                    <mat-icon *ngSwitchCase="revalidationGmcOutcome.UNDER_REVIEW" aria-hidden="true" class="icon-blue">
-                        done
-                    </mat-icon>
-                    <span class="outcome-text">{{ revalidationGmcOutcome[element.gmcOutcome] }}</span>
-                </div>
-            </td>
-        </ng-container>
-        <ng-container matColumnDef="gmcSubmissionDate">
-            <th mat-header-cell scope="col" *matHeaderCellDef>
-                GMC Submission Due Date
-            </th>
-            <td mat-cell *matCellDef="let element">
-                {{ element.gmcSubmissionDate | date: dateFormat }}
-            </td>
-        </ng-container>
-        <ng-container matColumnDef="actualSubmissionDate">
-            <th mat-header-cell scope="col" *matHeaderCellDef>
-                Actual Submission Date
-            </th>
-            <td mat-cell *matCellDef="let element">
-                {{ element.actualSubmissionDate | date: dateFormat }}
-            </td>
-        </ng-container>
-        <ng-container matColumnDef="admin">
-            <th mat-header-cell scope="col" *matHeaderCellDef>Submitted By</th>
-            <td mat-cell *matCellDef="let element">{{ element.admin }}</td>
-        </ng-container>
+  <table
+    mat-table
+    [dataSource]="revalidationHistory"
+    multiTemplateDataRows
+    class="w-100"
+  >
+    <caption class="collapsed no-height">
+      Trainee revalidation historical details
+    </caption>
+    <ng-container matColumnDef="revalidationType">
+      <th mat-header-cell scope="col" *matHeaderCellDef>Recommendation</th>
+      <td mat-cell *matCellDef="let element">
+        {{ revalidationType[element.revalidationType] }}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="gmcOutcome">
+      <th mat-header-cell scope="col" *matHeaderCellDef>Outcome</th>
+      <td mat-cell *matCellDef="let element">
+        <div class="outcome" [ngSwitch]="element.gmcOutcome">
+          <mat-icon
+            *ngSwitchCase="revalidationGmcOutcome.APPROVED"
+            aria-hidden="true"
+            class="icon-green"
+          >
+            done_all
+          </mat-icon>
+          <mat-icon
+            *ngSwitchCase="revalidationGmcOutcome.REJECTED"
+            aria-hidden="true"
+            class="icon-red"
+          >
+            error_outline
+          </mat-icon>
+          <mat-icon
+            *ngSwitchCase="revalidationGmcOutcome.UNDER_REVIEW"
+            aria-hidden="true"
+            class="icon-blue"
+          >
+            done
+          </mat-icon>
+          <span class="outcome-text">{{
+            revalidationGmcOutcome[element.gmcOutcome]
+          }}</span>
+        </div>
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="gmcSubmissionDate">
+      <th mat-header-cell scope="col" *matHeaderCellDef>
+        GMC Submission Due Date
+      </th>
+      <td mat-cell *matCellDef="let element">
+        {{ element.gmcSubmissionDate | date: dateFormat }}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="actualSubmissionDate">
+      <th mat-header-cell scope="col" *matHeaderCellDef>
+        Actual Submission Date
+      </th>
+      <td mat-cell *matCellDef="let element">
+        {{ element.actualSubmissionDate | date: dateFormat }}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="admin">
+      <th mat-header-cell scope="col" *matHeaderCellDef>Submitted By</th>
+      <td mat-cell *matCellDef="let element">{{ element.admin }}</td>
+    </ng-container>
 
-        <ng-container matColumnDef="expandedDetail">
-            <td mat-cell *matCellDef="let element" [attr.colspan]="columnsToDisplay.length">
-                <div class="element-detail" [@detailExpand]="
+    <ng-container matColumnDef="expandedDetail">
+      <td
+        mat-cell
+        *matCellDef="let element"
+        [attr.colspan]="columnsToDisplay.length"
+      >
+        <div
+          class="element-detail"
+          [@detailExpand]="
             element == expandedElement ? 'expanded' : 'collapsed'
-          ">
-                    <div class="element-submission-status">
-                        <strong>Submission Status:</strong>
-                        {{ revalidationStatus[element.revalidationStatus] }}
-                    </div>
-                    <mat-divider *ngIf="element.comments?.length > 0"></mat-divider>
-                    <ng-container *ngFor="let comment of element.comments">
-                        <div class="element-notes">
-                            {{ comment.comment }}
-                        </div>
-                    </ng-container>
-                </div>
-            </td>
-        </ng-container>
+          "
+        >
+          <div class="element-submission-status">
+            <strong>Submission Status:</strong>
+            {{ revalidationStatus[element.revalidationStatus] }}
+          </div>
+          <mat-divider *ngIf="element.comments?.length > 0"></mat-divider>
+          <ng-container *ngFor="let comment of element.comments">
+            <div class="element-notes">
+              {{ comment.comment }}
+            </div>
+          </ng-container>
+        </div>
+      </td>
+    </ng-container>
 
-        <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
-        <tr tabindex="0" mat-row *matRowDef="let element; columns: columnsToDisplay" class="element-row"
-            [class.expanded-row]="expandedElement === element" (click)="currentExpanded(element)"
-            (keyup.enter)="currentExpanded(element)" (keyup.space)="currentExpanded(element)"></tr>
-        <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
+    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+    <tr
+      tabindex="0"
+      mat-row
+      *matRowDef="let element; columns: columnsToDisplay"
+      class="element-row"
+      [class.expanded-row]="expandedElement === element"
+      (click)="currentExpanded(element)"
+      (keyup.enter)="currentExpanded(element)"
+      (keyup.space)="currentExpanded(element)"
+    ></tr>
+    <tr
+      mat-row
+      *matRowDef="let row; columns: ['expandedDetail']"
+      class="detail-row"
+    ></tr>
 
-        <ng-container matColumnDef="noRecord">
-            <td colspan="5" mat-footer-cell class="centered" *matFooterCellDef>
-                <em class="icon-red">No history available.</em>
-            </td>
-        </ng-container>
+    <ng-container matColumnDef="noRecord">
+      <td colspan="5" mat-footer-cell class="centered" *matFooterCellDef>
+        <em class="icon-red">No history available.</em>
+      </td>
+    </ng-container>
 
-        <tr mat-footer-row *matFooterRowDef="['noRecord']" [ngClass]="{ hide: revalidationHistory.length > 0 }"></tr>
-    </table>
+    <tr
+      mat-footer-row
+      *matFooterRowDef="['noRecord']"
+      [ngClass]="{ hide: revalidationHistory?.length > 0 }"
+    ></tr>
+  </table>
 </div>

--- a/src/app/trainee/revalidation-table/revalidation-table.component.spec.ts
+++ b/src/app/trainee/revalidation-table/revalidation-table.component.spec.ts
@@ -1,16 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { MaterialModule } from "../../shared/material/material.module";
 
-import { RevalidationTableComponent } from './revalidation-table.component';
+import { RevalidationTableComponent } from "./revalidation-table.component";
 
-describe('RevalidationTableComponent', () => {
+describe("RevalidationTableComponent", () => {
   let component: RevalidationTableComponent;
   let fixture: ComponentFixture<RevalidationTableComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ RevalidationTableComponent ]
-    })
-    .compileComponents();
+      declarations: [RevalidationTableComponent],
+      imports: [MaterialModule, NoopAnimationsModule]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
@@ -19,7 +21,7 @@ describe('RevalidationTableComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 });


### PR DESCRIPTION
console error and unit test warnings

most of the code changes are auto formatting done by prettier. actual changes are; 
- `revalidationHistory.length > 0` to `revalidationHistory?.length > 0` to fix console error
- and importing `MaterialModule`, `NoopAnimationsModule` in the spec file to get rid of the material table warnings
