### PR TITLE
fix: conditionally displaying checkbox cell

### DIFF
--- a/src/app/shared/records/constants.ts
+++ b/src/app/shared/records/constants.ts
@@ -8,10 +8,6 @@ export const DEFAULT_SORT: Sort = {
 
 export const RECORDS_COLUMN_DATA: IRecordDataCell[] = [
   {
-    isCheckbox: true,
-    name: "checkbox"
-  },
-  {
     label: "First name",
     name: "doctorFirstName",
     enableSort: true

--- a/src/app/shared/records/record-list/record-list.component.html
+++ b/src/app/shared/records/record-list/record-list.component.html
@@ -49,57 +49,45 @@
               *ngFor="let i of columnData"
               matColumnDef="{{ i.name }}"
             >
-              <!-- Header cells -->
-              <ng-container *ngIf="i.enableSort; else disabledSort">
-                <th
-                  mat-header-cell
-                  *matHeaderCellDef
-                  [mat-sort-header]="i.name"
-                  scope="col"
-                  [disabled]="data.enableAllocateAdmin"
+              <!-- header cell -->
+              <th
+                mat-header-cell
+                *matHeaderCellDef
+                [mat-sort-header]="i.name"
+                scope="col"
+                [disabled]="data.enableAllocateAdmin || !i.enableSort"
+              >
+                <mat-checkbox
+                  *ngIf="
+                    data.enableAllocateAdmin && i.name === 'doctorFirstName'
+                  "
+                  [checked]="data.allChecked"
+                  [indeterminate]="data.someChecked"
+                  (change)="toggleAllCheckboxes()"
+                  class="pr-20"
                 >
-                  {{ i.label }}
-                </th>
-              </ng-container>
-              <ng-template #disabledSort>
-                <th
-                  mat-header-cell
-                  *matHeaderCellDef
-                  [mat-sort-header]="i.name"
-                  scope="col"
-                  disabled
-                  [class.checkbox]="data.enableAllocateAdmin"
-                >
-                  <!-- toggle all checkboxes -->
-                  <ng-container
-                    *ngIf="
-                      data.enableAllocateAdmin && i.isCheckbox;
-                      else nonCheckbox
-                    "
-                  >
-                    <mat-checkbox
-                      [checked]="data.allChecked"
-                      [indeterminate]="data.someChecked"
-                      (change)="toggleAllCheckboxes()"
-                    >
-                    </mat-checkbox>
-                  </ng-container>
-
-                  <!-- header label -->
-                  <ng-template #nonCheckbox>
-                    {{ i.label }}
-                  </ng-template>
-                </th>
-              </ng-template>
+                </mat-checkbox>
+                {{ i.label }}
+              </th>
 
               <!-- mat cell -->
               <td mat-cell *matCellDef="let element">
-                <!-- checkbox -->
-                <ng-container *ngIf="data.enableAllocateAdmin && i.isCheckbox">
-                  <mat-checkbox
-                    [checked]="element.checked"
-                    (change)="toggleCheckbox(element.gmcReferenceNumber)"
-                  ></mat-checkbox>
+                <ng-container *ngIf="data.enableAllocateAdmin">
+                  <!-- checkbox -->
+                  <ng-container *ngIf="i.name === 'doctorFirstName'">
+                    <mat-checkbox
+                      class="pr-20"
+                      [checked]="element.checked"
+                      (change)="toggleCheckbox(element.gmcReferenceNumber)"
+                    ></mat-checkbox>
+                  </ng-container>
+
+                  <!-- render allocate admin component -->
+                  <ng-container *ngIf="i.name === 'admin'">
+                    <app-allocate-admin-autocomplete
+                      [gmcNumber]="element.gmcReferenceNumber"
+                    ></app-allocate-admin-autocomplete>
+                  </ng-container>
                 </ng-container>
 
                 <!-- cell value | format date -->
@@ -108,22 +96,7 @@
                 </ng-container>
 
                 <!-- cell value | no formatting needed -->
-                <ng-template #noPipe>
-                  <!-- render allocate admin component -->
-                  <ng-container
-                    *ngIf="
-                      data.enableAllocateAdmin && i.name === 'admin';
-                      else renderData
-                    "
-                  >
-                    <app-allocate-admin-autocomplete
-                      [gmcNumber]="element.gmcReferenceNumber"
-                    ></app-allocate-admin-autocomplete>
-                  </ng-container>
-
-                  <!-- render data -->
-                  <ng-template #renderData>{{ element[i.name] }}</ng-template>
-                </ng-template>
+                <ng-template #noPipe>{{ element[i.name] }}</ng-template>
               </td>
             </ng-container>
 

--- a/src/app/shared/records/record-list/record-list.component.scss
+++ b/src/app/shared/records/record-list/record-list.component.scss
@@ -1,9 +1,5 @@
 @import "~nhsuk-frontend/packages/core/settings/colours";
 
-.checkbox {
-  padding-right: 20px;
-}
-
 .highlight-row-warn td:first-child {
   padding-left: 20px;
 }

--- a/src/app/shared/records/record-list/record-list.component.spec.ts
+++ b/src/app/shared/records/record-list/record-list.component.spec.ts
@@ -101,7 +101,7 @@ describe("RecordListComponent", () => {
   it("`columnNames()` should return an array of strings", () => {
     component.columnData = generateColumnData(COLUMN_DATA);
     expect(component.columnNames).toBeInstanceOf(Array);
-    expect(component.columnNames[1]).toEqual("doctorFirstName");
+    expect(component.columnNames[0]).toEqual("doctorFirstName");
   });
 
   it("'navigateToDetails()' should navigate to details route", () => {


### PR DESCRIPTION
NO-TICKET

conditionally displaying checkbox cell

- cleanup and simplify markup to ensure an extra table cell is not created when allocate admin is enabled. when allocate admin is disabled it was causing an empty cell to render