### PR TITLE
feat: enable allocate admin mode

### DIFF
--- a/src/app/concerns/concerns.resolver.ts
+++ b/src/app/concerns/concerns.resolver.ts
@@ -13,7 +13,8 @@ import {
   ResetPaginator,
   ResetSort,
   Search,
-  Sort
+  Sort,
+  EnableAllocateAdmin
 } from "./state/concerns.actions";
 
 @Injectable()
@@ -33,7 +34,8 @@ export class ConcernsResolver extends RecordsResolver implements Resolve<any> {
       ResetPaginator,
       ResetSort,
       Search,
-      Sort
+      Sort,
+      EnableAllocateAdmin
     );
   }
 

--- a/src/app/concerns/state/concerns.actions.ts
+++ b/src/app/concerns/state/concerns.actions.ts
@@ -1,4 +1,5 @@
 import {
+  EnableAllocateAdminPayload,
   FilterPayload,
   GetErrorPayload,
   GetSuccessPayload,
@@ -55,4 +56,8 @@ export class Paginate extends PaginatePayload {
 
 export class ResetPaginator {
   static readonly type = `${label} Reset Paginator`;
+}
+
+export class EnableAllocateAdmin extends EnableAllocateAdminPayload {
+  static readonly type = `${label} Enable Allocate Admin`;
 }

--- a/src/app/concerns/state/concerns.state.ts
+++ b/src/app/concerns/state/concerns.state.ts
@@ -19,6 +19,7 @@ import {
 import { ConcernsService } from "../services/concerns.service";
 import {
   ClearSearch,
+  EnableAllocateAdmin,
   Filter,
   Get,
   GetError,
@@ -134,5 +135,13 @@ export class ConcernsState extends RecordsState {
   @Action(ResetFilter)
   resetFilter(ctx: StateContext<ConcernsStateModel>) {
     return super.resetFilterHandler(ctx, ConcernsFilterType.OPEN);
+  }
+
+  @Action(EnableAllocateAdmin)
+  enableAllocateAdmin(
+    ctx: StateContext<ConcernsStateModel>,
+    action: EnableAllocateAdmin
+  ) {
+    return super.enableAllocateAdminHandler(ctx, action.enableAllocateAdmin);
   }
 }

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -13,7 +13,8 @@ import {
   ResetPaginator,
   ResetSort,
   Search,
-  Sort
+  Sort,
+  EnableAllocateAdmin
 } from "./state/connections.actions";
 
 @Injectable()
@@ -34,7 +35,8 @@ export class ConnectionsResolver extends RecordsResolver
       ResetPaginator,
       ResetSort,
       Search,
-      Sort
+      Sort,
+      EnableAllocateAdmin
     );
   }
 

--- a/src/app/connections/state/connections.actions.ts
+++ b/src/app/connections/state/connections.actions.ts
@@ -1,4 +1,5 @@
 import {
+  EnableAllocateAdminPayload,
   FilterPayload,
   GetErrorPayload,
   GetSuccessPayload,
@@ -55,4 +56,8 @@ export class Paginate extends PaginatePayload {
 
 export class ResetPaginator {
   static readonly type = `${label} Reset Paginator`;
+}
+
+export class EnableAllocateAdmin extends EnableAllocateAdminPayload {
+  static readonly type = `${label} Enable Allocate Admin`;
 }

--- a/src/app/connections/state/connections.state.ts
+++ b/src/app/connections/state/connections.state.ts
@@ -18,6 +18,7 @@ import { DEFAULT_SORT } from "../../shared/records/constants";
 import { ConnectionsService } from "../services/connections.service";
 import {
   ClearSearch,
+  EnableAllocateAdmin,
   Filter,
   Paginate,
   ResetPaginator,
@@ -126,5 +127,13 @@ export class ConnectionsState extends RecordsState {
   @Action(ResetFilter)
   resetFilter(ctx: StateContext<ConnectionsStateModel>) {
     return super.resetFilterHandler(ctx, ConnectionsFilterType.ALL);
+  }
+
+  @Action(EnableAllocateAdmin)
+  enableAllocateAdmin(
+    ctx: StateContext<ConnectionsStateModel>,
+    action: EnableAllocateAdmin
+  ) {
+    return super.enableAllocateAdminHandler(ctx, action.enableAllocateAdmin);
   }
 }

--- a/src/app/recommendations/recommendations-filters/recommendations-filters.component.html
+++ b/src/app/recommendations/recommendations-filters/recommendations-filters.component.html
@@ -2,7 +2,8 @@
   *ngIf="{
     countTotal: countTotal$ | async,
     countUnderNotice: countUnderNotice$ | async,
-    filter: filter$ | async
+    filter: filter$ | async,
+    enableAllocateAdmin: enableAllocateAdmin$ | async
   } as data"
 >
   <nav mat-tab-nav-bar>
@@ -11,6 +12,7 @@
       [active]="data.filter === allDoctors"
       aria-label="Filter all doctors"
       (click)="filterByAllDoctors()"
+      [disabled]="data.enableAllocateAdmin"
     >
       ALL DOCTORS - {{ data.countTotal }}
     </a>
@@ -19,6 +21,7 @@
       [active]="data.filter === underNotice"
       aria-label="Filter under notice"
       (click)="filterByUnderNotice()"
+      [disabled]="data.enableAllocateAdmin"
     >
       UNDER NOTICE - {{ data.countUnderNotice }}
     </a>

--- a/src/app/recommendations/recommendations-filters/recommendations-filters.component.spec.ts
+++ b/src/app/recommendations/recommendations-filters/recommendations-filters.component.spec.ts
@@ -15,7 +15,8 @@ import {
   Paginate,
   ResetFilter,
   Search,
-  Sort
+  Sort,
+  EnableAllocateAdmin
 } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
@@ -58,7 +59,8 @@ describe("RecommendationsFiltersComponent", () => {
       ResetPaginator,
       ResetSort,
       Search,
-      Sort
+      Sort,
+      EnableAllocateAdmin
     );
   });
 

--- a/src/app/recommendations/recommendations-filters/recommendations-filters.component.ts
+++ b/src/app/recommendations/recommendations-filters/recommendations-filters.component.ts
@@ -18,6 +18,9 @@ export class RecommendationsFiltersComponent {
   >;
   @Select(RecommendationsState.filter<RecommendationsFilterType>())
   public filter$: Observable<RecommendationsFilterType>;
+  public enableAllocateAdmin$: Observable<boolean> = this.store.select(
+    (state) => state[this.recordsService.stateName].enableAllocateAdmin
+  );
   public allDoctors: RecommendationsFilterType =
     RecommendationsFilterType.ALL_DOCTORS;
   public underNotice: RecommendationsFilterType =

--- a/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.html
+++ b/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.html
@@ -5,5 +5,6 @@
   [pageSize]="20"
   [hidePageSize]="true"
   (page)="paginate($event)"
+  [disabled]="enableAllocateAdmin$ | async"
 >
 </mat-paginator>

--- a/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.ts
+++ b/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.ts
@@ -16,6 +16,9 @@ export class RecommendationsListPaginatorComponent {
   public totalResults$: Observable<number>;
   @Select(RecommendationsState.pageIndex<number>())
   public pageIndex$: Observable<number>;
+  public enableAllocateAdmin$: Observable<boolean> = this.store.select(
+    (state) => state[this.recordsService.stateName].enableAllocateAdmin
+  );
 
   constructor(private store: Store, private recordsService: RecordsService) {}
 

--- a/src/app/recommendations/recommendations.component.html
+++ b/src/app/recommendations/recommendations.component.html
@@ -8,3 +8,4 @@
 </div>
 
 <app-recommendations-list></app-recommendations-list>
+<app-allocate-admin-actions></app-allocate-admin-actions>

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -6,6 +6,7 @@ import { RecordsResolver } from "../shared/records/records.resolver";
 import { RecordsService } from "../shared/records/services/records.service";
 import {
   ClearSearch,
+  EnableAllocateAdmin,
   Filter,
   Get,
   Paginate,
@@ -34,7 +35,8 @@ export class RecommendationsResolver extends RecordsResolver
       ResetPaginator,
       ResetSort,
       Search,
-      Sort
+      Sort,
+      EnableAllocateAdmin
     );
   }
 

--- a/src/app/recommendations/state/recommendations.actions.ts
+++ b/src/app/recommendations/state/recommendations.actions.ts
@@ -1,4 +1,5 @@
 import {
+  EnableAllocateAdminPayload,
   FilterPayload,
   GetErrorPayload,
   GetSuccessPayload,
@@ -55,4 +56,8 @@ export class Paginate extends PaginatePayload {
 
 export class ResetPaginator {
   static readonly type = `${label} Reset Paginator`;
+}
+
+export class EnableAllocateAdmin extends EnableAllocateAdminPayload {
+  static readonly type = `${label} Enable Allocate Admin`;
 }

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -19,6 +19,7 @@ import {
 } from "../recommendations.interfaces";
 import {
   ClearSearch,
+  EnableAllocateAdmin,
   Filter,
   Get,
   GetError,
@@ -155,5 +156,13 @@ export class RecommendationsState extends RecordsState {
       ctx,
       RecommendationsFilterType.UNDER_NOTICE
     );
+  }
+
+  @Action(EnableAllocateAdmin)
+  enableAllocateAdmin(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: EnableAllocateAdmin
+  ) {
+    return super.enableAllocateAdminHandler(ctx, action.enableAllocateAdmin);
   }
 }

--- a/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.html
+++ b/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.html
@@ -1,0 +1,8 @@
+<div class="pt-30 pl-15" *ngIf="enableAllocateAdmin$ | async">
+  <button mat-button mat-raised-button class="mr-10" (click)="cancel()">
+    Cancel
+  </button>
+  <button mat-button mat-raised-button color="primary" (click)="save()">
+    Save
+  </button>
+</div>

--- a/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.spec.ts
+++ b/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.spec.ts
@@ -1,4 +1,8 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule } from "@ngxs/store";
+import { RecommendationsState } from "../../../recommendations/state/recommendations.state";
 
 import { AllocateAdminActionsComponent } from "./allocate-admin-actions.component";
 
@@ -8,7 +12,12 @@ describe("AllocateAdminActionsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [AllocateAdminActionsComponent]
+      declarations: [AllocateAdminActionsComponent],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        NgxsModule.forRoot([RecommendationsState])
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.spec.ts
+++ b/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { AllocateAdminActionsComponent } from "./allocate-admin-actions.component";
+
+describe("AllocateAdminActionsComponent", () => {
+  let component: AllocateAdminActionsComponent;
+  let fixture: ComponentFixture<AllocateAdminActionsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AllocateAdminActionsComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AllocateAdminActionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.ts
+++ b/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.ts
@@ -1,0 +1,26 @@
+import { Component } from "@angular/core";
+import { Store } from "@ngxs/store";
+import { Observable } from "rxjs";
+import { RecordsService } from "../services/records.service";
+
+@Component({
+  selector: "app-allocate-admin-actions",
+  templateUrl: "./allocate-admin-actions.component.html"
+})
+export class AllocateAdminActionsComponent {
+  public enableAllocateAdmin$: Observable<boolean> = this.store.select(
+    (state) => state[this.recordsService.stateName].enableAllocateAdmin
+  );
+
+  constructor(private store: Store, private recordsService: RecordsService) {}
+
+  // TODO add logic
+  public cancel(): void {
+    this.recordsService.enableAllocateAdmin(false);
+  }
+
+  // TODO add logic
+  public save(): void {
+    this.recordsService.enableAllocateAdmin(false);
+  }
+}

--- a/src/app/shared/records/allocate-admin-btn/allocate-admin-btn.component.html
+++ b/src/app/shared/records/allocate-admin-btn/allocate-admin-btn.component.html
@@ -1,0 +1,7 @@
+<button
+  mat-menu-item
+  (click)="enableAllocateAdmin()"
+  aria-label="Allocate admin"
+>
+  Allocate admin
+</button>

--- a/src/app/shared/records/allocate-admin-btn/allocate-admin-btn.component.spec.ts
+++ b/src/app/shared/records/allocate-admin-btn/allocate-admin-btn.component.spec.ts
@@ -1,0 +1,33 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule } from "@ngxs/store";
+import { RecommendationsState } from "../../../recommendations/state/recommendations.state";
+
+import { AllocateAdminBtnComponent } from "./allocate-admin-btn.component";
+
+describe("AllocateAdminBtnComponent", () => {
+  let component: AllocateAdminBtnComponent;
+  let fixture: ComponentFixture<AllocateAdminBtnComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AllocateAdminBtnComponent],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        NgxsModule.forRoot([RecommendationsState])
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AllocateAdminBtnComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/records/allocate-admin-btn/allocate-admin-btn.component.ts
+++ b/src/app/shared/records/allocate-admin-btn/allocate-admin-btn.component.ts
@@ -1,0 +1,14 @@
+import { Component } from "@angular/core";
+import { RecordsService } from "../services/records.service";
+
+@Component({
+  selector: "app-allocate-admin-btn",
+  templateUrl: "./allocate-admin-btn.component.html"
+})
+export class AllocateAdminBtnComponent {
+  constructor(private recordsService: RecordsService) {}
+
+  public enableAllocateAdmin(): void {
+    this.recordsService.enableAllocateAdmin(true);
+  }
+}

--- a/src/app/shared/records/record-list/record-list.component.html
+++ b/src/app/shared/records/record-list/record-list.component.html
@@ -29,7 +29,8 @@
             mat-table
             *ngIf="{
               sort: sort$ | async,
-              items: items$ | async
+              items: items$ | async,
+              enableAllocateAdmin: enableAllocateAdmin$ | async
             } as data"
             class="w-100"
             [dataSource]="data.items"
@@ -52,6 +53,7 @@
                   *matHeaderCellDef
                   [mat-sort-header]="i.name"
                   scope="col"
+                  [disabled]="data.enableAllocateAdmin"
                 >
                   {{ i.label }}
                 </th>

--- a/src/app/shared/records/record-list/record-list.component.spec.ts
+++ b/src/app/shared/records/record-list/record-list.component.spec.ts
@@ -11,6 +11,7 @@ import { IRecommendation } from "../../../recommendations/recommendations.interf
 import { mockRecommendationsResponse } from "../../../recommendations/services/recommendations.service.spec";
 import {
   ClearSearch,
+  EnableAllocateAdmin,
   Filter,
   Get,
   Paginate,
@@ -62,7 +63,8 @@ describe("RecordListComponent", () => {
       ResetPaginator,
       ResetSort,
       Search,
-      Sort
+      Sort,
+      EnableAllocateAdmin
     );
     fixture.detectChanges();
   });

--- a/src/app/shared/records/record-list/record-list.component.ts
+++ b/src/app/shared/records/record-list/record-list.component.ts
@@ -35,6 +35,9 @@ export class RecordListComponent {
   public error$: Observable<string> = this.store.select(
     (state) => state[this.recordsService.stateName].error
   );
+  public enableAllocateAdmin$: Observable<boolean> = this.store.select(
+    (state) => state[this.recordsService.stateName].enableAllocateAdmin
+  );
 
   constructor(
     protected activatedRoute: ActivatedRoute,

--- a/src/app/shared/records/record-search/record-search.component.html
+++ b/src/app/shared/records/record-search/record-search.component.html
@@ -9,9 +9,7 @@
     </button>
     <mat-menu #menu="matMenu">
       <app-reset-record-list></app-reset-record-list>
-      <button mat-menu-item disabled>
-        Allocate admin
-      </button>
+      <app-allocate-admin-btn></app-allocate-admin-btn>
     </mat-menu>
   </div>
 

--- a/src/app/shared/records/record-search/record-search.component.spec.ts
+++ b/src/app/shared/records/record-search/record-search.component.spec.ts
@@ -9,6 +9,7 @@ import { MaterialModule } from "../../material/material.module";
 import { RecordsService } from "../services/records.service";
 import {
   ClearSearch,
+  EnableAllocateAdmin,
   Filter,
   Get,
   Paginate,
@@ -57,7 +58,8 @@ describe("RecordSearchComponent", () => {
       ResetPaginator,
       ResetSort,
       Search,
-      Sort
+      Sort,
+      EnableAllocateAdmin
     );
     fixture.detectChanges();
   });
@@ -73,9 +75,9 @@ describe("RecordSearchComponent", () => {
   });
 
   it("should invoke setupSubscription() on `ngOnInit()`", () => {
-    spyOn(component, "setupSubscription");
+    spyOn(component, "listenToClearAllEvent");
     component.ngOnInit();
-    expect(component.setupSubscription).toHaveBeenCalled();
+    expect(component.listenToClearAllEvent).toHaveBeenCalled();
   });
 
   it("should create form, form control with default value", () => {
@@ -92,7 +94,7 @@ describe("RecordSearchComponent", () => {
     spyOn(component.ngForm, "resetForm");
 
     recordsService.resetSearchForm$.next(true);
-    component.setupSubscription();
+    component.listenToClearAllEvent();
 
     expect(component.ngForm.resetForm).toHaveBeenCalled();
   });

--- a/src/app/shared/records/record-search/record-search.component.ts
+++ b/src/app/shared/records/record-search/record-search.component.ts
@@ -15,6 +15,9 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public searchQuery$: Observable<string> = this.store.select(
     (state) => state[this.recordsService.stateName].searchQuery
   );
+  public enableAllocateAdmin$: Observable<boolean> = this.store.select(
+    (state) => state[this.recordsService.stateName].enableAllocateAdmin
+  );
 
   public form: FormGroup;
   public subscriptions: Subscription = new Subscription();
@@ -29,7 +32,8 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.setupForm();
-    this.setupSubscription();
+    this.listenToClearAllEvent();
+    this.listenToAllocateAdminsEvent();
   }
 
   public setupForm(): void {
@@ -46,11 +50,25 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
    * so therefore form must be reset by resetForm() instead of FormGroup's reset()
    * https://github.com/angular/components/issues/4190
    */
-  public setupSubscription(): void {
+  public listenToClearAllEvent(): void {
     this.subscriptions.add(
       this.recordsService.resetSearchForm$
         .pipe(filter(Boolean))
         .subscribe(() => this.ngForm.resetForm())
+    );
+  }
+
+  public listenToAllocateAdminsEvent(): void {
+    this.subscriptions.add(
+      this.enableAllocateAdmin$
+        .pipe(filter(Boolean))
+        .subscribe((enableAllocateAdmin: boolean) => {
+          if (enableAllocateAdmin) {
+            this.form.disable();
+          } else {
+            this.form.enable();
+          }
+        })
     );
   }
 

--- a/src/app/shared/records/record-search/record-search.component.ts
+++ b/src/app/shared/records/record-search/record-search.component.ts
@@ -61,11 +61,11 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public listenToAllocateAdminsEvent(): void {
     this.subscriptions.add(
       this.enableAllocateAdmin$
-        .pipe(filter(Boolean))
+        .pipe(filter((value) => value !== undefined))
         .subscribe((enableAllocateAdmin: boolean) => {
-          if (enableAllocateAdmin) {
+          if (enableAllocateAdmin === true) {
             this.form.disable();
-          } else {
+          } else if (enableAllocateAdmin === false) {
             this.form.enable();
           }
         })

--- a/src/app/shared/records/records.module.ts
+++ b/src/app/shared/records/records.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MaterialModule } from "../material/material.module";
+import { AllocateAdminBtnComponent } from "./allocate-admin-btn/allocate-admin-btn.component";
 import { RecordListComponent } from "./record-list/record-list.component";
 import { RecordSearchComponent } from "./record-search/record-search.component";
 import { ResetRecordListComponent } from "./reset-record-list/reset-record-list.component";
@@ -9,7 +10,8 @@ import { ResetRecordListComponent } from "./reset-record-list/reset-record-list.
 const components: any[] = [
   RecordListComponent,
   RecordSearchComponent,
-  ResetRecordListComponent
+  ResetRecordListComponent,
+  AllocateAdminBtnComponent
 ];
 
 @NgModule({

--- a/src/app/shared/records/records.module.ts
+++ b/src/app/shared/records/records.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MaterialModule } from "../material/material.module";
+import { AllocateAdminActionsComponent } from "./allocate-admin-actions/allocate-admin-actions.component";
 import { AllocateAdminBtnComponent } from "./allocate-admin-btn/allocate-admin-btn.component";
 import { RecordListComponent } from "./record-list/record-list.component";
 import { RecordSearchComponent } from "./record-search/record-search.component";
@@ -11,7 +12,8 @@ const components: any[] = [
   RecordListComponent,
   RecordSearchComponent,
   ResetRecordListComponent,
-  AllocateAdminBtnComponent
+  AllocateAdminBtnComponent,
+  AllocateAdminActionsComponent
 ];
 
 @NgModule({

--- a/src/app/shared/records/reset-record-list/reset-record-list.component.html
+++ b/src/app/shared/records/reset-record-list/reset-record-list.component.html
@@ -1,3 +1,8 @@
-<button mat-menu-item (click)="resetRecordList()" aria-label="Clear all">
+<button
+  mat-menu-item
+  (click)="resetRecordList()"
+  aria-label="Clear all"
+  [disabled]="enableAllocateAdmin$ | async"
+>
   Clear all
 </button>

--- a/src/app/shared/records/reset-record-list/reset-record-list.component.spec.ts
+++ b/src/app/shared/records/reset-record-list/reset-record-list.component.spec.ts
@@ -7,6 +7,7 @@ import { MaterialModule } from "../../material/material.module";
 import { RecordsService } from "../services/records.service";
 import {
   ClearSearch,
+  EnableAllocateAdmin,
   Filter,
   Get,
   Paginate,
@@ -54,7 +55,8 @@ describe("ResetRecordListComponent", () => {
       ResetPaginator,
       ResetSort,
       Search,
-      Sort
+      Sort,
+      EnableAllocateAdmin
     );
   });
 

--- a/src/app/shared/records/reset-record-list/reset-record-list.component.ts
+++ b/src/app/shared/records/reset-record-list/reset-record-list.component.ts
@@ -1,5 +1,4 @@
 import { Component } from "@angular/core";
-import { Sort } from "@angular/material/sort";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
@@ -10,11 +9,8 @@ import { RecordsService } from "../services/records.service";
   templateUrl: "./reset-record-list.component.html"
 })
 export class ResetRecordListComponent {
-  public sort$: Observable<Sort> = this.store.select(
-    (state) => state[this.recordsService.stateName].sort
-  );
-  public pageIndex$: Observable<number> = this.store.select(
-    (state) => state[this.recordsService.stateName].pageIndex
+  public enableAllocateAdmin$: Observable<boolean> = this.store.select(
+    (state) => state[this.recordsService.stateName].enableAllocateAdmin
   );
 
   constructor(private store: Store, private recordsService: RecordsService) {}

--- a/src/app/shared/records/services/records.service.ts
+++ b/src/app/shared/records/services/records.service.ts
@@ -22,6 +22,7 @@ export class RecordsService {
   public resetSortAction: any;
   public searchAction: any;
   public sortAction: any;
+  public enableAllocateAdminAction: any;
 
   constructor(
     private http: HttpClient,
@@ -38,7 +39,8 @@ export class RecordsService {
     resetPaginatorAction,
     resetSortAction,
     searchAction,
-    sortAction
+    sortAction,
+    enableAllocateAdminAction
   ): void {
     this.clearSearchAction = clearSearchAction;
     this.filterAction = filterAction;
@@ -49,6 +51,7 @@ export class RecordsService {
     this.resetSortAction = resetSortAction;
     this.searchAction = searchAction;
     this.sortAction = sortAction;
+    this.enableAllocateAdminAction = enableAllocateAdminAction;
   }
 
   public getRecords<T>(endPoint: string, params?: HttpParams): Observable<T> {
@@ -175,6 +178,16 @@ export class RecordsService {
     return this.resetSortPageAndSearch().pipe(
       take(1),
       switchMap(() => this.resetFilter())
+    );
+  }
+
+  public enableAllocateAdmin(enableAllocateAdmin: boolean): Observable<any> {
+    if (!this.enableAllocateAdminAction) {
+      throw new Error("enableAllocateAdminAction must be defined");
+    }
+
+    return this.store.dispatch(
+      new this.enableAllocateAdminAction(enableAllocateAdmin)
     );
   }
 }

--- a/src/app/shared/records/state/records.actions.ts
+++ b/src/app/shared/records/state/records.actions.ts
@@ -24,3 +24,7 @@ export class SearchPayload {
 export class PaginatePayload {
   constructor(public pageIndex: number) {}
 }
+
+export class EnableAllocateAdminPayload {
+  constructor(public enableAllocateAdmin: boolean) {}
+}

--- a/src/app/shared/records/state/records.state.ts
+++ b/src/app/shared/records/state/records.state.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SORT } from "../constants";
 import { RecordsService } from "../services/records.service";
 
 export class RecordsStateModel<T, F> {
+  public enableAllocateAdmin?: boolean;
   public error?: string;
   public filter: T;
   public items: F;
@@ -21,8 +22,8 @@ export const defaultRecordsState = {
   loading: null,
   pageIndex: 0,
   searchQuery: null,
-  totalPages: null,
   sort: DEFAULT_SORT,
+  totalPages: null,
   totalResults: null
 };
 
@@ -74,6 +75,12 @@ export class RecordsState {
   static filter<T>() {
     return createSelector([this], (state: { filter: T }) => {
       return state.filter;
+    });
+  }
+
+  static enableAllocateAdmin<T>() {
+    return createSelector([this], (state: { enableAllocateAdmin: boolean }) => {
+      return state.enableAllocateAdmin;
     });
   }
 
@@ -146,5 +153,11 @@ export class RecordsState {
 
   protected resetFilterHandler(ctx: StateContext<any>, action: any) {
     ctx.patchState({ filter: action });
+  }
+
+  protected enableAllocateAdminHandler(ctx: StateContext<any>, action: any) {
+    ctx.patchState({
+      enableAllocateAdmin: action
+    });
   }
 }


### PR DESCRIPTION
TISNEW-4834

feat: enable allocate admin mode for summary screens.

- created new generic `AllocateAdminBtnComponent` which dispatches store event and updates state with new `enableAllocateAdmin: true/false` 
- subscribe to event and disable search form, clear all, pagination, sorting and filters
- updated and effected fixed tests