### PR TITLE
get admin users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Pre requisite
 
-After cloning this repo run `npm install` in order to get all dependencies
+- Once you have acquired aws access and credentials you must create `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID`
+  system environment variables in order for the application to read there values.
+- Clone this repo and then run `npm install` in order to get all dependencies.
 
 ## Development server
 
 - Run `npm run start` for a dev server which will consume staging hosted BE endpoints. Navigate to `http://localhost:4200/`.
+
+#### Alternatively
+
 - Run `npm run start:mocky` for a dev server which will consume mocked BE endpoints that are hosted on `https://designer.mocky.io/`.
   This allows rapid FE development without relying on the real BE endpoints or whilst a BE endpoint is being updated. Navigate to `http://localhost:4200/`.
 

--- a/angular.json
+++ b/angular.json
@@ -15,8 +15,11 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-builders/custom-webpack:browser",
           "options": {
+            "customWebpackConfig": {
+              "path": "custom-webpack.config.js"
+            },
             "outputPath": "dist/revalidation",
             "index": "src/index.html",
             "main": "src/main.ts",
@@ -132,7 +135,7 @@
           }
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
             "browserTarget": "revalidation:build",
             "proxyConfig": "proxy.conf.json"

--- a/custom-webpack.config.js
+++ b/custom-webpack.config.js
@@ -1,0 +1,12 @@
+const webpack = require("webpack");
+
+module.exports = {
+  plugins: [
+    new webpack.DefinePlugin({
+      "process.env": {
+        AWS_ACCESS_KEY_ID: JSON.stringify(process.env.AWS_ACCESS_KEY_ID),
+        AWS_SECRET_ACCESS_KEY: JSON.stringify(process.env.AWS_SECRET_ACCESS_KEY)
+      }
+    })
+  ]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,47 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@angular-builders/custom-webpack": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@angular-builders/custom-webpack/-/custom-webpack-9.2.0.tgz",
+      "integrity": "sha512-0ivkjENONFm0oNy6hdCod4YaT4dUk80KuP9+eDliWuZIA70yKQgIYMLul0bz6/i+Cm24PaZ2tq4w7kW7AuSMoA==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/architect": ">=0.900.0 < 0.1000.0",
+        "@angular-devkit/build-angular": ">=0.900.0 < 0.1000.0",
+        "@angular-devkit/core": "^9.0.0",
+        "lodash": "^4.17.10",
+        "ts-node": "^8.5.2",
+        "webpack-merge": "^4.2.1"
+      }
+    },
+    "@angular-builders/dev-server": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@angular-builders/dev-server/-/dev-server-7.3.1.tgz",
+      "integrity": "sha512-rFr0NyFcwTb4RkkboYQN5JeR9ZraOkfUrQYljMSe/O01MM3SJvE8LYJbsyMwGtp71Rc8T6JrpdxaNEeYCV/4PA==",
+      "dev": true
+    },
+    "@angular-devkit/architect": {
+      "version": "0.901.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.901.9.tgz",
+      "integrity": "sha512-Xokyh7bv4qICHpb5Xui1jPTi6ZZvzR5tbTIxT0DFWqw16TEkFgkNubQsW6mFSR3g3CXdySMfOwWExfa/rE1ggA==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "9.1.9",
+        "rxjs": "6.5.4"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+          "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
+      }
+    },
     "@angular-devkit/build-angular": {
       "version": "0.901.9",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.901.9.tgz",
@@ -484,6 +525,63 @@
             "source-map": "0.7.3"
           }
         },
+        "ajv": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        },
+        "rxjs": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+          "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
+      }
+    },
+    "@angular-devkit/core": {
+      "version": "9.1.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-9.1.9.tgz",
+      "integrity": "sha512-SWgBh4an/Vezjw2BZ5S+bKvuK5lH6gOtR8d5YjN9vxpJSZ0GimrGjfnLlWOkwWAsU8jfn4JzofECUHwX/7EW6Q==",
+      "dev": true,
+      "requires": {
+        "ajv": "6.12.0",
+        "fast-json-stable-stringify": "2.1.0",
+        "magic-string": "0.25.7",
+        "rxjs": "6.5.4",
+        "source-map": "0.7.3"
+      },
+      "dependencies": {
         "ajv": {
           "version": "6.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
@@ -1278,6 +1376,67 @@
             "aws-sdk": "2.518.0",
             "url": "^0.11.0",
             "zen-observable": "^0.8.6"
+          },
+          "dependencies": {
+            "aws-sdk": {
+              "version": "2.518.0",
+              "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.518.0.tgz",
+              "integrity": "sha512-hwtKKf93TFyd3qugDW54ElpkUXhPe+ArPIHadre6IAFjCJiv08L8DaZKLRyclDnKfTavKe+f/PhdSEYo1QUHiA==",
+              "dev": true,
+              "requires": {
+                "buffer": "4.9.1",
+                "events": "1.1.1",
+                "ieee754": "1.1.8",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+              },
+              "dependencies": {
+                "buffer": {
+                  "version": "5.6.0",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                  "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+                  "dev": true,
+                  "requires": {
+                    "base64-js": "^1.0.2",
+                    "ieee754": "^1.1.4"
+                  }
+                },
+                "url": {
+                  "version": "0.10.3",
+                  "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+                  "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+                  "dev": true,
+                  "requires": {
+                    "punycode": "1.3.2",
+                    "querystring": "0.2.0"
+                  }
+                }
+              }
+            },
+            "buffer": {
+              "version": "5.6.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+              "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+              "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            },
+            "ieee754": {
+              "version": "1.1.8",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+              "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            }
           }
         },
         "amazon-cognito-identity-js": {
@@ -1311,6 +1470,24 @@
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
           }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+          "dev": true
         }
       }
     },
@@ -6704,14 +6881,13 @@
       }
     },
     "aws-sdk": {
-      "version": "2.518.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.518.0.tgz",
-      "integrity": "sha512-hwtKKf93TFyd3qugDW54ElpkUXhPe+ArPIHadre6IAFjCJiv08L8DaZKLRyclDnKfTavKe+f/PhdSEYo1QUHiA==",
-      "dev": true,
+      "version": "2.706.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.706.0.tgz",
+      "integrity": "sha512-7GT+yrB5Wb/zOReRdv/Pzkb2Qt+hz6B/8FGMVaoysX3NryHvQUdz7EQWi5yhg9CxOjKxdw5lFwYSs69YlSp1KA==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.13",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
@@ -6724,7 +6900,6 @@
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
           "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -6733,32 +6908,22 @@
         "events": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-          "dev": true
-        },
-        "ieee754": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-          "dev": true
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         },
         "sax": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-          "dev": true
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "url": {
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-          "dev": true,
           "requires": {
             "punycode": "1.3.2",
             "querystring": "0.2.0"
@@ -6767,8 +6932,7 @@
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -12720,8 +12884,7 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
-      "dev": true
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-cookie": {
       "version": "2.2.1",
@@ -18736,8 +18899,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "2.7.0",
@@ -22630,7 +22792,6 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -22639,8 +22800,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@ngxs/store": "^3.6.2",
     "angulartics2": "^9.1.0",
     "aws-amplify": "^3.0.18",
+    "aws-sdk": "^2.706.0",
     "browserslist": "^4.12.1",
     "caniuse-lite": "^1.0.30001088",
     "nhsuk-frontend": "^3.1.0",
@@ -48,9 +49,11 @@
     "zone.js": "~0.10.3"
   },
   "devDependencies": {
-    "@angular/cli": "^9.1.9",
+    "@angular-builders/custom-webpack": "^9.2.0",
+    "@angular-builders/dev-server": "^7.3.1",
     "@angular-devkit/build-angular": "^0.901.9",
     "@angular-devkit/build-ng-packagr": "^0.901.9",
+    "@angular/cli": "^9.1.9",
     "@angular/compiler-cli": "~9.1.11",
     "@angular/language-service": "^9.1.11",
     "@aws-amplify/pubsub": "^2.1.9",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,26 +1,46 @@
-import { TestBed, async } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { TestBed, async, ComponentFixture } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule, Store } from "@ngxs/store";
 import { AppComponent } from "./app.component";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { AdminsState } from "./shared/admins/state/admins.state";
 import { MainNavigationModule } from "./shared/main-navigation/main-navigation.module";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
 describe("AppComponent", () => {
+  let store: Store;
+  let component: AppComponent;
+  let fixture: ComponentFixture<AppComponent>;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
         MainNavigationModule,
-        NoopAnimationsModule // no operation mock for replacing BrowserAnimationsModule in tests
+        HttpClientTestingModule,
+        NoopAnimationsModule, // no operation mock for replacing BrowserAnimationsModule in tests
+        NgxsModule.forRoot([AdminsState])
       ],
       declarations: [AppComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
+    store = TestBed.inject(Store);
   }));
 
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
   it("should create the app", () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(component).toBeTruthy();
+  });
+
+  it("should create the app", () => {
+    spyOn(store, "dispatch").and.callThrough();
+    component.ngOnInit();
+    expect(store.dispatch).toHaveBeenCalled();
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,15 @@
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
+import { Store } from "@ngxs/store";
+import { Get } from "./shared/admins/state/admins.actions";
 
 @Component({
   selector: "app-root",
   templateUrl: "./app.component.html"
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  constructor(private store: Store) {}
+
+  ngOnInit(): void {
+    this.store.dispatch(new Get());
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,6 @@ export class AppComponent implements OnInit {
   constructor(private store: Store) {}
 
   ngOnInit(): void {
-    this.store.dispatch(new Get());
+    this.store.dispatch(new Get("site-admin-group"));
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { AnalyticsModule, HotJarModule } from "hee-shared";
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
 import { AWS_CONFIG } from "./core/auth/aws-config";
+import { AdminsState } from "./shared/admins/state/admins.state";
 import { MainNavigationModule } from "./shared/main-navigation/main-navigation.module";
 import { MaterialModule } from "./shared/material/material.module";
 import { SharedModule } from "./shared/shared.module";
@@ -42,7 +43,9 @@ Amplify.configure(AWS_CONFIG);
       hotJarSv: environment.hotJarSv,
       enabled: environment.production
     }),
-    NgxsModule.forRoot([], { developmentMode: !environment.production }),
+    NgxsModule.forRoot([AdminsState], {
+      developmentMode: !environment.production
+    }),
     MainNavigationModule
   ],
   providers: [

--- a/src/app/shared/admins/services/admins.service.spec.ts
+++ b/src/app/shared/admins/services/admins.service.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from "@angular/core/testing";
+import { NgxsModule } from "@ngxs/store";
+import { ListUsersResponse } from "aws-sdk/clients/cognitoidentityserviceprovider";
+import { MaterialModule } from "../../material/material.module";
+import { AdminsState } from "../state/admins.state";
+
+import { AdminsService } from "./admins.service";
+
+export const mockAdminsResponse: ListUsersResponse = {
+  Users: [
+    {
+      Attributes: [
+        { Name: "sub", Value: "2c6df0c3-ded9-4669-9e89-ac719ad84493" },
+        { Name: "email", Value: "siteadmin@hee.nhs.uk" }
+      ],
+      Enabled: true,
+      UserCreateDate: new Date(),
+      UserLastModifiedDate: new Date(),
+      UserStatus: "CONFIRMED",
+      Username: "siteadmin@hee.nhs.uk"
+    }
+  ]
+};
+
+describe("AdminsService", () => {
+  let service: AdminsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [MaterialModule, NgxsModule.forRoot([AdminsState])]
+    });
+    service = TestBed.inject(AdminsService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/admins/services/admins.service.ts
+++ b/src/app/shared/admins/services/admins.service.ts
@@ -19,10 +19,10 @@ import { GetError, GetSuccess } from "../state/admins.actions";
 export class AdminsService {
   constructor(private store: Store, private snackBar: MatSnackBar) {}
 
-  public get listUsersInGroupRequest(): ListUsersInGroupRequest {
+  public listUsersInGroupRequest(groupName: string): ListUsersInGroupRequest {
     return {
       UserPoolId: environment.awsConfig.userPoolId,
-      GroupName: "site-admin-group"
+      GroupName: groupName
     };
   }
 
@@ -36,9 +36,9 @@ export class AdminsService {
     });
   }
 
-  public getAdminUsers(): void {
+  public getAdminUsers(groupName: string): void {
     this.awsCognito.listUsersInGroup(
-      this.listUsersInGroupRequest,
+      this.listUsersInGroupRequest(groupName),
       (error: AWSError, response: ListUsersResponse) => {
         if (error) {
           const errorMsg = `Error: ${error.message}`;

--- a/src/app/shared/admins/services/admins.service.ts
+++ b/src/app/shared/admins/services/admins.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from "@angular/core";
+import {
+  MatSnackBar,
+  MatSnackBarRef,
+  SimpleSnackBar
+} from "@angular/material/snack-bar";
+import { environment } from "@environment";
+import { Store } from "@ngxs/store";
+import { AWSError, CognitoIdentityServiceProvider } from "aws-sdk";
+import {
+  ListUsersInGroupRequest,
+  ListUsersResponse
+} from "aws-sdk/clients/cognitoidentityserviceprovider";
+import { GetError, GetSuccess } from "../state/admins.actions";
+
+@Injectable({
+  providedIn: "root"
+})
+export class AdminsService {
+  constructor(private store: Store, private snackBar: MatSnackBar) {}
+
+  public get listUsersInGroupRequest(): ListUsersInGroupRequest {
+    return {
+      UserPoolId: environment.awsConfig.userPoolId,
+      GroupName: "site-admin-group"
+    };
+  }
+
+  public get awsCognito(): any {
+    return new CognitoIdentityServiceProvider({
+      region: environment.awsConfig.region,
+      credentials: {
+        accessKeyId: environment.awsConfig.accessKeyId,
+        secretAccessKey: environment.awsConfig.secretAccessKey
+      }
+    });
+  }
+
+  public getAdminUsers(): void {
+    this.awsCognito.listUsersInGroup(
+      this.listUsersInGroupRequest,
+      (error: AWSError, response: ListUsersResponse) => {
+        if (error) {
+          const errorMsg = `Error: ${error.message}`;
+          this.openSnackBar(errorMsg);
+          this.store.dispatch(new GetError(errorMsg));
+        } else {
+          this.store.dispatch(new GetSuccess(response.Users));
+        }
+      }
+    );
+  }
+
+  private openSnackBar(message: string): MatSnackBarRef<SimpleSnackBar> {
+    return this.snackBar.open(message, "Close", {
+      duration: 5000
+    });
+  }
+}

--- a/src/app/shared/admins/state/admins.actions.ts
+++ b/src/app/shared/admins/state/admins.actions.ts
@@ -4,6 +4,7 @@ const label = `[Admins]`;
 
 export class Get {
   static readonly type = `${label} Get`;
+  constructor(public groupName: string) {}
 }
 
 export class GetSuccess {

--- a/src/app/shared/admins/state/admins.actions.ts
+++ b/src/app/shared/admins/state/admins.actions.ts
@@ -1,0 +1,17 @@
+import { UserType } from "aws-sdk/clients/cognitoidentityserviceprovider";
+
+const label = `[Admins]`;
+
+export class Get {
+  static readonly type = `${label} Get`;
+}
+
+export class GetSuccess {
+  static readonly type = `${label} Get Success`;
+  constructor(public response: UserType[]) {}
+}
+
+export class GetError {
+  static readonly type = `${label} Get Error`;
+  constructor(public error: string) {}
+}

--- a/src/app/shared/admins/state/admins.state.spec.ts
+++ b/src/app/shared/admins/state/admins.state.spec.ts
@@ -34,7 +34,7 @@ describe("Admins state", () => {
   it("should dispatch 'Get' and invoke `adminsService.getAdminUsers()`", () => {
     spyOn(adminsService, "getAdminUsers");
     store
-      .dispatch(new Get())
+      .dispatch(new Get("site-admin-group"))
       .subscribe(() => expect(adminsService.getAdminUsers).toHaveBeenCalled());
   });
 

--- a/src/app/shared/admins/state/admins.state.spec.ts
+++ b/src/app/shared/admins/state/admins.state.spec.ts
@@ -1,0 +1,54 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { async, TestBed } from "@angular/core/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { MaterialModule } from "../../material/material.module";
+import { AdminsService } from "../services/admins.service";
+import { mockAdminsResponse } from "../services/admins.service.spec";
+import { Get, GetError, GetSuccess } from "./admins.actions";
+import { AdminsState } from "./admins.state";
+
+describe("Admins state", () => {
+  let store: Store;
+  let adminsService: AdminsService;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MaterialModule,
+        NgxsModule.forRoot([AdminsState]),
+        HttpClientTestingModule
+      ],
+      providers: [AdminsService],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+    store = TestBed.inject(Store);
+    adminsService = TestBed.inject(AdminsService);
+  }));
+
+  it("should select 'AdminsState'", () => {
+    const state = store.selectSnapshot(AdminsState);
+    expect(state).toBeTruthy();
+  });
+
+  it("should dispatch 'Get' and invoke `adminsService.getAdminUsers()`", () => {
+    spyOn(adminsService, "getAdminUsers");
+    store
+      .dispatch(new Get())
+      .subscribe(() => expect(adminsService.getAdminUsers).toHaveBeenCalled());
+  });
+
+  it("should dispatch 'GetSuccess' and select 'items' slice", () => {
+    store.dispatch(new GetSuccess(mockAdminsResponse.Users));
+    const items = store.selectSnapshot(AdminsState.items);
+    expect(items.length).toEqual(1);
+    expect(items[0].Username).toEqual("siteadmin@hee.nhs.uk");
+  });
+
+  it("should dispatch 'GetError' and select 'error' slice", () => {
+    const errorMsg = `Error: Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_LOAD_CONFIG=1`;
+    store.dispatch(new GetError(errorMsg));
+    const error = store.selectSnapshot(AdminsState.error);
+    expect(error).toEqual(errorMsg);
+  });
+});

--- a/src/app/shared/admins/state/admins.state.ts
+++ b/src/app/shared/admins/state/admins.state.ts
@@ -30,8 +30,8 @@ export class AdminsState {
   }
 
   @Action(Get)
-  get() {
-    return this.adminsService.getAdminUsers();
+  get(action: Get) {
+    return this.adminsService.getAdminUsers(action.groupName);
   }
 
   @Action(GetSuccess)

--- a/src/app/shared/admins/state/admins.state.ts
+++ b/src/app/shared/admins/state/admins.state.ts
@@ -1,0 +1,50 @@
+import { Injectable } from "@angular/core";
+import { Action, Selector, State, StateContext } from "@ngxs/store";
+import { UserType } from "aws-sdk/clients/cognitoidentityserviceprovider";
+import { AdminsService } from "../services/admins.service";
+import { Get, GetError, GetSuccess } from "./admins.actions";
+
+export class AdminsStateModel {
+  public error?: string;
+  public items: UserType[];
+}
+
+@State<AdminsStateModel>({
+  name: "admins",
+  defaults: {
+    items: null
+  }
+})
+@Injectable()
+export class AdminsState {
+  constructor(protected adminsService: AdminsService) {}
+
+  @Selector()
+  public static items(state: AdminsStateModel) {
+    return state.items;
+  }
+
+  @Selector()
+  public static error(state: AdminsStateModel) {
+    return state.error;
+  }
+
+  @Action(Get)
+  get() {
+    return this.adminsService.getAdminUsers();
+  }
+
+  @Action(GetSuccess)
+  getSuccess(ctx: StateContext<AdminsStateModel>, action: GetSuccess) {
+    return ctx.patchState({
+      items: action.response
+    });
+  }
+
+  @Action(GetError)
+  getError(ctx: StateContext<AdminsStateModel>, action: GetError) {
+    return ctx.patchState({
+      error: action.error
+    });
+  }
+}

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -14,6 +14,7 @@ export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
 };
 
 export const AWS_CONFIG: IEnvironment["awsConfig"] = {
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   authenticationFlowType: "USER_PASSWORD_AUTH",
   domain: "stage-auth.tis.nhs.uk",
   mandatorySignIn: null,
@@ -22,6 +23,7 @@ export const AWS_CONFIG: IEnvironment["awsConfig"] = {
   region: "eu-west-2",
   responseType: "token",
   scope: ["openid", "aws.cognito.signin.user.admin"],
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   userPoolId: "eu-west-2_hkwYIoHu3",
   userPoolWebClientId: "3adscm2usl3lop510nfijpr12f"
 };

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -33,5 +33,7 @@ export abstract class IEnvironment {
     readonly redirectSignOut: string;
     readonly responseType: string;
     readonly mandatorySignIn: boolean;
+    readonly accessKeyId: string;
+    readonly secretAccessKey: string;
   };
 }


### PR DESCRIPTION
TISNEW-4829

feat: get admin users list

- fetch admins list via aws cognito sdk api and store on `admins` state slice
- invoke `Get` admins action from app component as the admins list is to be used across all summary & details pages
- extend default angular webpack config so that environment variables can be consumed for AWS `secretAccessKey` & `AWS_ACCESS_KEY_ID`
- updated `README.md`

