### PR TITLE
fix: ensure data is fetched upon browser history navigation

### DIFF
--- a/src/app/concerns/concern-list/concern-list.component.spec.ts
+++ b/src/app/concerns/concern-list/concern-list.component.spec.ts
@@ -3,15 +3,12 @@ import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
-import { NgxsModule, Store } from "@ngxs/store";
+import { NgxsModule } from "@ngxs/store";
 import { MaterialModule } from "../../shared/material/material.module";
-import { Filter } from "../state/concerns.actions";
-import { ConcernsFilterType } from "../concerns.interfaces";
 import { ConcernsState } from "../state/concerns.state";
 import { ConcernListComponent } from "./concern-list.component";
 
 describe("ConcernListComponent", () => {
-  let store: Store;
   let component: ConcernListComponent;
   let fixture: ComponentFixture<ConcernListComponent>;
 
@@ -27,7 +24,6 @@ describe("ConcernListComponent", () => {
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
-    store = TestBed.inject(Store);
   }));
 
   beforeEach(() => {
@@ -38,41 +34,5 @@ describe("ConcernListComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
-  });
-
-  it("should invoke `setupInitialFilter()` upon ngOnInit", () => {
-    spyOn(component, "setupInitialFilter");
-
-    component.ngOnInit();
-    expect(component.setupInitialFilter).toHaveBeenCalled();
-  });
-
-  it("'setupInitialFilter()' should dispatch 'Open' filter if param value is `Open`", () => {
-    spyOn(store, "dispatch");
-
-    component.params = { filter: ConcernsFilterType.OPEN };
-    component.setupInitialFilter();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(ConcernsFilterType.OPEN)
-    );
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new Filter(ConcernsFilterType.CLOSED)
-    );
-  });
-
-  it("'setupInitialFilter()' should dispatch 'Closed' filter if param does not exist", () => {
-    spyOn(store, "dispatch");
-
-    component.setupInitialFilter();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(ConcernsFilterType.CLOSED)
-    );
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new Filter(ConcernsFilterType.OPEN)
-    );
   });
 });

--- a/src/app/concerns/concern-list/concern-list.component.ts
+++ b/src/app/concerns/concern-list/concern-list.component.ts
@@ -1,15 +1,16 @@
-import { Component, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, ViewEncapsulation } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { generateColumnData } from "../../shared/records/constants";
 import { RecordListComponent } from "../../shared/records/record-list/record-list.component";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { ConcernsFilterType } from "../concerns.interfaces";
 import { COLUMN_DATA } from "../constants";
 import {
+  ClearSearch,
   Filter,
   Get,
   Paginate,
+  ResetFilter,
   ResetPaginator,
   ResetSort,
   Search,
@@ -21,8 +22,7 @@ import {
   templateUrl: "./concern-list.component.html",
   encapsulation: ViewEncapsulation.None
 })
-export class ConcernListComponent extends RecordListComponent
-  implements OnInit {
+export class ConcernListComponent extends RecordListComponent {
   public dateColumns = [
     "closedDate",
     "dateRaised",
@@ -32,31 +32,22 @@ export class ConcernListComponent extends RecordListComponent
   public columnData = generateColumnData(COLUMN_DATA);
 
   constructor(
+    protected activatedRoute: ActivatedRoute,
     protected recordsService: RecordsService,
-    protected route: ActivatedRoute,
     protected router: Router,
     protected store: Store
   ) {
-    super(recordsService, route, router, store);
+    super(activatedRoute, recordsService, router, store);
     this.recordsService.setActions(
+      ClearSearch,
+      Filter,
       Get,
-      Sort,
-      ResetSort,
       Paginate,
+      ResetFilter,
       ResetPaginator,
-      Search
+      ResetSort,
+      Search,
+      Sort
     );
-  }
-
-  ngOnInit(): void {
-    this.setupInitialFilter();
-  }
-
-  public setupInitialFilter(): void {
-    if (this.params.filter && this.params.filter === ConcernsFilterType.OPEN) {
-      this.store.dispatch(new Filter(ConcernsFilterType.OPEN));
-    } else {
-      this.store.dispatch(new Filter(ConcernsFilterType.CLOSED));
-    }
   }
 }

--- a/src/app/concerns/state/concerns.actions.ts
+++ b/src/app/concerns/state/concerns.actions.ts
@@ -37,6 +37,10 @@ export class Filter extends FilterPayload<ConcernsFilterType> {
   static readonly type = `${label} Filter`;
 }
 
+export class ResetFilter {
+  static readonly type = `${label} Reset Filter`;
+}
+
 export class Search extends SearchPayload {
   static readonly type = `${label} Search`;
 }

--- a/src/app/concerns/state/concerns.state.ts
+++ b/src/app/concerns/state/concerns.state.ts
@@ -3,41 +3,45 @@ import { Injectable } from "@angular/core";
 import { environment } from "@environment";
 import { Action, State, StateContext } from "@ngxs/store";
 import { catchError, finalize, map, switchMap, take } from "rxjs/operators";
+import { RecommendationStatus } from "../../recommendation/recommendation-history.interface";
+import { DEFAULT_SORT } from "../../shared/records/constants";
 import { RecordsService } from "../../shared/records/services/records.service";
 import {
   defaultRecordsState,
   RecordsState,
   RecordsStateModel
 } from "../../shared/records/state/records.state";
-import { RecommendationStatus } from "../../recommendation/recommendation-history.interface";
-import { DEFAULT_SORT } from "../../shared/records/constants";
-import {
-  ClearSearch,
-  Filter,
-  Paginate,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  Get,
-  GetError,
-  GetSuccess
-} from "./concerns.actions";
 import {
   ConcernsFilterType,
   IConcern,
   IGetConcernsResponse
 } from "../concerns.interfaces";
 import { ConcernsService } from "../services/concerns.service";
+import {
+  ClearSearch,
+  Filter,
+  Get,
+  GetError,
+  GetSuccess,
+  Paginate,
+  ResetFilter,
+  ResetPaginator,
+  ResetSort,
+  Search,
+  Sort
+} from "./concerns.actions";
 
 export class ConcernsStateModel extends RecordsStateModel<
   ConcernsFilterType,
   IConcern[]
-> {}
+> {
+  public filter: ConcernsFilterType;
+}
 
 @State<ConcernsStateModel>({
   name: "concerns",
   defaults: {
+    filter: ConcernsFilterType.OPEN,
     ...defaultRecordsState
   }
 })
@@ -125,5 +129,10 @@ export class ConcernsState extends RecordsState {
   @Action(Filter)
   filter(ctx: StateContext<ConcernsStateModel>, action: Filter) {
     return super.filterHandler(ctx, action);
+  }
+
+  @Action(ResetFilter)
+  resetFilter(ctx: StateContext<ConcernsStateModel>) {
+    return super.resetFilterHandler(ctx, ConcernsFilterType.OPEN);
   }
 }

--- a/src/app/connections/connection-list/connection-list.component.spec.ts
+++ b/src/app/connections/connection-list/connection-list.component.spec.ts
@@ -3,15 +3,12 @@ import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
-import { NgxsModule, Store } from "@ngxs/store";
+import { NgxsModule } from "@ngxs/store";
 import { MaterialModule } from "../../shared/material/material.module";
-import { ConnectionsFilterType } from "../connections.interfaces";
-import { Filter } from "../state/connections.actions";
 import { ConnectionsState } from "../state/connections.state";
 import { ConnectionListComponent } from "./connection-list.component";
 
 describe("ConnectionListComponent", () => {
-  let store: Store;
   let component: ConnectionListComponent;
   let fixture: ComponentFixture<ConnectionListComponent>;
 
@@ -27,7 +24,6 @@ describe("ConnectionListComponent", () => {
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
-    store = TestBed.inject(Store);
   }));
 
   beforeEach(() => {
@@ -38,41 +34,5 @@ describe("ConnectionListComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
-  });
-
-  it("should invoke `setupInitialFilter()` upon ngOnInit", () => {
-    spyOn(component, "setupInitialFilter");
-
-    component.ngOnInit();
-    expect(component.setupInitialFilter).toHaveBeenCalled();
-  });
-
-  it("'setupInitialFilter()' should dispatch 'Add Connection' filter if param value is `Add Connection`", () => {
-    spyOn(store, "dispatch");
-
-    component.params = { filter: ConnectionsFilterType.ADD_CONNECTION };
-    component.setupInitialFilter();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(ConnectionsFilterType.ADD_CONNECTION)
-    );
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new Filter(ConnectionsFilterType.ALL)
-    );
-  });
-
-  it("'setupInitialFilter()' should dispatch 'All' filter if param does not exist", () => {
-    spyOn(store, "dispatch");
-
-    component.setupInitialFilter();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(ConnectionsFilterType.ALL)
-    );
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new Filter(ConnectionsFilterType.ADD_CONNECTION)
-    );
   });
 });

--- a/src/app/connections/connection-list/connection-list.component.ts
+++ b/src/app/connections/connection-list/connection-list.component.ts
@@ -1,15 +1,16 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { generateColumnData } from "../../shared/records/constants";
 import { RecordListComponent } from "../../shared/records/record-list/record-list.component";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { ConnectionsFilterType } from "../connections.interfaces";
 import { COLUMN_DATA } from "../constants";
 import {
+  ClearSearch,
   Filter,
   Get,
   Paginate,
+  ResetFilter,
   ResetPaginator,
   ResetSort,
   Search,
@@ -20,40 +21,27 @@ import {
   selector: "app-connection-list",
   templateUrl: "./connection-list.component.html"
 })
-export class ConnectionListComponent extends RecordListComponent
-  implements OnInit {
+export class ConnectionListComponent extends RecordListComponent {
   public dateColumns = ["gmcSubmissionDate", "endDate", "startDate"];
   public columnData = generateColumnData(COLUMN_DATA);
 
   constructor(
+    protected activatedRoute: ActivatedRoute,
     protected recordsService: RecordsService,
-    protected route: ActivatedRoute,
     protected router: Router,
     protected store: Store
   ) {
-    super(recordsService, route, router, store);
+    super(activatedRoute, recordsService, router, store);
     this.recordsService.setActions(
+      ClearSearch,
+      Filter,
       Get,
-      Sort,
-      ResetSort,
       Paginate,
+      ResetFilter,
       ResetPaginator,
-      Search
+      ResetSort,
+      Search,
+      Sort
     );
-  }
-
-  ngOnInit(): void {
-    this.setupInitialFilter();
-  }
-
-  public setupInitialFilter(): void {
-    if (
-      this.params.filter &&
-      this.params.filter === ConnectionsFilterType.ADD_CONNECTION
-    ) {
-      this.store.dispatch(new Filter(ConnectionsFilterType.ADD_CONNECTION));
-    } else {
-      this.store.dispatch(new Filter(ConnectionsFilterType.ALL));
-    }
   }
 }

--- a/src/app/connections/state/connections.actions.ts
+++ b/src/app/connections/state/connections.actions.ts
@@ -37,6 +37,10 @@ export class Filter extends FilterPayload<ConnectionsFilterType> {
   static readonly type = `${label} Filter`;
 }
 
+export class ResetFilter {
+  static readonly type = `${label} Reset Filter`;
+}
+
 export class Search extends SearchPayload {
   static readonly type = `${label} Search`;
 }

--- a/src/app/connections/state/connections.state.ts
+++ b/src/app/connections/state/connections.state.ts
@@ -26,17 +26,21 @@ import {
   Sort,
   Get,
   GetError,
-  GetSuccess
+  GetSuccess,
+  ResetFilter
 } from "./connections.actions";
 
 export class ConnectionsStateModel extends RecordsStateModel<
   ConnectionsFilterType,
   IConnection[]
-> {}
+> {
+  public filter: ConnectionsFilterType;
+}
 
 @State<ConnectionsStateModel>({
   name: "connections",
   defaults: {
+    filter: ConnectionsFilterType.ALL,
     ...defaultRecordsState
   }
 })
@@ -117,5 +121,10 @@ export class ConnectionsState extends RecordsState {
   @Action(Filter)
   filter(ctx: StateContext<ConnectionsStateModel>, action: Filter) {
     return super.filterHandler(ctx, action);
+  }
+
+  @Action(ResetFilter)
+  resetFilter(ctx: StateContext<ConnectionsStateModel>) {
+    return super.resetFilterHandler(ctx, ConnectionsFilterType.ALL);
   }
 }

--- a/src/app/recommendations/recommendations-filters/recommendations-filters.component.spec.ts
+++ b/src/app/recommendations/recommendations-filters/recommendations-filters.component.spec.ts
@@ -11,7 +11,11 @@ import {
   ClearSearch,
   Get,
   ResetPaginator,
-  ResetSort
+  ResetSort,
+  Paginate,
+  ResetFilter,
+  Search,
+  Sort
 } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
@@ -45,6 +49,17 @@ describe("RecommendationsFiltersComponent", () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     recordsService.stateName = "recommendations";
+    recordsService.setActions(
+      ClearSearch,
+      Filter,
+      Get,
+      Paginate,
+      ResetFilter,
+      ResetPaginator,
+      ResetSort,
+      Search,
+      Sort
+    );
   });
 
   it("should create", () => {
@@ -79,16 +94,10 @@ describe("RecommendationsFiltersComponent", () => {
     expect(component.getRecommendations).toHaveBeenCalled();
   });
 
-  it("`getRecommendations()` should dispatch relevant events", () => {
-    spyOn(store, "dispatch").and.callThrough();
-
+  it("`getRecommendations()` should invoke `recordsService.resetSortPageAndSearch()`", () => {
+    spyOn(recordsService, "resetSortPageAndSearch").and.callThrough();
     component.getRecommendations();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(4);
-    expect(store.dispatch).toHaveBeenCalledWith(new ResetSort());
-    expect(store.dispatch).toHaveBeenCalledWith(new ResetPaginator());
-    expect(store.dispatch).toHaveBeenCalledWith(new ClearSearch());
-    expect(store.dispatch).toHaveBeenCalledWith(new Get());
+    expect(recordsService.resetSortPageAndSearch).toHaveBeenCalled();
   });
 
   it("`getRecommendations()` should invoke `updateRoute()`", () => {

--- a/src/app/recommendations/recommendations-filters/recommendations-filters.component.ts
+++ b/src/app/recommendations/recommendations-filters/recommendations-filters.component.ts
@@ -4,13 +4,7 @@ import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
 import { RecordsService } from "../../shared/records/services/records.service";
 import { RecommendationsFilterType } from "../recommendations.interfaces";
-import {
-  Filter,
-  ClearSearch,
-  Get,
-  ResetPaginator,
-  ResetSort
-} from "../state/recommendations.actions";
+import { Filter } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
 @Component({
@@ -23,7 +17,7 @@ export class RecommendationsFiltersComponent {
     number
   >;
   @Select(RecommendationsState.filter<RecommendationsFilterType>())
-  filter$: Observable<RecommendationsFilterType>;
+  public filter$: Observable<RecommendationsFilterType>;
   public allDoctors: RecommendationsFilterType =
     RecommendationsFilterType.ALL_DOCTORS;
   public underNotice: RecommendationsFilterType =
@@ -42,11 +36,8 @@ export class RecommendationsFiltersComponent {
   }
 
   public getRecommendations(): void {
-    this.store.dispatch(new ResetSort());
-    this.store.dispatch(new ResetPaginator());
-    this.store.dispatch(new ClearSearch());
-    this.store
-      .dispatch(new Get())
+    this.recordsService
+      .resetSortPageAndSearch()
       .pipe(take(1))
       .subscribe(() => this.recordsService.updateRoute());
   }

--- a/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.spec.ts
+++ b/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.spec.ts
@@ -5,9 +5,9 @@ import { MatPaginatorModule, PageEvent } from "@angular/material/paginator";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
-import { of } from "rxjs";
+import { DEFAULT_SORT } from "../../shared/records/constants";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { Get, Paginate } from "../state/recommendations.actions";
+import { Paginate } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
 import { RecommendationsListPaginatorComponent } from "./recommendations-list-paginator.component";
@@ -17,6 +17,12 @@ describe("RecommendationsListPaginatorComponent", () => {
   let component: RecommendationsListPaginatorComponent;
   let fixture: ComponentFixture<RecommendationsListPaginatorComponent>;
   let recordsService: RecordsService;
+  const mockPageEvent: PageEvent = {
+    pageIndex: 2,
+    previousPageIndex: 1,
+    pageSize: 100,
+    length: 20
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -32,6 +38,8 @@ describe("RecommendationsListPaginatorComponent", () => {
     }).compileComponents();
     store = TestBed.inject(Store);
     recordsService = TestBed.inject(RecordsService);
+    recordsService.stateName = "recommendations";
+    store.reset({ recommendations: { sort: DEFAULT_SORT } });
   }));
 
   beforeEach(() => {
@@ -44,23 +52,18 @@ describe("RecommendationsListPaginatorComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should dispatch relevant actions on 'paginate()'", () => {
-    const mockPageEvent: PageEvent = {
-      pageIndex: 2,
-      previousPageIndex: 1,
-      pageSize: 100,
-      length: 20
-    };
-    spyOn(store, "dispatch").and.returnValue(of({}));
-    spyOn(recordsService, "updateRoute");
-
+  it("should dispatch 'paginate()' event", () => {
+    spyOn(store, "dispatch").and.callThrough();
     component.paginate(mockPageEvent);
-
-    expect(store.dispatch).toHaveBeenCalledTimes(2);
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
     expect(store.dispatch).toHaveBeenCalledWith(
       new Paginate(mockPageEvent.pageIndex)
     );
-    expect(store.dispatch).toHaveBeenCalledWith(new Get());
+  });
+
+  it("should invoke 'recordsService.updateRoute()' method", () => {
+    spyOn(recordsService, "updateRoute").and.callThrough();
+    component.paginate(mockPageEvent);
     expect(recordsService.updateRoute).toHaveBeenCalled();
   });
 });

--- a/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.ts
+++ b/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.ts
@@ -4,8 +4,7 @@ import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { RecommendationsService } from "../services/recommendations.service";
-import { Get, Paginate } from "../state/recommendations.actions";
+import { Paginate } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
 @Component({
@@ -14,21 +13,21 @@ import { RecommendationsState } from "../state/recommendations.state";
 })
 export class RecommendationsListPaginatorComponent {
   @Select(RecommendationsState.totalResults<number>())
-  totalResults$: Observable<number>;
-  @Select(RecommendationsState.pageIndex<number>()) pageIndex$: Observable<
-    number
-  >;
+  public totalResults$: Observable<number>;
+  @Select(RecommendationsState.pageIndex<number>())
+  public pageIndex$: Observable<number>;
 
-  constructor(
-    private store: Store,
-    private recommendationsService: RecommendationsService,
-    private recordsService: RecordsService
-  ) {}
+  constructor(private store: Store, private recordsService: RecordsService) {}
 
-  public paginate(event: PageEvent) {
-    this.store.dispatch(new Paginate(event.pageIndex));
+  /**
+   * Leverage angular materials paginator
+   * And dispatch event to store to update pageIndex
+   * Then update route with new query param values
+   * @param event PageEvent
+   */
+  public paginate(event: PageEvent): void {
     this.store
-      .dispatch(new Get())
+      .dispatch(new Paginate(Number(event.pageIndex)))
       .pipe(take(1))
       .subscribe(() => this.recordsService.updateRoute());
   }

--- a/src/app/recommendations/recommendations-list/recommendations-list.component.spec.ts
+++ b/src/app/recommendations/recommendations-list/recommendations-list.component.spec.ts
@@ -3,15 +3,12 @@ import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
-import { NgxsModule, Store } from "@ngxs/store";
+import { NgxsModule } from "@ngxs/store";
 import { MaterialModule } from "../../shared/material/material.module";
-import { Filter } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
-import { RecommendationsFilterType } from "../recommendations.interfaces";
 import { RecommendationsListComponent } from "./recommendations-list.component";
 
 describe("RecommendationsListComponent", () => {
-  let store: Store;
   let component: RecommendationsListComponent;
   let fixture: ComponentFixture<RecommendationsListComponent>;
 
@@ -27,7 +24,6 @@ describe("RecommendationsListComponent", () => {
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
-    store = TestBed.inject(Store);
   }));
 
   beforeEach(() => {
@@ -38,34 +34,5 @@ describe("RecommendationsListComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
-  });
-
-  it("'setupInitialFilter()' should dispatch 'AllDoctorsFilter' if param value is `allDoctors`", () => {
-    spyOn(store, "dispatch");
-
-    component.params = { filter: RecommendationsFilterType.ALL_DOCTORS };
-    component.ngOnInit();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(RecommendationsFilterType.ALL_DOCTORS)
-    );
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new Filter(RecommendationsFilterType.UNDER_NOTICE)
-    );
-  });
-
-  it("'setupInitialFilter()' should dispatch 'UnderNoticeFilter' if param does not exist", () => {
-    spyOn(store, "dispatch");
-
-    component.ngOnInit();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(1);
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(RecommendationsFilterType.UNDER_NOTICE)
-    );
-    expect(store.dispatch).not.toHaveBeenCalledWith(
-      new Filter(RecommendationsFilterType.ALL_DOCTORS)
-    );
   });
 });

--- a/src/app/recommendations/recommendations-list/recommendations-list.component.ts
+++ b/src/app/recommendations/recommendations-list/recommendations-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, ViewEncapsulation } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { generateColumnData } from "../../shared/records/constants";
@@ -6,15 +6,16 @@ import { RecordListComponent } from "../../shared/records/record-list/record-lis
 import { RecordsService } from "../../shared/records/services/records.service";
 import { COLUMN_DATA } from "../constants";
 import {
+  ClearSearch,
   Filter,
   Get,
   Paginate,
+  ResetFilter,
   ResetPaginator,
   ResetSort,
   Search,
   Sort
 } from "../state/recommendations.actions";
-import { RecommendationsFilterType } from "../recommendations.interfaces";
 
 @Component({
   selector: "app-recommendations-list",
@@ -22,8 +23,7 @@ import { RecommendationsFilterType } from "../recommendations.interfaces";
   styleUrls: ["./recommendations-list.component.scss"],
   encapsulation: ViewEncapsulation.None
 })
-export class RecommendationsListComponent extends RecordListComponent
-  implements OnInit {
+export class RecommendationsListComponent extends RecordListComponent {
   public dateColumns = [
     "cctDate",
     "submissionDate",
@@ -33,34 +33,22 @@ export class RecommendationsListComponent extends RecordListComponent
   public columnData = generateColumnData(COLUMN_DATA);
 
   constructor(
+    protected activatedRoute: ActivatedRoute,
     protected recordsService: RecordsService,
-    protected route: ActivatedRoute,
     protected router: Router,
     protected store: Store
   ) {
-    super(recordsService, route, router, store);
+    super(activatedRoute, recordsService, router, store);
     this.recordsService.setActions(
+      ClearSearch,
+      Filter,
       Get,
-      Sort,
-      ResetSort,
       Paginate,
+      ResetFilter,
       ResetPaginator,
-      Search
+      ResetSort,
+      Search,
+      Sort
     );
-  }
-
-  ngOnInit(): void {
-    this.setupInitialFilter();
-  }
-
-  public setupInitialFilter(): void {
-    if (
-      this.params.filter &&
-      this.params.filter === RecommendationsFilterType.ALL_DOCTORS
-    ) {
-      this.store.dispatch(new Filter(RecommendationsFilterType.ALL_DOCTORS));
-    } else {
-      this.store.dispatch(new Filter(RecommendationsFilterType.UNDER_NOTICE));
-    }
   }
 }

--- a/src/app/recommendations/recommendations-search/recommendations-search.component.spec.ts
+++ b/src/app/recommendations/recommendations-search/recommendations-search.component.spec.ts
@@ -5,11 +5,9 @@ import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
-import { of } from "rxjs";
-import { RecordsService } from "../../shared/records/services/records.service";
 import { MaterialModule } from "../../shared/material/material.module";
+import { RecordsService } from "../../shared/records/services/records.service";
 import {
-  Get,
   ResetPaginator,
   ResetSort,
   Search
@@ -109,7 +107,7 @@ describe("RecommendationsSearchComponent", () => {
   });
 
   it("should dispatch relevant actions on valid form submission", () => {
-    spyOn(store, "dispatch").and.returnValue(of({}));
+    spyOn(store, "dispatch").and.callThrough();
     spyOn(recordsService, "updateRoute");
 
     component.params = {
@@ -118,13 +116,12 @@ describe("RecommendationsSearchComponent", () => {
     component.setupForm();
     component.submitForm(component.params.searchQuery);
 
-    expect(store.dispatch).toHaveBeenCalledTimes(4);
+    expect(store.dispatch).toHaveBeenCalledTimes(3);
     expect(store.dispatch).toHaveBeenCalledWith(
       new Search(component.params.searchQuery)
     );
     expect(store.dispatch).toHaveBeenCalledWith(new ResetSort());
     expect(store.dispatch).toHaveBeenCalledWith(new ResetPaginator());
-    expect(store.dispatch).toHaveBeenCalledWith(new Get());
     expect(recordsService.updateRoute).toHaveBeenCalled();
   });
 

--- a/src/app/recommendations/recommendations-search/recommendations-search.component.ts
+++ b/src/app/recommendations/recommendations-search/recommendations-search.component.ts
@@ -6,7 +6,6 @@ import { Observable, Subscription } from "rxjs";
 import { filter, take } from "rxjs/operators";
 import { RecordsService } from "../../shared/records/services/records.service";
 import {
-  Get,
   ResetPaginator,
   ResetSort,
   Search
@@ -76,9 +75,8 @@ export class RecommendationsSearchComponent implements OnInit, OnDestroy {
   public submitForm(searchQuery: string): void {
     this.store.dispatch(new Search(searchQuery));
     this.store.dispatch(new ResetSort());
-    this.store.dispatch(new ResetPaginator());
     this.store
-      .dispatch(new Get())
+      .dispatch(new ResetPaginator())
       .pipe(take(1))
       .subscribe(() => this.recordsService.updateRoute());
   }

--- a/src/app/recommendations/recommendations.module.ts
+++ b/src/app/recommendations/recommendations.module.ts
@@ -24,7 +24,6 @@ import { RecommendationsFiltersComponent } from "./recommendations-filters/recom
     SharedModule,
     RecommendationsRoutingModule,
     NgxsModule.forFeature([RecommendationsState])
-  ],
-  providers: []
+  ]
 })
 export class RecommendationsModule {}

--- a/src/app/recommendations/reset-recommendations-list/reset-recommendations-list.component.spec.ts
+++ b/src/app/recommendations/reset-recommendations-list/reset-recommendations-list.component.spec.ts
@@ -1,29 +1,28 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import { NgxsModule, Store } from "@ngxs/store";
-import { of } from "rxjs";
+import { NgxsModule } from "@ngxs/store";
 import { MaterialModule } from "../../shared/material/material.module";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { RecommendationsFilterType } from "../recommendations.interfaces";
 import {
   ClearSearch,
+  Filter,
   Get,
+  Paginate,
+  ResetFilter,
   ResetPaginator,
   ResetSort,
-  Filter
+  Search,
+  Sort
 } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
 import { ResetRecommendationsListComponent } from "./reset-recommendations-list.component";
 
 describe("ResetRecommendationsListComponent", () => {
-  let store: Store;
   let component: ResetRecommendationsListComponent;
   let fixture: ComponentFixture<ResetRecommendationsListComponent>;
-  let router: Router;
   let recordsService: RecordsService;
 
   beforeEach(async(() => {
@@ -39,8 +38,6 @@ describe("ResetRecommendationsListComponent", () => {
         HttpClientTestingModule
       ]
     }).compileComponents();
-    store = TestBed.inject(Store);
-    router = TestBed.inject(Router);
     recordsService = TestBed.inject(RecordsService);
   }));
 
@@ -49,6 +46,17 @@ describe("ResetRecommendationsListComponent", () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     recordsService.stateName = "recommendations";
+    recordsService.setActions(
+      ClearSearch,
+      Filter,
+      Get,
+      Paginate,
+      ResetFilter,
+      ResetPaginator,
+      ResetSort,
+      Search,
+      Sort
+    );
   });
 
   it("should create", () => {
@@ -61,23 +69,13 @@ describe("ResetRecommendationsListComponent", () => {
     expect(recordsService.resetSearchForm$.next).toHaveBeenCalledWith(true);
   });
 
-  it("should dispatch relevant actions to reset recommendations list", () => {
-    spyOn(store, "dispatch").and.returnValue(of({}));
-    spyOn(router, "navigate");
-
+  it("should invoke `recordsService.resetRecordsState()` to reset recommendations list", () => {
+    spyOn(recordsService, "resetRecordsState").and.callThrough();
     component.resetRecommendationsList();
-
-    expect(store.dispatch).toHaveBeenCalledTimes(5);
-    expect(store.dispatch).toHaveBeenCalledWith(new ResetSort());
-    expect(store.dispatch).toHaveBeenCalledWith(new ResetPaginator());
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(RecommendationsFilterType.UNDER_NOTICE)
-    );
-    expect(store.dispatch).toHaveBeenCalledWith(new ClearSearch());
-    expect(store.dispatch).toHaveBeenCalledWith(new Get());
+    expect(recordsService.resetRecordsState).toHaveBeenCalled();
   });
 
-  it("should invoke `updateRoute()` on resetRecommendationsList()", () => {
+  it("should invoke `recordsService.updateRoute()` on resetRecommendationsList()", () => {
     spyOn(recordsService, "updateRoute");
     component.resetRecommendationsList();
     expect(recordsService.updateRoute).toHaveBeenCalled();

--- a/src/app/recommendations/reset-recommendations-list/reset-recommendations-list.component.ts
+++ b/src/app/recommendations/reset-recommendations-list/reset-recommendations-list.component.ts
@@ -4,14 +4,6 @@ import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { RecommendationsFilterType } from "../recommendations.interfaces";
-import {
-  Filter,
-  ClearSearch,
-  Get,
-  ResetPaginator,
-  ResetSort
-} from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
 @Component({
@@ -19,21 +11,16 @@ import { RecommendationsState } from "../state/recommendations.state";
   templateUrl: "./reset-recommendations-list.component.html"
 })
 export class ResetRecommendationsListComponent {
-  @Select(RecommendationsState.sort<ISort>()) sort$: Observable<ISort>;
-  @Select(RecommendationsState.pageIndex<number>()) pageIndex$: Observable<
-    number
-  >;
+  @Select(RecommendationsState.sort<ISort>()) public sort$: Observable<ISort>;
+  @Select(RecommendationsState.pageIndex<number>())
+  public pageIndex$: Observable<number>;
 
   constructor(private store: Store, private recordsService: RecordsService) {}
 
   public resetRecommendationsList(): void {
     this.recordsService.resetSearchForm$.next(true);
-    this.store.dispatch(new Filter(RecommendationsFilterType.UNDER_NOTICE));
-    this.store.dispatch(new ResetSort());
-    this.store.dispatch(new ResetPaginator());
-    this.store.dispatch(new ClearSearch());
-    this.store
-      .dispatch(new Get())
+    this.recordsService
+      .resetRecordsState()
       .pipe(take(1))
       .subscribe(() => this.recordsService.updateRoute());
   }

--- a/src/app/recommendations/state/recommendations.actions.ts
+++ b/src/app/recommendations/state/recommendations.actions.ts
@@ -37,6 +37,10 @@ export class Filter extends FilterPayload<RecommendationsFilterType> {
   static readonly type = `${label} Filter`;
 }
 
+export class ResetFilter {
+  static readonly type = `${label} Reset Filter`;
+}
+
 export class Search extends SearchPayload {
   static readonly type = `${label} Search`;
 }

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -24,6 +24,7 @@ import {
   GetError,
   GetSuccess,
   Paginate,
+  ResetFilter,
   ResetPaginator,
   ResetSort,
   Search,
@@ -43,6 +44,7 @@ export class RecommendationsStateModel extends RecordsStateModel<
   defaults: {
     countTotal: null,
     countUnderNotice: null,
+    filter: RecommendationsFilterType.UNDER_NOTICE,
     ...defaultRecordsState
   }
 })
@@ -145,5 +147,13 @@ export class RecommendationsState extends RecordsState {
   @Action(Filter)
   filter(ctx: StateContext<RecommendationsStateModel>, action: Filter) {
     return super.filterHandler(ctx, action);
+  }
+
+  @Action(ResetFilter)
+  resetFilter(ctx: StateContext<RecommendationsStateModel>) {
+    return super.resetFilterHandler(
+      ctx,
+      RecommendationsFilterType.UNDER_NOTICE
+    );
   }
 }

--- a/src/app/shared/details/notes-tool-bar/notes-tool-bar.component.spec.ts
+++ b/src/app/shared/details/notes-tool-bar/notes-tool-bar.component.spec.ts
@@ -1,8 +1,11 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { NgxsModule } from "@ngxs/store";
+import { RecommendationNotesState } from "../../../recommendation/state/recommendation-notes.state";
+import { MaterialModule } from "../../material/material.module";
 
 import { NotesToolBarComponent } from "./notes-tool-bar.component";
-import { MaterialModule } from "../../material/material.module";
-import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
 describe("NotesToolBarComponent", () => {
   let component: NotesToolBarComponent;
@@ -10,7 +13,12 @@ describe("NotesToolBarComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MaterialModule, NoopAnimationsModule],
+      imports: [
+        MaterialModule,
+        NoopAnimationsModule,
+        HttpClientTestingModule,
+        NgxsModule.forRoot([RecommendationNotesState])
+      ],
       declarations: [NotesToolBarComponent]
     }).compileComponents();
   }));

--- a/src/app/shared/records/state/records.state.ts
+++ b/src/app/shared/records/state/records.state.ts
@@ -1,6 +1,7 @@
 import { Sort } from "@angular/material/sort";
 import { Sort as ISort } from "@angular/material/sort/sort";
 import { createSelector, StateContext } from "@ngxs/store";
+import { DEFAULT_SORT } from "../constants";
 import { RecordsService } from "../services/records.service";
 
 export class RecordsStateModel<T, F> {
@@ -16,16 +17,12 @@ export class RecordsStateModel<T, F> {
 }
 
 export const defaultRecordsState = {
-  filter: null,
   items: null,
   loading: null,
   pageIndex: 0,
   searchQuery: null,
   totalPages: null,
-  sort: {
-    active: null,
-    direction: null
-  },
+  sort: DEFAULT_SORT,
   totalResults: null
 };
 
@@ -145,5 +142,9 @@ export class RecordsState {
 
   protected filterHandler(ctx: StateContext<any>, action: any) {
     ctx.patchState(action);
+  }
+
+  protected resetFilterHandler(ctx: StateContext<any>, action: any) {
+    ctx.patchState({ filter: action });
   }
 }


### PR DESCRIPTION
NO-TICKET

fix: ensure data is fetched upon browser history navigation

- simplified list components by moving filter actions to base `RecordsComponent`
- added `ResetFilter` action, method for list screens
- set default filter, sort values to list screens state
- created resuable `resetSortPageAndSearch` and `resetRecordsState` methods to bundle common events that need to be dispatched
- moved `Get` action to single place i.e list components
- fixed unit tests