### PR TITLE
feat: allocate admin

### DIFF
--- a/src/app/concerns/concerns.resolver.ts
+++ b/src/app/concerns/concerns.resolver.ts
@@ -5,19 +5,19 @@ import { Observable } from "rxjs";
 import { RecordsResolver } from "../shared/records/records.resolver";
 import { RecordsService } from "../shared/records/services/records.service";
 import {
-  ClearSearch,
-  Filter,
-  Get,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  EnableAllocateAdmin,
-  ToggleCheckbox,
-  ToggleAllCheckboxes
-} from "../shared/records/state/records.actions";
+  ClearConcernsSearch,
+  FilterConcerns,
+  GetConcerns,
+  PaginateConcerns,
+  ResetConcernsFilter,
+  ResetConcernsPaginator,
+  ResetConcernsSort,
+  ConcernsSearch,
+  SortConcerns,
+  EnableConcernsAllocateAdmin,
+  ToggleConcernsCheckbox,
+  ToggleAllConcernsCheckboxes
+} from "./state/concerns.actions";
 
 @Injectable()
 export class ConcernsResolver extends RecordsResolver implements Resolve<any> {
@@ -28,18 +28,18 @@ export class ConcernsResolver extends RecordsResolver implements Resolve<any> {
     super(store, recordsService);
     this.recordsService.stateName = "concerns";
     this.recordsService.setActions(
-      ClearSearch,
-      Filter,
-      Get,
-      Paginate,
-      ResetFilter,
-      ResetPaginator,
-      ResetSort,
-      Search,
-      Sort,
-      EnableAllocateAdmin,
-      ToggleCheckbox,
-      ToggleAllCheckboxes
+      ClearConcernsSearch,
+      FilterConcerns,
+      GetConcerns,
+      PaginateConcerns,
+      ResetConcernsFilter,
+      ResetConcernsPaginator,
+      ResetConcernsSort,
+      ConcernsSearch,
+      SortConcerns,
+      EnableConcernsAllocateAdmin,
+      ToggleConcernsCheckbox,
+      ToggleAllConcernsCheckboxes
     );
   }
 

--- a/src/app/concerns/state/concerns.actions.ts
+++ b/src/app/concerns/state/concerns.actions.ts
@@ -1,0 +1,70 @@
+import { ConcernStatus } from "../../concern/concern-history.interface";
+import {
+  EnableAllocateAdminPayload,
+  FilterPayload,
+  GetErrorPayload,
+  GetSuccessPayload,
+  PaginatePayload,
+  SearchPayload,
+  SortPayload,
+  ToggleCheckboxPayload
+} from "../../shared/records/state/records.actions";
+import { IGetConcernsResponse } from "../concerns.interfaces";
+
+export class GetConcerns {
+  static readonly type = `[Concerns] Get`;
+}
+
+export class GetConcernsSuccess extends GetSuccessPayload<
+  IGetConcernsResponse
+> {
+  static readonly type = `[Concerns] Get Success`;
+}
+
+export class GetConcernsError extends GetErrorPayload {
+  static readonly type = `[Concerns] Get Error`;
+}
+
+export class SortConcerns extends SortPayload {
+  static readonly type = `[Concerns] Sort`;
+}
+
+export class ResetConcernsSort {
+  static readonly type = `[Concerns] Reset Sort`;
+}
+
+export class FilterConcerns extends FilterPayload<ConcernStatus> {
+  static readonly type = `[Concerns] Filter`;
+}
+
+export class ResetConcernsFilter {
+  static readonly type = `[Concerns] Reset Filter`;
+}
+
+export class ConcernsSearch extends SearchPayload {
+  static readonly type = `[Concerns] Search`;
+}
+
+export class ClearConcernsSearch {
+  static readonly type = `[Concerns] Clear Search`;
+}
+
+export class PaginateConcerns extends PaginatePayload {
+  static readonly type = `[Concerns] Paginate`;
+}
+
+export class ResetConcernsPaginator {
+  static readonly type = `[Concerns] Reset Paginator`;
+}
+
+export class EnableConcernsAllocateAdmin extends EnableAllocateAdminPayload {
+  static readonly type = `[Concerns] Enable Allocate Admin`;
+}
+
+export class ToggleConcernsCheckbox extends ToggleCheckboxPayload {
+  static readonly type = `[Concerns] Toggle Checkbox`;
+}
+
+export class ToggleAllConcernsCheckboxes {
+  static readonly type = `[Concerns] Toggle All Checkboxes`;
+}

--- a/src/app/concerns/state/concerns.state.ts
+++ b/src/app/concerns/state/concerns.state.ts
@@ -15,19 +15,21 @@ import {
 import { IConcern, IGetConcernsResponse } from "../concerns.interfaces";
 import { ConcernsService } from "../services/concerns.service";
 import {
-  ClearSearch,
-  EnableAllocateAdmin,
-  Filter,
-  Get,
-  GetError,
-  GetSuccess,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort
-} from "../../shared/records/state/records.actions";
+  ClearConcernsSearch,
+  EnableConcernsAllocateAdmin,
+  FilterConcerns,
+  GetConcerns,
+  GetConcernsError,
+  GetConcernsSuccess,
+  PaginateConcerns,
+  ResetConcernsFilter,
+  ResetConcernsPaginator,
+  ResetConcernsSort,
+  ConcernsSearch,
+  SortConcerns,
+  ToggleAllConcernsCheckboxes,
+  ToggleConcernsCheckbox
+} from "./concerns.actions";
 
 export class ConcernsStateModel extends RecordsStateModel<
   ConcernStatus,
@@ -52,7 +54,7 @@ export class ConcernsState extends RecordsState {
     super(recordsService);
   }
 
-  @Action(Get)
+  @Action(GetConcerns)
   get(ctx: StateContext<ConcernsStateModel>) {
     const params: HttpParams = this.concernsService.generateParams();
     const endPoint = `${environment.appUrls.getConcerns}`;
@@ -70,10 +72,10 @@ export class ConcernsState extends RecordsState {
           return response;
         }),
         switchMap((response: IGetConcernsResponse) =>
-          ctx.dispatch(new GetSuccess(response))
+          ctx.dispatch(new GetConcernsSuccess(response))
         ),
         catchError((error: HttpErrorResponse) =>
-          ctx.dispatch(new GetError(error))
+          ctx.dispatch(new GetConcernsError(error))
         ),
         finalize(() =>
           ctx.patchState({
@@ -84,64 +86,77 @@ export class ConcernsState extends RecordsState {
       .subscribe();
   }
 
-  @Action(GetSuccess)
+  @Action(GetConcernsSuccess)
   getSuccess(
     ctx: StateContext<ConcernsStateModel>,
-    action: GetSuccess<IGetConcernsResponse>
+    action: GetConcernsSuccess
   ) {
     return super.getSuccessHandler(ctx, action, "concernTrainees");
   }
 
-  @Action(GetError)
-  getError(ctx: StateContext<ConcernsStateModel>, action: GetError) {
+  @Action(GetConcernsError)
+  getError(ctx: StateContext<ConcernsStateModel>, action: GetConcernsError) {
     return super.getErrorHandler(ctx, action);
   }
 
-  @Action(Sort)
-  sort(ctx: StateContext<ConcernsStateModel>, action: Sort) {
+  @Action(SortConcerns)
+  sort(ctx: StateContext<ConcernsStateModel>, action: SortConcerns) {
     return super.sortHandler(ctx, action);
   }
 
-  @Action(ResetSort)
+  @Action(ResetConcernsSort)
   resetSort(ctx: StateContext<ConcernsStateModel>) {
     return super.resetSortHandler(ctx, DEFAULT_SORT);
   }
 
-  @Action(Paginate)
-  paginate(ctx: StateContext<ConcernsStateModel>, action: Paginate) {
+  @Action(PaginateConcerns)
+  paginate(ctx: StateContext<ConcernsStateModel>, action: PaginateConcerns) {
     return super.paginateHandler(ctx, action);
   }
 
-  @Action(ResetPaginator)
+  @Action(ResetConcernsPaginator)
   resetPaginator(ctx: StateContext<ConcernsStateModel>) {
     return super.resetPaginatorHandler(ctx);
   }
 
-  @Action(Search)
-  search(ctx: StateContext<ConcernsStateModel>, action: Search) {
+  @Action(ConcernsSearch)
+  search(ctx: StateContext<ConcernsStateModel>, action: ConcernsSearch) {
     return super.searchHandler(ctx, action);
   }
 
-  @Action(ClearSearch)
+  @Action(ClearConcernsSearch)
   clearSearch(ctx: StateContext<ConcernsStateModel>) {
     return super.clearSearchHandler(ctx);
   }
 
-  @Action(Filter)
-  filter(ctx: StateContext<ConcernsStateModel>, action: Filter<ConcernStatus>) {
+  @Action(FilterConcerns)
+  filter(ctx: StateContext<ConcernsStateModel>, action: FilterConcerns) {
     return super.filterHandler(ctx, action);
   }
 
-  @Action(ResetFilter)
+  @Action(ResetConcernsFilter)
   resetFilter(ctx: StateContext<ConcernsStateModel>) {
     return super.resetFilterHandler(ctx, ConcernStatus.OPEN);
   }
 
-  @Action(EnableAllocateAdmin)
+  @Action(EnableConcernsAllocateAdmin)
   enableAllocateAdmin(
     ctx: StateContext<ConcernsStateModel>,
-    action: EnableAllocateAdmin
+    action: EnableConcernsAllocateAdmin
   ) {
     return super.enableAllocateAdminHandler(ctx, action.enableAllocateAdmin);
+  }
+
+  @Action(ToggleConcernsCheckbox)
+  toggleCheckbox(
+    ctx: StateContext<ConcernsStateModel>,
+    action: ToggleConcernsCheckbox
+  ) {
+    return super.toggleCheckboxHandler(ctx, action);
+  }
+
+  @Action(ToggleAllConcernsCheckboxes)
+  toggleAllCheckboxes(ctx: StateContext<ConcernsStateModel>) {
+    return super.toggleAllCheckboxesHandler(ctx);
   }
 }

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -5,19 +5,19 @@ import { Observable } from "rxjs";
 import { RecordsResolver } from "../shared/records/records.resolver";
 import { RecordsService } from "../shared/records/services/records.service";
 import {
-  ClearSearch,
-  Filter,
-  Get,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  EnableAllocateAdmin,
-  ToggleCheckbox,
-  ToggleAllCheckboxes
-} from "../shared/records/state/records.actions";
+  ClearConnectionsSearch,
+  FilterConnections,
+  GetConnections,
+  PaginateConnections,
+  ResetConnectionsFilter,
+  ResetConnectionsPaginator,
+  ResetConnectionsSort,
+  ConnectionsSearch,
+  SortConnections,
+  EnableConnectionsAllocateAdmin,
+  ToggleConnectionsCheckbox,
+  ToggleAllConnectionsCheckboxes
+} from "./state/connections.actions";
 
 @Injectable()
 export class ConnectionsResolver extends RecordsResolver
@@ -29,18 +29,18 @@ export class ConnectionsResolver extends RecordsResolver
     super(store, recordsService);
     this.recordsService.stateName = "connections";
     this.recordsService.setActions(
-      ClearSearch,
-      Filter,
-      Get,
-      Paginate,
-      ResetFilter,
-      ResetPaginator,
-      ResetSort,
-      Search,
-      Sort,
-      EnableAllocateAdmin,
-      ToggleCheckbox,
-      ToggleAllCheckboxes
+      ClearConnectionsSearch,
+      FilterConnections,
+      GetConnections,
+      PaginateConnections,
+      ResetConnectionsFilter,
+      ResetConnectionsPaginator,
+      ResetConnectionsSort,
+      ConnectionsSearch,
+      SortConnections,
+      EnableConnectionsAllocateAdmin,
+      ToggleConnectionsCheckbox,
+      ToggleAllConnectionsCheckboxes
     );
   }
 

--- a/src/app/connections/state/connections.actions.ts
+++ b/src/app/connections/state/connections.actions.ts
@@ -1,0 +1,72 @@
+import {
+  EnableAllocateAdminPayload,
+  FilterPayload,
+  GetErrorPayload,
+  GetSuccessPayload,
+  PaginatePayload,
+  SearchPayload,
+  SortPayload,
+  ToggleCheckboxPayload
+} from "../../shared/records/state/records.actions";
+import {
+  ConnectionsFilterType,
+  IGetConnectionsResponse
+} from "../connections.interfaces";
+
+export class GetConnections {
+  static readonly type = `[Connections] Get`;
+}
+
+export class GetConnectionsSuccess extends GetSuccessPayload<
+  IGetConnectionsResponse
+> {
+  static readonly type = `[Connections] Get Success`;
+}
+
+export class GetConnectionsError extends GetErrorPayload {
+  static readonly type = `[Connections] Get Error`;
+}
+
+export class SortConnections extends SortPayload {
+  static readonly type = `[Connections] Sort`;
+}
+
+export class ResetConnectionsSort {
+  static readonly type = `[Connections] Reset Sort`;
+}
+
+export class FilterConnections extends FilterPayload<ConnectionsFilterType> {
+  static readonly type = `[Connections] Filter`;
+}
+
+export class ResetConnectionsFilter {
+  static readonly type = `[Connections] Reset Filter`;
+}
+
+export class ConnectionsSearch extends SearchPayload {
+  static readonly type = `[Connections] Search`;
+}
+
+export class ClearConnectionsSearch {
+  static readonly type = `[Connections] Clear Search`;
+}
+
+export class PaginateConnections extends PaginatePayload {
+  static readonly type = `[Connections] Paginate`;
+}
+
+export class ResetConnectionsPaginator {
+  static readonly type = `[Connections] Reset Paginator`;
+}
+
+export class EnableConnectionsAllocateAdmin extends EnableAllocateAdminPayload {
+  static readonly type = `[Connections] Enable Allocate Admin`;
+}
+
+export class ToggleConnectionsCheckbox extends ToggleCheckboxPayload {
+  static readonly type = `[Connections] Toggle Checkbox`;
+}
+
+export class ToggleAllConnectionsCheckboxes {
+  static readonly type = `[Connections] Toggle All Checkboxes`;
+}

--- a/src/app/connections/state/connections.state.ts
+++ b/src/app/connections/state/connections.state.ts
@@ -17,19 +17,21 @@ import {
 import { DEFAULT_SORT } from "../../shared/records/constants";
 import { ConnectionsService } from "../services/connections.service";
 import {
-  ClearSearch,
-  EnableAllocateAdmin,
-  Filter,
-  Paginate,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  Get,
-  GetError,
-  GetSuccess,
-  ResetFilter
-} from "../../shared/records/state/records.actions";
+  ClearConnectionsSearch,
+  EnableConnectionsAllocateAdmin,
+  FilterConnections,
+  PaginateConnections,
+  ResetConnectionsPaginator,
+  ResetConnectionsSort,
+  ConnectionsSearch,
+  SortConnections,
+  GetConnections,
+  GetConnectionsError,
+  GetConnectionsSuccess,
+  ResetConnectionsFilter,
+  ToggleAllConnectionsCheckboxes,
+  ToggleConnectionsCheckbox
+} from "./connections.actions";
 
 export class ConnectionsStateModel extends RecordsStateModel<
   ConnectionsFilterType,
@@ -54,7 +56,7 @@ export class ConnectionsState extends RecordsState {
     super(recordsService);
   }
 
-  @Action(Get)
+  @Action(GetConnections)
   get(ctx: StateContext<ConnectionsStateModel>) {
     const params: HttpParams = this.connectionsService.generateParams();
     const endPoint = `${environment.appUrls.getConnections}`;
@@ -65,10 +67,10 @@ export class ConnectionsState extends RecordsState {
       .pipe(
         take(1),
         switchMap((response: IGetConnectionsResponse) =>
-          ctx.dispatch(new GetSuccess(response))
+          ctx.dispatch(new GetConnectionsSuccess(response))
         ),
         catchError((error: HttpErrorResponse) =>
-          ctx.dispatch(new GetError(error))
+          ctx.dispatch(new GetConnectionsError(error))
         ),
         finalize(() =>
           ctx.patchState({
@@ -79,67 +81,83 @@ export class ConnectionsState extends RecordsState {
       .subscribe();
   }
 
-  @Action(GetSuccess)
+  @Action(GetConnectionsSuccess)
   getSuccess(
     ctx: StateContext<ConnectionsStateModel>,
-    action: GetSuccess<IGetConnectionsResponse>
+    action: GetConnectionsSuccess
   ) {
     return super.getSuccessHandler(ctx, action, "connectionsInfo");
   }
 
-  @Action(GetError)
-  getError(ctx: StateContext<ConnectionsStateModel>, action: GetError) {
+  @Action(GetConnectionsError)
+  getError(
+    ctx: StateContext<ConnectionsStateModel>,
+    action: GetConnectionsError
+  ) {
     return super.getErrorHandler(ctx, action);
   }
 
-  @Action(Sort)
-  sort(ctx: StateContext<ConnectionsStateModel>, action: Sort) {
+  @Action(SortConnections)
+  sort(ctx: StateContext<ConnectionsStateModel>, action: SortConnections) {
     return super.sortHandler(ctx, action);
   }
 
-  @Action(ResetSort)
+  @Action(ResetConnectionsSort)
   resetSort(ctx: StateContext<ConnectionsStateModel>) {
     return super.resetSortHandler(ctx, DEFAULT_SORT);
   }
 
-  @Action(Paginate)
-  paginate(ctx: StateContext<ConnectionsStateModel>, action: Paginate) {
+  @Action(PaginateConnections)
+  paginate(
+    ctx: StateContext<ConnectionsStateModel>,
+    action: PaginateConnections
+  ) {
     return super.paginateHandler(ctx, action);
   }
 
-  @Action(ResetPaginator)
+  @Action(ResetConnectionsPaginator)
   resetPaginator(ctx: StateContext<ConnectionsStateModel>) {
     return super.resetPaginatorHandler(ctx);
   }
 
-  @Action(Search)
-  search(ctx: StateContext<ConnectionsStateModel>, action: Search) {
+  @Action(ConnectionsSearch)
+  search(ctx: StateContext<ConnectionsStateModel>, action: ConnectionsSearch) {
     return super.searchHandler(ctx, action);
   }
 
-  @Action(ClearSearch)
+  @Action(ClearConnectionsSearch)
   clearSearch(ctx: StateContext<ConnectionsStateModel>) {
     return super.clearSearchHandler(ctx);
   }
 
-  @Action(Filter)
-  filter(
-    ctx: StateContext<ConnectionsStateModel>,
-    action: Filter<ConnectionsFilterType>
-  ) {
+  @Action(FilterConnections)
+  filter(ctx: StateContext<ConnectionsStateModel>, action: FilterConnections) {
     return super.filterHandler(ctx, action);
   }
 
-  @Action(ResetFilter)
+  @Action(ResetConnectionsFilter)
   resetFilter(ctx: StateContext<ConnectionsStateModel>) {
     return super.resetFilterHandler(ctx, ConnectionsFilterType.ALL);
   }
 
-  @Action(EnableAllocateAdmin)
+  @Action(EnableConnectionsAllocateAdmin)
   enableAllocateAdmin(
     ctx: StateContext<ConnectionsStateModel>,
-    action: EnableAllocateAdmin
+    action: EnableConnectionsAllocateAdmin
   ) {
     return super.enableAllocateAdminHandler(ctx, action.enableAllocateAdmin);
+  }
+
+  @Action(ToggleConnectionsCheckbox)
+  toggleCheckbox(
+    ctx: StateContext<ConnectionsStateModel>,
+    action: ToggleConnectionsCheckbox
+  ) {
+    return super.toggleCheckboxHandler(ctx, action);
+  }
+
+  @Action(ToggleAllConnectionsCheckboxes)
+  toggleAllCheckboxes(ctx: StateContext<ConnectionsStateModel>) {
+    return super.toggleAllCheckboxesHandler(ctx);
   }
 }

--- a/src/app/recommendations/recommendations-filters/recommendations-filters.component.spec.ts
+++ b/src/app/recommendations/recommendations-filters/recommendations-filters.component.spec.ts
@@ -7,19 +7,19 @@ import { MaterialModule } from "../../shared/material/material.module";
 import { RecordsService } from "../../shared/records/services/records.service";
 import { RecommendationsFilterType } from "../recommendations.interfaces";
 import {
-  Filter,
-  ClearSearch,
-  Get,
-  ResetPaginator,
-  ResetSort,
-  Paginate,
-  ResetFilter,
-  Search,
-  Sort,
-  EnableAllocateAdmin,
-  ToggleAllCheckboxes,
-  ToggleCheckbox
-} from "../../shared/records/state/records.actions";
+  FilterRecommendations,
+  ClearRecommendationsSearch,
+  GetRecommendations,
+  ResetRecommendationsPaginator,
+  ResetRecommendationsSort,
+  PaginateRecommendations,
+  ResetRecommendationsFilter,
+  RecommendationsSearch,
+  SortRecommendations,
+  EnableRecommendationsAllocateAdmin,
+  ToggleAllRecommendationsCheckboxes,
+  ToggleRecommendationsCheckbox
+} from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
 import { RecommendationsFiltersComponent } from "./recommendations-filters.component";
@@ -53,18 +53,18 @@ describe("RecommendationsFiltersComponent", () => {
     fixture.detectChanges();
     recordsService.stateName = "recommendations";
     recordsService.setActions(
-      ClearSearch,
-      Filter,
-      Get,
-      Paginate,
-      ResetFilter,
-      ResetPaginator,
-      ResetSort,
-      Search,
-      Sort,
-      EnableAllocateAdmin,
-      ToggleAllCheckboxes,
-      ToggleCheckbox
+      ClearRecommendationsSearch,
+      FilterRecommendations,
+      GetRecommendations,
+      PaginateRecommendations,
+      ResetRecommendationsFilter,
+      ResetRecommendationsPaginator,
+      ResetRecommendationsSort,
+      RecommendationsSearch,
+      SortRecommendations,
+      EnableRecommendationsAllocateAdmin,
+      ToggleAllRecommendationsCheckboxes,
+      ToggleRecommendationsCheckbox
     );
   });
 
@@ -76,7 +76,7 @@ describe("RecommendationsFiltersComponent", () => {
     spyOn(store, "dispatch").and.callThrough();
     component.filterByAllDoctors();
     expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(RecommendationsFilterType.ALL_DOCTORS)
+      new FilterRecommendations(RecommendationsFilterType.ALL_DOCTORS)
     );
   });
 
@@ -90,7 +90,7 @@ describe("RecommendationsFiltersComponent", () => {
     spyOn(store, "dispatch").and.callThrough();
     component.filterByUnderNotice();
     expect(store.dispatch).toHaveBeenCalledWith(
-      new Filter(RecommendationsFilterType.UNDER_NOTICE)
+      new FilterRecommendations(RecommendationsFilterType.UNDER_NOTICE)
     );
   });
 

--- a/src/app/recommendations/recommendations-filters/recommendations-filters.component.ts
+++ b/src/app/recommendations/recommendations-filters/recommendations-filters.component.ts
@@ -3,7 +3,7 @@ import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { Filter } from "../../shared/records/state/records.actions";
+import { FilterRecommendations } from "../state/recommendations.actions";
 import { RecommendationsFilterType } from "../recommendations.interfaces";
 import { RecommendationsState } from "../state/recommendations.state";
 
@@ -29,12 +29,12 @@ export class RecommendationsFiltersComponent {
   constructor(private store: Store, private recordsService: RecordsService) {}
 
   public filterByAllDoctors(): void {
-    this.store.dispatch(new Filter(this.allDoctors));
+    this.store.dispatch(new FilterRecommendations(this.allDoctors));
     this.getRecommendations();
   }
 
   public filterByUnderNotice(): void {
-    this.store.dispatch(new Filter(this.underNotice));
+    this.store.dispatch(new FilterRecommendations(this.underNotice));
     this.getRecommendations();
   }
 

--- a/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.spec.ts
+++ b/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { DEFAULT_SORT } from "../../shared/records/constants";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { Paginate } from "../../shared/records/state/records.actions";
+import { PaginateRecommendations } from "../state/recommendations.actions";
 
 import { RecommendationsState } from "../state/recommendations.state";
 
@@ -58,7 +58,7 @@ describe("RecommendationsListPaginatorComponent", () => {
     component.paginate(mockPageEvent);
     expect(store.dispatch).toHaveBeenCalledTimes(1);
     expect(store.dispatch).toHaveBeenCalledWith(
-      new Paginate(mockPageEvent.pageIndex)
+      new PaginateRecommendations(mockPageEvent.pageIndex)
     );
   });
 

--- a/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.ts
+++ b/src/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.component.ts
@@ -4,7 +4,7 @@ import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
 import { RecordsService } from "../../shared/records/services/records.service";
-import { Paginate } from "../../shared/records/state/records.actions";
+import { PaginateRecommendations } from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 
 @Component({
@@ -30,7 +30,7 @@ export class RecommendationsListPaginatorComponent {
    */
   public paginate(event: PageEvent): void {
     this.store
-      .dispatch(new Paginate(Number(event.pageIndex)))
+      .dispatch(new PaginateRecommendations(Number(event.pageIndex)))
       .pipe(take(1))
       .subscribe(() => this.recordsService.updateRoute());
   }

--- a/src/app/recommendations/recommendations-list/recommendations-list.component.scss
+++ b/src/app/recommendations/recommendations-list/recommendations-list.component.scss
@@ -27,7 +27,7 @@
       width: 110px
     ),
     admin: (
-      width: 150px
+      width: 180px
     ),
     lastUpdatedDate: (
       width: 110px

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -5,19 +5,19 @@ import { Observable } from "rxjs";
 import { RecordsResolver } from "../shared/records/records.resolver";
 import { RecordsService } from "../shared/records/services/records.service";
 import {
-  ClearSearch,
-  EnableAllocateAdmin,
-  Filter,
-  Get,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  ToggleCheckbox,
-  ToggleAllCheckboxes
-} from "../shared/records/state/records.actions";
+  ClearRecommendationsSearch,
+  EnableRecommendationsAllocateAdmin,
+  FilterRecommendations,
+  GetRecommendations,
+  PaginateRecommendations,
+  ResetRecommendationsFilter,
+  ResetRecommendationsPaginator,
+  ResetRecommendationsSort,
+  RecommendationsSearch,
+  SortRecommendations,
+  ToggleRecommendationsCheckbox,
+  ToggleAllRecommendationsCheckboxes
+} from "./state/recommendations.actions";
 
 @Injectable()
 export class RecommendationsResolver extends RecordsResolver
@@ -29,18 +29,18 @@ export class RecommendationsResolver extends RecordsResolver
     super(store, recordsService);
     this.recordsService.stateName = "recommendations";
     this.recordsService.setActions(
-      ClearSearch,
-      Filter,
-      Get,
-      Paginate,
-      ResetFilter,
-      ResetPaginator,
-      ResetSort,
-      Search,
-      Sort,
-      EnableAllocateAdmin,
-      ToggleCheckbox,
-      ToggleAllCheckboxes
+      ClearRecommendationsSearch,
+      FilterRecommendations,
+      GetRecommendations,
+      PaginateRecommendations,
+      ResetRecommendationsFilter,
+      ResetRecommendationsPaginator,
+      ResetRecommendationsSort,
+      RecommendationsSearch,
+      SortRecommendations,
+      EnableRecommendationsAllocateAdmin,
+      ToggleRecommendationsCheckbox,
+      ToggleAllRecommendationsCheckboxes
     );
   }
 

--- a/src/app/recommendations/services/recommendations.service.spec.ts
+++ b/src/app/recommendations/services/recommendations.service.spec.ts
@@ -6,10 +6,10 @@ import { NgxsModule, Store } from "@ngxs/store";
 import { BehaviorSubject, Observable, of } from "rxjs";
 import { RecommendationStatus } from "../../recommendation/recommendation-history.interface";
 import {
-  Filter,
-  ResetPaginator,
-  Search
-} from "../../shared/records/state/records.actions";
+  FilterRecommendations,
+  ResetRecommendationsPaginator,
+  RecommendationsSearch
+} from "../state/recommendations.actions";
 import { RecommendationsState } from "../state/recommendations.state";
 import {
   IGetRecommendationsResponse,
@@ -90,8 +90,10 @@ describe("RecommendationsService", () => {
   });
 
   it("`generateParams()` should generate and return HttpParams", () => {
-    store.dispatch(new ResetPaginator());
-    store.dispatch(new Filter(RecommendationsFilterType.UNDER_NOTICE));
+    store.dispatch(new ResetRecommendationsPaginator());
+    store.dispatch(
+      new FilterRecommendations(RecommendationsFilterType.UNDER_NOTICE)
+    );
 
     const params: HttpParams = recommendationsService.generateParams();
 
@@ -99,9 +101,11 @@ describe("RecommendationsService", () => {
   });
 
   it("`generateParams()` should include search query if its set on store", () => {
-    store.dispatch(new Search("lisa"));
-    store.dispatch(new ResetPaginator());
-    store.dispatch(new Filter(RecommendationsFilterType.UNDER_NOTICE));
+    store.dispatch(new RecommendationsSearch("lisa"));
+    store.dispatch(new ResetRecommendationsPaginator());
+    store.dispatch(
+      new FilterRecommendations(RecommendationsFilterType.UNDER_NOTICE)
+    );
 
     const params: HttpParams = recommendationsService.generateParams();
 

--- a/src/app/recommendations/state/recommendations.actions.ts
+++ b/src/app/recommendations/state/recommendations.actions.ts
@@ -1,0 +1,74 @@
+import {
+  EnableAllocateAdminPayload,
+  FilterPayload,
+  GetErrorPayload,
+  GetSuccessPayload,
+  PaginatePayload,
+  SearchPayload,
+  SortPayload,
+  ToggleCheckboxPayload
+} from "../../shared/records/state/records.actions";
+import {
+  IGetRecommendationsResponse,
+  RecommendationsFilterType
+} from "../recommendations.interfaces";
+
+export class GetRecommendations {
+  static readonly type = `[Recommendations] Get`;
+}
+
+export class GetRecommendationsSuccess extends GetSuccessPayload<
+  IGetRecommendationsResponse
+> {
+  static readonly type = `[Recommendations] Get Success`;
+}
+
+export class GetRecommendationsError extends GetErrorPayload {
+  static readonly type = `[Recommendations] Get Error`;
+}
+
+export class SortRecommendations extends SortPayload {
+  static readonly type = `[Recommendations] Sort`;
+}
+
+export class ResetRecommendationsSort {
+  static readonly type = `[Recommendations] Reset Sort`;
+}
+
+export class FilterRecommendations extends FilterPayload<
+  RecommendationsFilterType
+> {
+  static readonly type = `[Recommendations] Filter`;
+}
+
+export class ResetRecommendationsFilter {
+  static readonly type = `[Recommendations] Reset Filter`;
+}
+
+export class RecommendationsSearch extends SearchPayload {
+  static readonly type = `[Recommendations] Search`;
+}
+
+export class ClearRecommendationsSearch {
+  static readonly type = `[Recommendations] Clear Search`;
+}
+
+export class PaginateRecommendations extends PaginatePayload {
+  static readonly type = `[Recommendations] Paginate`;
+}
+
+export class ResetRecommendationsPaginator {
+  static readonly type = `[Recommendations] Reset Paginator`;
+}
+
+export class EnableRecommendationsAllocateAdmin extends EnableAllocateAdminPayload {
+  static readonly type = `[Recommendations] Enable Allocate Admin`;
+}
+
+export class ToggleRecommendationsCheckbox extends ToggleCheckboxPayload {
+  static readonly type = `[Recommendations] Toggle Checkbox`;
+}
+
+export class ToggleAllRecommendationsCheckboxes {
+  static readonly type = `[Recommendations] Toggle All Checkboxes`;
+}

--- a/src/app/recommendations/state/recommendations.state.spec.ts
+++ b/src/app/recommendations/state/recommendations.state.spec.ts
@@ -11,15 +11,15 @@ import { DEFAULT_SORT } from "../../shared/records/constants";
 import { mockRecommendationsResponse } from "../services/recommendations.service.spec";
 import { RecommendationsFilterType } from "../recommendations.interfaces";
 import {
-  ClearSearch,
-  Filter,
-  Get,
-  GetError,
-  Paginate,
-  ResetPaginator,
-  Search,
-  Sort
-} from "../../shared/records/state/records.actions";
+  ClearRecommendationsSearch,
+  FilterRecommendations,
+  GetRecommendations,
+  GetRecommendationsError,
+  PaginateRecommendations,
+  ResetRecommendationsPaginator,
+  RecommendationsSearch,
+  SortRecommendations
+} from "./recommendations.actions";
 import { RecommendationsState } from "./recommendations.state";
 
 describe("Recommendations state", () => {
@@ -49,7 +49,7 @@ describe("Recommendations state", () => {
   it("should dispatch 'Get' and invoke `getHandler`", () => {
     spyOn(recordsService, "getRecords").and.returnValue(of({}));
     store
-      .dispatch(new Get())
+      .dispatch(new GetRecommendations())
       .subscribe(() => expect(recordsService.getRecords).toHaveBeenCalled());
   });
 
@@ -58,7 +58,7 @@ describe("Recommendations state", () => {
       of(mockRecommendationsResponse)
     );
 
-    store.dispatch(new Get()).subscribe(() => {
+    store.dispatch(new GetRecommendations()).subscribe(() => {
       const items = store.snapshot().recommendations.items;
       expect(items.length).toEqual(2);
       expect(items[0].doctorFirstName).toEqual("Bobby");
@@ -70,7 +70,7 @@ describe("Recommendations state", () => {
       of(mockRecommendationsResponse)
     );
 
-    store.dispatch(new Get()).subscribe(() => {
+    store.dispatch(new GetRecommendations()).subscribe(() => {
       const countTotal = store.snapshot().recommendations.countTotal;
       expect(countTotal).toEqual(21312);
     });
@@ -86,49 +86,55 @@ describe("Recommendations state", () => {
       }
     });
 
-    store.dispatch(new GetError(mockError));
+    store.dispatch(new GetRecommendationsError(mockError));
     const error = store.snapshot().recommendations.error;
     expect(error).toEqual(`Error: ${mockError.error.message}`);
   });
 
   it("should dispatch 'Sort' and update store", () => {
-    store.dispatch(new Sort(DEFAULT_SORT.active, DEFAULT_SORT.direction));
+    store.dispatch(
+      new SortRecommendations(DEFAULT_SORT.active, DEFAULT_SORT.direction)
+    );
     const sort = store.snapshot().recommendations.sort;
     expect(sort).toEqual(DEFAULT_SORT);
   });
 
   it("should dispatch 'Paginate' and update store", () => {
-    store.dispatch(new Paginate(34));
+    store.dispatch(new PaginateRecommendations(34));
     const pageIndex = store.snapshot().recommendations.pageIndex;
     expect(pageIndex).toEqual(34);
   });
 
   it("should dispatch 'ResetPaginator' and update store", () => {
-    store.dispatch(new ResetPaginator());
+    store.dispatch(new ResetRecommendationsPaginator());
     const pageIndex = store.snapshot().recommendations.pageIndex;
     expect(pageIndex).toEqual(0);
   });
 
   it("should dispatch 'Search' and update store", () => {
-    store.dispatch(new Search("smith"));
+    store.dispatch(new RecommendationsSearch("smith"));
     const searchQuery = store.snapshot().recommendations.searchQuery;
     expect(searchQuery).toEqual("smith");
   });
 
   it("should dispatch 'ClearSearch' and update store", () => {
-    store.dispatch(new ClearSearch());
+    store.dispatch(new ClearRecommendationsSearch());
     const searchQuery = store.snapshot().recommendations.searchQuery;
     expect(searchQuery).toBeNull();
   });
 
   it("should dispatch 'Filter' with `underNotice` and update store", () => {
-    store.dispatch(new Filter(RecommendationsFilterType.UNDER_NOTICE));
+    store.dispatch(
+      new FilterRecommendations(RecommendationsFilterType.UNDER_NOTICE)
+    );
     const filter = store.snapshot().recommendations.filter;
     expect(filter).toEqual(RecommendationsFilterType.UNDER_NOTICE);
   });
 
   it("should dispatch 'Filter' with `allDoctors` and update store", () => {
-    store.dispatch(new Filter(RecommendationsFilterType.ALL_DOCTORS));
+    store.dispatch(
+      new FilterRecommendations(RecommendationsFilterType.ALL_DOCTORS)
+    );
     const filter = store.snapshot().recommendations.filter;
     expect(filter).toEqual(RecommendationsFilterType.ALL_DOCTORS);
   });

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -18,21 +18,21 @@ import {
   RecommendationsFilterType
 } from "../recommendations.interfaces";
 import {
-  ClearSearch,
-  EnableAllocateAdmin,
-  Filter,
-  Get,
-  GetError,
-  GetSuccess,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  ToggleAllCheckboxes,
-  ToggleCheckbox
-} from "../../shared/records/state/records.actions";
+  ClearRecommendationsSearch,
+  EnableRecommendationsAllocateAdmin,
+  FilterRecommendations,
+  GetRecommendations,
+  GetRecommendationsError,
+  GetRecommendationsSuccess,
+  PaginateRecommendations,
+  ResetRecommendationsFilter,
+  ResetRecommendationsPaginator,
+  ResetRecommendationsSort,
+  RecommendationsSearch,
+  SortRecommendations,
+  ToggleAllRecommendationsCheckboxes,
+  ToggleRecommendationsCheckbox
+} from "./recommendations.actions";
 
 export class RecommendationsStateModel extends RecordsStateModel<
   RecommendationsFilterType,
@@ -70,7 +70,7 @@ export class RecommendationsState extends RecordsState {
     return state.countUnderNotice;
   }
 
-  @Action(Get)
+  @Action(GetRecommendations)
   get(ctx: StateContext<RecommendationsStateModel>) {
     const params: HttpParams = this.recommendationsService.generateParams();
     const endPoint = `${environment.appUrls.getRecommendations}`;
@@ -88,10 +88,10 @@ export class RecommendationsState extends RecordsState {
           return response;
         }),
         switchMap((response: IGetRecommendationsResponse) =>
-          ctx.dispatch(new GetSuccess(response))
+          ctx.dispatch(new GetRecommendationsSuccess(response))
         ),
         catchError((error: HttpErrorResponse) =>
-          ctx.dispatch(new GetError(error))
+          ctx.dispatch(new GetRecommendationsError(error))
         ),
         finalize(() =>
           ctx.patchState({
@@ -102,10 +102,10 @@ export class RecommendationsState extends RecordsState {
       .subscribe();
   }
 
-  @Action(GetSuccess)
+  @Action(GetRecommendationsSuccess)
   getSuccess(
     ctx: StateContext<RecommendationsStateModel>,
-    action: GetSuccess<IGetRecommendationsResponse>
+    action: GetRecommendationsSuccess
   ) {
     super.getSuccessHandler(ctx, action, "traineeInfo");
 
@@ -115,50 +115,62 @@ export class RecommendationsState extends RecordsState {
     });
   }
 
-  @Action(GetError)
-  getError(ctx: StateContext<RecommendationsStateModel>, action: GetError) {
+  @Action(GetRecommendationsError)
+  getError(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: GetRecommendationsError
+  ) {
     return super.getErrorHandler(ctx, action);
   }
 
-  @Action(Sort)
-  sort(ctx: StateContext<RecommendationsStateModel>, action: Sort) {
+  @Action(SortRecommendations)
+  sort(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: SortRecommendations
+  ) {
     return super.sortHandler(ctx, action);
   }
 
-  @Action(ResetSort)
+  @Action(ResetRecommendationsSort)
   resetSort(ctx: StateContext<RecommendationsStateModel>) {
     return super.resetSortHandler(ctx, DEFAULT_SORT);
   }
 
-  @Action(Paginate)
-  paginate(ctx: StateContext<RecommendationsStateModel>, action: Paginate) {
+  @Action(PaginateRecommendations)
+  paginate(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: PaginateRecommendations
+  ) {
     return super.paginateHandler(ctx, action);
   }
 
-  @Action(ResetPaginator)
+  @Action(ResetRecommendationsPaginator)
   resetPaginator(ctx: StateContext<RecommendationsStateModel>) {
     return super.resetPaginatorHandler(ctx);
   }
 
-  @Action(Search)
-  search(ctx: StateContext<RecommendationsStateModel>, action: Search) {
+  @Action(RecommendationsSearch)
+  search(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: RecommendationsSearch
+  ) {
     return super.searchHandler(ctx, action);
   }
 
-  @Action(ClearSearch)
+  @Action(ClearRecommendationsSearch)
   clearSearch(ctx: StateContext<RecommendationsStateModel>) {
     return super.clearSearchHandler(ctx);
   }
 
-  @Action(Filter)
+  @Action(FilterRecommendations)
   filter(
     ctx: StateContext<RecommendationsStateModel>,
-    action: Filter<RecommendationsFilterType>
+    action: FilterRecommendations
   ) {
     return super.filterHandler(ctx, action);
   }
 
-  @Action(ResetFilter)
+  @Action(ResetRecommendationsFilter)
   resetFilter(ctx: StateContext<RecommendationsStateModel>) {
     return super.resetFilterHandler(
       ctx,
@@ -166,23 +178,23 @@ export class RecommendationsState extends RecordsState {
     );
   }
 
-  @Action(EnableAllocateAdmin)
+  @Action(EnableRecommendationsAllocateAdmin)
   enableAllocateAdmin(
     ctx: StateContext<RecommendationsStateModel>,
-    action: EnableAllocateAdmin
+    action: EnableRecommendationsAllocateAdmin
   ) {
     return super.enableAllocateAdminHandler(ctx, action.enableAllocateAdmin);
   }
 
-  @Action(ToggleCheckbox)
+  @Action(ToggleRecommendationsCheckbox)
   toggleCheckbox(
     ctx: StateContext<RecommendationsStateModel>,
-    action: ToggleCheckbox
+    action: ToggleRecommendationsCheckbox
   ) {
     return super.toggleCheckboxHandler(ctx, action);
   }
 
-  @Action(ToggleAllCheckboxes)
+  @Action(ToggleAllRecommendationsCheckboxes)
   toggleAllCheckboxes(ctx: StateContext<RecommendationsStateModel>) {
     return super.toggleAllCheckboxesHandler(ctx);
   }

--- a/src/app/shared/material/material.module.ts
+++ b/src/app/shared/material/material.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from "@angular/core";
 import { LayoutModule } from "@angular/cdk/layout";
+import { MatAutocompleteModule } from "@angular/material/autocomplete";
 import { MatChipsModule } from "@angular/material/chips";
 import { MatPaginatorModule } from "@angular/material/paginator";
 import { MatSortModule } from "@angular/material/sort";
@@ -56,7 +57,8 @@ const materialModules = [
   MatChipsModule,
   MatStepperModule,
   MatCheckboxModule,
-  MatSnackBarModule
+  MatSnackBarModule,
+  MatAutocompleteModule
 ];
 
 @NgModule({

--- a/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.html
+++ b/src/app/shared/records/allocate-admin-actions/allocate-admin-actions.component.html
@@ -1,4 +1,4 @@
-<div class="pt-30 pl-15" *ngIf="enableAllocateAdmin$ | async">
+<div class="pt-30 pb-30 pl-15" *ngIf="enableAllocateAdmin$ | async">
   <button mat-button mat-raised-button class="mr-10" (click)="cancel()">
     Cancel
   </button>

--- a/src/app/shared/records/allocate-admin-autocomplete/allocate-admin-autocomplete.component.html
+++ b/src/app/shared/records/allocate-admin-autocomplete/allocate-admin-autocomplete.component.html
@@ -1,0 +1,17 @@
+<form [formGroup]="form" *ngIf="items$ | async">
+  <mat-form-field>
+    <input
+      type="text"
+      placeholder="Allocate admin"
+      aria-label="Allocate admin"
+      matInput
+      [formControlName]="'autocomplete'"
+      [matAutocomplete]="auto"
+    />
+    <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayWith">
+      <mat-option *ngFor="let i of filteredItems$ | async" [value]="i">
+        {{ i.Username }}
+      </mat-option>
+    </mat-autocomplete>
+  </mat-form-field>
+</form>

--- a/src/app/shared/records/allocate-admin-autocomplete/allocate-admin-autocomplete.component.spec.ts
+++ b/src/app/shared/records/allocate-admin-autocomplete/allocate-admin-autocomplete.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { MaterialModule } from "../../material/material.module";
+
+import { AllocateAdminAutocompleteComponent } from "./allocate-admin-autocomplete.component";
+
+describe("AllocateAdminAutocompleteComponent", () => {
+  let component: AllocateAdminAutocompleteComponent;
+  let fixture: ComponentFixture<AllocateAdminAutocompleteComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AllocateAdminAutocompleteComponent],
+      imports: [ReactiveFormsModule, NoopAnimationsModule, MaterialModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AllocateAdminAutocompleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/records/allocate-admin-autocomplete/allocate-admin-autocomplete.component.ts
+++ b/src/app/shared/records/allocate-admin-autocomplete/allocate-admin-autocomplete.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from "@angular/core";
+import { FormBuilder, FormGroup } from "@angular/forms";
+import { Select } from "@ngxs/store";
+import { UserType } from "aws-sdk/clients/cognitoidentityserviceprovider";
+import { Observable } from "rxjs";
+import { distinctUntilChanged, map, startWith, take } from "rxjs/operators";
+import { AdminsState } from "../../admins/state/admins.state";
+
+@Component({
+  selector: "app-allocate-admin-autocomplete",
+  templateUrl: "./allocate-admin-autocomplete.component.html"
+})
+export class AllocateAdminAutocompleteComponent implements OnInit {
+  @Select(AdminsState.items) public items$: Observable<UserType[]>;
+  public filteredItems$: Observable<UserType[]>;
+  public form: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.setupForm();
+    this.getItems();
+  }
+
+  public setupForm(): void {
+    this.form = this.formBuilder.group({ autocomplete: null });
+  }
+
+  public getItems(): void {
+    this.items$
+      .pipe(take(1))
+      .subscribe((items: UserType[]) => this.filterItems(items));
+  }
+
+  public displayWith(item: UserType): string {
+    return item ? item.Username : null;
+  }
+
+  public filterItems(items: UserType[]) {
+    this.filteredItems$ = this.form.get("autocomplete").valueChanges.pipe(
+      startWith(""),
+      distinctUntilChanged(),
+      map((value: any) => (value.Username ? value.Username : value)),
+      map((value: string) => this.filter(value, items))
+    );
+  }
+
+  private filter(value: string, items): any {
+    const filterValue = value.toLowerCase();
+
+    return items.filter((i: UserType) =>
+      i.Username.toLowerCase().includes(filterValue.toLowerCase())
+    );
+  }
+}

--- a/src/app/shared/records/record-list/record-list.component.html
+++ b/src/app/shared/records/record-list/record-list.component.html
@@ -102,12 +102,26 @@
                   ></mat-checkbox>
                 </ng-container>
 
-                <!-- cell value -->
-                <ng-container
-                  *ngIf="dateColumns.includes(i.name); else noPipe"
-                  >{{ element[i.name] | date: dateFormat }}</ng-container
-                >
-                <ng-template #noPipe>{{ element[i.name] }}</ng-template>
+                <!-- cell value | format date -->
+                <ng-container *ngIf="dateColumns.includes(i.name); else noPipe">
+                  {{ element[i.name] | date: dateFormat }}
+                </ng-container>
+
+                <!-- cell value | no formatting needed -->
+                <ng-template #noPipe>
+                  <!-- render allocate admin component -->
+                  <ng-container
+                    *ngIf="
+                      data.enableAllocateAdmin && i.name === 'admin';
+                      else renderData
+                    "
+                  >
+                    <app-allocate-admin-autocomplete></app-allocate-admin-autocomplete>
+                  </ng-container>
+
+                  <!-- render data -->
+                  <ng-template #renderData>{{ element[i.name] }}</ng-template>
+                </ng-template>
               </td>
             </ng-container>
 

--- a/src/app/shared/records/record-list/record-list.component.spec.ts
+++ b/src/app/shared/records/record-list/record-list.component.spec.ts
@@ -10,19 +10,19 @@ import { RecommendationStatus } from "../../../recommendation/recommendation-his
 import { IRecommendation } from "../../../recommendations/recommendations.interfaces";
 import { mockRecommendationsResponse } from "../../../recommendations/services/recommendations.service.spec";
 import {
-  ClearSearch,
-  EnableAllocateAdmin,
-  Filter,
-  Get,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  ToggleAllCheckboxes,
-  ToggleCheckbox
-} from "../state/records.actions";
+  ClearRecommendationsSearch,
+  EnableRecommendationsAllocateAdmin,
+  FilterRecommendations,
+  GetRecommendations,
+  PaginateRecommendations,
+  ResetRecommendationsFilter,
+  ResetRecommendationsPaginator,
+  ResetRecommendationsSort,
+  RecommendationsSearch,
+  SortRecommendations,
+  ToggleAllRecommendationsCheckboxes,
+  ToggleRecommendationsCheckbox
+} from "../../../recommendations/state/recommendations.actions";
 import { RecommendationsState } from "../../../recommendations/state/recommendations.state";
 import { MaterialModule } from "../../material/material.module";
 import { DEFAULT_SORT, generateColumnData } from "../constants";
@@ -57,18 +57,18 @@ describe("RecordListComponent", () => {
     component = fixture.componentInstance;
     recordsService.stateName = "recommendations";
     recordsService.setActions(
-      ClearSearch,
-      Filter,
-      Get,
-      Paginate,
-      ResetFilter,
-      ResetPaginator,
-      ResetSort,
-      Search,
-      Sort,
-      EnableAllocateAdmin,
-      ToggleAllCheckboxes,
-      ToggleCheckbox
+      ClearRecommendationsSearch,
+      FilterRecommendations,
+      GetRecommendations,
+      PaginateRecommendations,
+      ResetRecommendationsFilter,
+      ResetRecommendationsPaginator,
+      ResetRecommendationsSort,
+      RecommendationsSearch,
+      SortRecommendations,
+      EnableRecommendationsAllocateAdmin,
+      ToggleAllRecommendationsCheckboxes,
+      ToggleRecommendationsCheckbox
     );
     fixture.detectChanges();
   });

--- a/src/app/shared/records/record-search/record-search.component.html
+++ b/src/app/shared/records/record-search/record-search.component.html
@@ -34,6 +34,7 @@
         color="primary"
         aria-label="Recommendations search"
         type="submit"
+        [disabled]="enableAllocateAdmin$ | async"
       >
         <mat-icon aria-label="search icon">search</mat-icon>
       </button>

--- a/src/app/shared/records/record-search/record-search.component.spec.ts
+++ b/src/app/shared/records/record-search/record-search.component.spec.ts
@@ -8,19 +8,19 @@ import { NgxsModule, Store } from "@ngxs/store";
 import { MaterialModule } from "../../material/material.module";
 import { RecordsService } from "../services/records.service";
 import {
-  ClearSearch,
-  EnableAllocateAdmin,
-  Filter,
-  Get,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  ToggleAllCheckboxes,
-  ToggleCheckbox
-} from "../state/records.actions";
+  ClearRecommendationsSearch,
+  EnableRecommendationsAllocateAdmin,
+  FilterRecommendations,
+  GetRecommendations,
+  PaginateRecommendations,
+  ResetRecommendationsFilter,
+  ResetRecommendationsPaginator,
+  ResetRecommendationsSort,
+  RecommendationsSearch,
+  SortRecommendations,
+  ToggleAllRecommendationsCheckboxes,
+  ToggleRecommendationsCheckbox
+} from "../../../recommendations/state/recommendations.actions";
 import { RecommendationsState } from "../../../recommendations/state/recommendations.state";
 import { RecordSearchComponent } from "./record-search.component";
 
@@ -52,18 +52,18 @@ describe("RecordSearchComponent", () => {
     component = fixture.componentInstance;
     recordsService.stateName = "recommendations";
     recordsService.setActions(
-      ClearSearch,
-      Filter,
-      Get,
-      Paginate,
-      ResetFilter,
-      ResetPaginator,
-      ResetSort,
-      Search,
-      Sort,
-      EnableAllocateAdmin,
-      ToggleAllCheckboxes,
-      ToggleCheckbox
+      ClearRecommendationsSearch,
+      FilterRecommendations,
+      GetRecommendations,
+      PaginateRecommendations,
+      ResetRecommendationsFilter,
+      ResetRecommendationsPaginator,
+      ResetRecommendationsSort,
+      RecommendationsSearch,
+      SortRecommendations,
+      EnableRecommendationsAllocateAdmin,
+      ToggleAllRecommendationsCheckboxes,
+      ToggleRecommendationsCheckbox
     );
     fixture.detectChanges();
   });
@@ -120,9 +120,13 @@ describe("RecordSearchComponent", () => {
     component.submitForm("87723113");
 
     expect(store.dispatch).toHaveBeenCalledTimes(3);
-    expect(store.dispatch).toHaveBeenCalledWith(new Search("87723113"));
-    expect(store.dispatch).toHaveBeenCalledWith(new ResetSort());
-    expect(store.dispatch).toHaveBeenCalledWith(new ResetPaginator());
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new RecommendationsSearch("87723113")
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(new ResetRecommendationsSort());
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new ResetRecommendationsPaginator()
+    );
     expect(recordsService.updateRoute).toHaveBeenCalled();
   });
 

--- a/src/app/shared/records/record-search/record-search.component.ts
+++ b/src/app/shared/records/record-search/record-search.component.ts
@@ -37,9 +37,12 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   }
 
   public setupForm(): void {
-    this.form = this.formBuilder.group({
-      searchQuery: [null, [Validators.required]]
-    });
+    this.form = this.formBuilder.group(
+      {
+        searchQuery: [null, [Validators.required]]
+      },
+      { updateOn: "submit" }
+    );
   }
 
   /**

--- a/src/app/shared/records/records.module.ts
+++ b/src/app/shared/records/records.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MaterialModule } from "../material/material.module";
 import { AllocateAdminActionsComponent } from "./allocate-admin-actions/allocate-admin-actions.component";
+import { AllocateAdminAutocompleteComponent } from "./allocate-admin-autocomplete/allocate-admin-autocomplete.component";
 import { AllocateAdminBtnComponent } from "./allocate-admin-btn/allocate-admin-btn.component";
 import { RecordListComponent } from "./record-list/record-list.component";
 import { RecordSearchComponent } from "./record-search/record-search.component";
@@ -13,7 +14,8 @@ const components: any[] = [
   RecordSearchComponent,
   ResetRecordListComponent,
   AllocateAdminBtnComponent,
-  AllocateAdminActionsComponent
+  AllocateAdminActionsComponent,
+  AllocateAdminAutocompleteComponent
 ];
 
 @NgModule({

--- a/src/app/shared/records/reset-record-list/reset-record-list.component.spec.ts
+++ b/src/app/shared/records/reset-record-list/reset-record-list.component.spec.ts
@@ -6,19 +6,19 @@ import { NgxsModule } from "@ngxs/store";
 import { MaterialModule } from "../../material/material.module";
 import { RecordsService } from "../services/records.service";
 import {
-  ClearSearch,
-  EnableAllocateAdmin,
-  Filter,
-  Get,
-  Paginate,
-  ResetFilter,
-  ResetPaginator,
-  ResetSort,
-  Search,
-  Sort,
-  ToggleAllCheckboxes,
-  ToggleCheckbox
-} from "../state/records.actions";
+  ClearRecommendationsSearch,
+  EnableRecommendationsAllocateAdmin,
+  FilterRecommendations,
+  GetRecommendations,
+  PaginateRecommendations,
+  ResetRecommendationsFilter,
+  ResetRecommendationsPaginator,
+  ResetRecommendationsSort,
+  RecommendationsSearch,
+  SortRecommendations,
+  ToggleAllRecommendationsCheckboxes,
+  ToggleRecommendationsCheckbox
+} from "../../../recommendations/state/recommendations.actions";
 import { RecommendationsState } from "../../../recommendations/state/recommendations.state";
 import { ResetRecordListComponent } from "./reset-record-list.component";
 
@@ -49,18 +49,18 @@ describe("ResetRecordListComponent", () => {
     fixture.detectChanges();
     recordsService.stateName = "recommendations";
     recordsService.setActions(
-      ClearSearch,
-      Filter,
-      Get,
-      Paginate,
-      ResetFilter,
-      ResetPaginator,
-      ResetSort,
-      Search,
-      Sort,
-      EnableAllocateAdmin,
-      ToggleAllCheckboxes,
-      ToggleCheckbox
+      ClearRecommendationsSearch,
+      FilterRecommendations,
+      GetRecommendations,
+      PaginateRecommendations,
+      ResetRecommendationsFilter,
+      ResetRecommendationsPaginator,
+      ResetRecommendationsSort,
+      RecommendationsSearch,
+      SortRecommendations,
+      EnableRecommendationsAllocateAdmin,
+      ToggleAllRecommendationsCheckboxes,
+      ToggleRecommendationsCheckbox
     );
   });
 

--- a/src/app/shared/records/state/records.actions.ts
+++ b/src/app/shared/records/state/records.actions.ts
@@ -1,68 +1,34 @@
 import { HttpErrorResponse } from "@angular/common/http";
 import { SortDirection } from "@angular/material/sort/sort-direction";
 
-const label = `[Records]`;
-
-export class Get {
-  static readonly type = `${label} Get`;
-}
-
-export class GetSuccess<T> {
-  static readonly type = `${label} Get Success`;
+export class GetSuccessPayload<T> {
   constructor(public response: T) {}
 }
 
-export class GetError {
-  static readonly type = `${label} Get Error`;
+export class GetErrorPayload {
   constructor(public error: HttpErrorResponse) {}
 }
 
-export class Sort {
-  static readonly type = `${label} Sort`;
+export class SortPayload {
   constructor(public column: string, public direction: SortDirection) {}
 }
 
-export class ResetSort {
-  static readonly type = `${label} Reset Sort`;
-}
-
-export class Filter<T> {
-  static readonly type = `${label} Filter`;
+export class FilterPayload<T> {
   constructor(public filter: T) {}
 }
 
-export class ResetFilter {
-  static readonly type = `${label} Reset Filter`;
-}
-
-export class Search {
-  static readonly type = `${label} Search`;
+export class SearchPayload {
   constructor(public searchQuery: string) {}
 }
 
-export class ClearSearch {
-  static readonly type = `${label} Clear Search`;
-}
-
-export class Paginate {
-  static readonly type = `${label} Paginate`;
+export class PaginatePayload {
   constructor(public pageIndex: number) {}
 }
 
-export class ResetPaginator {
-  static readonly type = `${label} Reset Paginator`;
-}
-
-export class EnableAllocateAdmin {
-  static readonly type = `${label} Enable Allocate Admin`;
+export class EnableAllocateAdminPayload {
   constructor(public enableAllocateAdmin: boolean) {}
 }
 
-export class ToggleCheckbox {
-  static readonly type = `${label} Toggle Checkbox`;
+export class ToggleCheckboxPayload {
   constructor(public gmcReferenceNumber: string) {}
-}
-
-export class ToggleAllCheckboxes {
-  static readonly type = `${label} Toggle All Checkboxes`;
 }

--- a/src/app/shared/records/state/records.state.ts
+++ b/src/app/shared/records/state/records.state.ts
@@ -201,12 +201,12 @@ export class RecordsState {
   protected someCheckedHandler(ctx: StateContext<any>) {
     const stateItems: any[] = ctx.getState().items;
     const checkedItems: any[] = stateItems.filter((i) => i.checked);
+    const someChecked: boolean =
+      !!checkedItems.length && checkedItems.length !== stateItems.length;
+    const allChecked: boolean =
+      !!checkedItems.length && checkedItems.length === stateItems.length;
 
-    ctx.patchState({ someChecked: !!checkedItems.length });
-
-    if (checkedItems.length === stateItems.length) {
-      ctx.patchState({ allChecked: !!checkedItems.length, someChecked: false });
-    }
+    ctx.patchState({ allChecked, someChecked });
   }
 
   protected toggleAllCheckboxesHandler(ctx: StateContext<any>) {
@@ -225,5 +225,7 @@ export class RecordsState {
         })
       );
     });
+
+    this.someCheckedHandler(ctx);
   }
 }


### PR DESCRIPTION
TISNEW-4831

- put back concerns, connections and recommendations actions as they are needed for NGXS to distinguish between which state store to work from. updated specs, state, components, resolvers accordingly
- created new `AllocateAdminAutocomplete` component in order to display and filter admins list on the ui once in allocate admin mode
- ensured search component validation is triggered on submit instead of blur as requested