### PR TITLE
chore: Add dependency caching to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,16 @@ jobs:
         with:
           node-version: "12.x"
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: npm-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+
       - name: Install Angular CLI
         run: npm install -g @angular/cli@latest
 


### PR DESCRIPTION
Installing dependencies takes a considerable portion of the workflow run
time, this can be reduced by enabling caching of the node_modules.

NO-TICKET