### PR TITLE
feat: consume download api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11019,6 +11019,11 @@
         "schema-utils": "^2.6.5"
       }
     },
+    "file-saver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,16 +38,17 @@
     "@angular/service-worker": "^9.1.11",
     "@ngxs/logger-plugin": "^3.6.2",
     "@ngxs/store": "^3.6.2",
+    "@sentry/browser": "^5.11.0",
     "angulartics2": "^9.1.0",
     "aws-amplify": "^3.0.18",
-    "browserslist": "^4.13.0",
     "aws-sdk": "^2.714.0",
+    "browserslist": "^4.13.0",
     "caniuse-lite": "^1.0.30001099",
+    "file-saver": "^2.0.2",
     "nhsuk-frontend": "^3.1.0",
     "rxjs": "~6.6.0",
     "tslib": "^1.13.0",
-    "zone.js": "~0.10.3",
-    "@sentry/browser": "^5.11.0"
+    "zone.js": "~0.10.3"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.901.11",

--- a/src/app/concern/concern.interfaces.ts
+++ b/src/app/concern/concern.interfaces.ts
@@ -3,6 +3,13 @@ export interface IGetConcernResponse {
   concerns: IConcernSummary[];
 }
 
+export interface IListFile {
+  bucketName: string;
+  fileName: string;
+  fileType: string;
+  key: string;
+}
+
 export interface IConcernSummary {
   admin: string;
   comments: string[];

--- a/src/app/concern/constants.ts
+++ b/src/app/concern/constants.ts
@@ -28,3 +28,5 @@ export const ACCEPTED_IMAGE_FILE_TYPES: string[] = [
   ".tiff",
   ".webp"
 ];
+
+export const FILE_BUCKET_NAME = "tis-test-bucket-2020";

--- a/src/app/concern/file-uploader/file-uploader.component.html
+++ b/src/app/concern/file-uploader/file-uploader.component.html
@@ -1,7 +1,7 @@
 <!-- spinner -->
 <div
   class="d-flex align-items-center mb-25"
-  *ngIf="uploadInProgress$ | async; else notLoading"
+  *ngIf="uploadFileInProgress$ | async; else notLoading"
 >
   <mat-spinner [diameter]="50"></mat-spinner>
   <span class="pl-15">Upload in progress...</span>
@@ -14,8 +14,8 @@
       #dropArea
       (dragenter)="preventDefaults($event); highlight()"
       (dragover)="preventDefaults($event); highlight()"
-      (dragleave)="preventDefaults($event); unhighlight()"
-      (drop)="preventDefaults($event); unhighlight(); handleDrop($event)"
+      (dragleave)="preventDefaults($event); unHighlight()"
+      (drop)="preventDefaults($event); unHighlight(); handleDrop($event)"
     >
       <p class="pr-10">
         Drag and drop supporting documents, or click attach icon to upload:

--- a/src/app/concern/file-uploader/file-uploader.component.spec.ts
+++ b/src/app/concern/file-uploader/file-uploader.component.spec.ts
@@ -2,14 +2,19 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
-import { NgxsModule } from "@ngxs/store";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { NgxsModule, Store } from "@ngxs/store";
 import { MaterialModule } from "../../shared/material/material.module";
+import { SnackBarService } from "../../shared/services/snack-bar/snack-bar.service";
+import { Upload } from "../state/concern.actions";
 import { ConcernState } from "../state/concern.state";
 import { FileUploaderComponent } from "./file-uploader.component";
 
 describe("FileUploaderComponent", () => {
+  let store: Store;
   let component: FileUploaderComponent;
   let fixture: ComponentFixture<FileUploaderComponent>;
+  let snackBarService: SnackBarService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -18,10 +23,14 @@ describe("FileUploaderComponent", () => {
         ReactiveFormsModule,
         MaterialModule,
         HttpClientTestingModule,
+        NoopAnimationsModule,
         NgxsModule.forRoot([ConcernState])
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
+    store = TestBed.inject(Store);
+    snackBarService = TestBed.inject(SnackBarService);
+    store.reset({ concern: { gmcNumber: 8119389 } });
   }));
 
   beforeEach(() => {
@@ -32,5 +41,92 @@ describe("FileUploaderComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("ngOnInit() should invoke `setupForm()`", () => {
+    spyOn(component, "setupForm");
+    component.ngOnInit();
+    expect(component.setupForm).toHaveBeenCalled();
+  });
+
+  it("preventDefaults() should stop propagation and prevent default event`", () => {
+    const $event: MouseEvent = new MouseEvent("drag", {
+      bubbles: true,
+      cancelable: true
+    });
+
+    spyOn($event, "preventDefault");
+    spyOn($event, "stopPropagation");
+
+    component.preventDefaults($event);
+
+    expect($event.preventDefault).toHaveBeenCalled();
+    expect($event.stopPropagation).toHaveBeenCalled();
+  });
+
+  it("highlight() should add 'highlight' class", () => {
+    const dropArea: Element = component.dropArea.nativeElement;
+    component.highlight();
+    expect(dropArea.classList.contains("highlight")).toBeTrue();
+  });
+
+  it("unHighlight() should remove 'highlight' class", () => {
+    const dropArea: Element = component.dropArea.nativeElement;
+    component.unHighlight();
+    expect(dropArea.classList.contains("highlight")).toBeFalse();
+  });
+
+  it("handleDrop() should invoke `upload()` if valid files have been dropped", () => {
+    spyOn(component, "upload");
+
+    const mockFile = new File([""], "mockfile.txt", { type: "text/plain" });
+    const mockEvt = {
+      dataTransfer: {
+        items: [{ type: mockFile.type, getAsFile: () => mockFile }]
+      }
+    };
+
+    component.handleDrop(mockEvt as any);
+    expect(component.upload).toHaveBeenCalledWith([mockFile]);
+  });
+
+  it("handleDrop() should invoke `snackBarService.openSnackBar()` if invalid files have been dropped", () => {
+    spyOn(snackBarService, "openSnackBar");
+
+    const mockFile = new File([""], "mockfile.zip", {
+      type: "application/zip"
+    });
+    const mockEvt = {
+      dataTransfer: {
+        items: [{ type: mockFile.type, getAsFile: () => mockFile }]
+      }
+    };
+
+    component.handleDrop(mockEvt as any);
+    expect(snackBarService.openSnackBar).toHaveBeenCalledWith(
+      `${mockFile.name} not valid`
+    );
+  });
+
+  it("onFilesSelection() should invoke `upload()`", () => {
+    spyOn(component, "upload");
+
+    const mockFile = new File([""], "filename", { type: "text/html" });
+    const mockEvt = { target: { files: [mockFile] } };
+
+    component.onFilesSelection(mockEvt as any);
+    expect(component.upload).toHaveBeenCalledWith([mockFile]);
+  });
+
+  it("upload() should reset form", () => {
+    spyOn(component.form, "reset");
+    component.upload([]);
+    expect(component.form.reset).toHaveBeenCalled();
+  });
+
+  it("upload() should dispatch `Upload` event", () => {
+    spyOn(store, "dispatch");
+    component.upload([]);
+    expect(store.dispatch).toHaveBeenCalledWith(new Upload(8119389, []));
   });
 });

--- a/src/app/concern/file-uploader/file-uploader.component.ts
+++ b/src/app/concern/file-uploader/file-uploader.component.ts
@@ -16,7 +16,7 @@ import { ConcernState } from "../state/concern.state";
 export class FileUploaderComponent implements OnInit {
   public acceptedFileTypes: string[] = [
     ...ACCEPTED_IMAGE_FILE_TYPES,
-    ".pdf",
+    "application/pdf",
     ".doc",
     ".docx",
     "application/msword",
@@ -26,9 +26,8 @@ export class FileUploaderComponent implements OnInit {
   ];
   public form: FormGroup;
   public gmcNumber: number = this.store.selectSnapshot(ConcernState.gmcNumber);
-  @Select(ConcernState.uploadInProgress) public uploadInProgress$: Observable<
-    boolean
-  >;
+  @Select(ConcernState.uploadFileInProgress)
+  public uploadFileInProgress$: Observable<boolean>;
   @ViewChild("dropArea") dropArea: ElementRef;
 
   constructor(
@@ -46,16 +45,16 @@ export class FileUploaderComponent implements OnInit {
     this.form = this.formBuilder.group({ fileUploader: null });
   }
 
-  public preventDefaults(e: Event): void {
-    e.preventDefault();
-    e.stopPropagation();
+  public preventDefaults($event: Event): void {
+    $event.preventDefault();
+    $event.stopPropagation();
   }
 
   public highlight(): void {
     this.dropArea.nativeElement.classList.add("highlight");
   }
 
-  public unhighlight(): void {
+  public unHighlight(): void {
     this.dropArea.nativeElement.classList.remove("highlight");
   }
 

--- a/src/app/concern/services/upload/upload.service.spec.ts
+++ b/src/app/concern/services/upload/upload.service.spec.ts
@@ -1,19 +1,45 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { HttpParams } from "@angular/common/http";
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
-
+import { environment } from "@environment";
 import { UploadService } from "./upload.service";
 
 describe("UploadService", () => {
   let service: UploadService;
+  let http: HttpTestingController;
+  let params: HttpParams;
+  const mockKey = "119389/8119389/mockfile.txt";
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     });
     service = TestBed.inject(UploadService);
+    http = TestBed.inject(HttpTestingController);
+    params = service.createDownloadFileParams(mockKey);
   });
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  it("`createDownloadFileParams()` should generate and return HttpParams", () => {
+    expect(params instanceof HttpParams).toBeTruthy();
+    expect(params.get("key")).toEqual(mockKey);
+  });
+
+  it("`downloadFile()` should call api", () => {
+    const endPoint = `${environment.appUrls.downloadFile}`;
+    service.downloadFile(service.createDownloadFileParams(mockKey)).subscribe();
+
+    const mockHttp = http.expectOne(
+      `${endPoint}?bucketName=tis-test-bucket-2020&key=${mockKey}`
+    );
+    expect(mockHttp.request.method).toBe("GET");
+
+    http.verify();
   });
 });

--- a/src/app/concern/services/upload/upload.service.ts
+++ b/src/app/concern/services/upload/upload.service.ts
@@ -2,6 +2,8 @@ import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { environment } from "@environment";
 import { Observable, of } from "rxjs";
+import { IListFile } from "../../concern.interfaces";
+import { FILE_BUCKET_NAME } from "../../constants";
 
 @Injectable({
   providedIn: "root"
@@ -9,9 +11,9 @@ import { Observable, of } from "rxjs";
 export class UploadService {
   constructor(private http: HttpClient) {}
 
-  public generateRequest(gmcNumber: number, payload: File[]): FormData {
+  public createUploadRequest(gmcNumber: number, payload: File[]): FormData {
     const formData: FormData = new FormData();
-    formData.append("bucketName", "tis-test-bucket-2020");
+    formData.append("bucketName", FILE_BUCKET_NAME);
     // TODO once we can create a concern (FE & BE work not implemented yet)
     // swap out second gmcNumber with concernId
     formData.append("folderPath", `${gmcNumber}/${gmcNumber}`);
@@ -20,28 +22,38 @@ export class UploadService {
   }
 
   public upload(payload: FormData): Observable<any> {
-    return this.http.post(environment.appUrls.fileUpload, payload);
+    return this.http.post(environment.appUrls.upload, payload);
   }
 
-  // TODO placeholder method
-  public download(): Observable<any> {
-    return of({});
-  }
-
-  public generateParams(gmcNumber: number): HttpParams {
+  public createDownloadFileParams(key: string): HttpParams {
     const params: HttpParams = new HttpParams()
-      .set("bucketName", "tis-test-bucket-2020")
+      .set("bucketName", FILE_BUCKET_NAME)
+      .set("key", key);
+
+    return params;
+  }
+
+  public downloadFile(params: HttpParams): Observable<Blob> {
+    return this.http.get(environment.appUrls.downloadFile, {
+      params,
+      responseType: "blob"
+    });
+  }
+
+  public createListFilesParams(gmcNumber: number): HttpParams {
+    const params: HttpParams = new HttpParams()
+      .set("bucketName", FILE_BUCKET_NAME)
       .set("folderPath", `${gmcNumber}/${gmcNumber}`);
 
     return params;
   }
 
-  public list(params: HttpParams): Observable<any> {
-    return this.http.get(environment.appUrls.fileList, { params });
+  public listFiles(params: HttpParams): Observable<IListFile[] | any> {
+    return this.http.get(environment.appUrls.listFiles, { params });
   }
 
   // TODO placeholder method
-  public delete(): Observable<any> {
+  public deleteFile(): Observable<any> {
     return of({});
   }
 }

--- a/src/app/concern/state/concern.actions.ts
+++ b/src/app/concern/state/concern.actions.ts
@@ -35,12 +35,22 @@ export class ApiError {
   constructor(public error: HttpErrorResponse) {}
 }
 
-export class GetFiles {
-  static readonly type = "[Concern] Get Files";
+export class ListFiles {
+  static readonly type = "[Concern] List Files";
   constructor(public gmcNumber: number) {}
 }
 
-export class GetFilesSuccess {
-  static readonly type = "[Concern] Get Files Success";
+export class ListFilesSuccess {
+  static readonly type = "[Concern] List Files Success";
   constructor(public uploadedFiles: any[]) {}
+}
+
+export class DownloadFile {
+  static readonly type = "[Concern] Download File";
+  constructor(public fileName: string, public key: string) {}
+}
+
+export class DownloadFileSuccess {
+  static readonly type = "[Concern] Download File Success";
+  constructor(public blob: Blob, public fileName: string) {}
 }

--- a/src/app/concern/uploaded-files-list/uploaded-files-list.component.html
+++ b/src/app/concern/uploaded-files-list/uploaded-files-list.component.html
@@ -1,7 +1,7 @@
 <!-- spinner -->
 <div
   class="d-flex align-items-center mb-25 mt-25"
-  *ngIf="getFilesInProgress$ | async; else notLoading"
+  *ngIf="listFilesInProgress$ | async; else notLoading"
 >
   <mat-spinner [diameter]="50"></mat-spinner>
   <span class="pl-15">Fetching uploaded files...</span>
@@ -32,15 +32,15 @@
             <div>{{ file.fileName }}</div>
             <mat-icon
               mat-list-icon
-              (click)="downloadFile($event)"
-              class="cursor-pointer"
+              (click)="downloadFile(file.fileName, file.key)"
+              class="cursor-pointer justify-self-end"
             >
               cloud_download
             </mat-icon>
             <mat-icon
               mat-list-icon
               (click)="deleteFile($event)"
-              class="cursor-pointer"
+              class="cursor-pointer justify-self-end"
               >delete</mat-icon
             >
           </div>

--- a/src/app/concern/uploaded-files-list/uploaded-files-list.component.spec.ts
+++ b/src/app/concern/uploaded-files-list/uploaded-files-list.component.spec.ts
@@ -1,13 +1,15 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { NgxsModule } from "@ngxs/store";
+import { NgxsModule, Store } from "@ngxs/store";
 import { MaterialModule } from "../../shared/material/material.module";
+import { DownloadFile } from "../state/concern.actions";
 import { ConcernState } from "../state/concern.state";
 
 import { UploadedFilesListComponent } from "./uploaded-files-list.component";
 
 describe("UploadedFilesListComponent", () => {
+  let store: Store;
   let component: UploadedFilesListComponent;
   let fixture: ComponentFixture<UploadedFilesListComponent>;
 
@@ -21,6 +23,7 @@ describe("UploadedFilesListComponent", () => {
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
+    store = TestBed.inject(Store);
   }));
 
   beforeEach(() => {
@@ -31,5 +34,22 @@ describe("UploadedFilesListComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("ngOnInit() should invoke `listFiles()`", () => {
+    spyOn(component, "listFiles");
+    component.ngOnInit();
+    expect(component.listFiles).toHaveBeenCalled();
+  });
+
+  it("downloadFile() should dispatch event", () => {
+    spyOn(store, "dispatch");
+    const mockFileName = "mockfile.txt";
+    const mockKey = "119389/8119389/mockfile.txt";
+
+    component.downloadFile(mockFileName, mockKey);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new DownloadFile(mockFileName, mockKey)
+    );
   });
 });

--- a/src/app/concern/uploaded-files-list/uploaded-files-list.component.ts
+++ b/src/app/concern/uploaded-files-list/uploaded-files-list.component.ts
@@ -4,7 +4,7 @@ import { Select, Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { ACCEPTED_IMAGE_FILE_TYPES } from "../constants";
 import { UploadService } from "../services/upload/upload.service";
-import { GetFiles } from "../state/concern.actions";
+import { DownloadFile, ListFiles } from "../state/concern.actions";
 import { ConcernState } from "../state/concern.state";
 
 @Component({
@@ -15,20 +15,19 @@ import { ConcernState } from "../state/concern.state";
 export class UploadedFilesListComponent implements OnInit {
   public dateFormat = environment.dateFormat;
   public gmcNumber: number = this.store.selectSnapshot(ConcernState.gmcNumber);
-  @Select(ConcernState.getFilesInProgress)
-  public getFilesInProgress$: Observable<boolean>;
+  @Select(ConcernState.listFilesInProgress)
+  public listFilesInProgress$: Observable<boolean>;
   @Select(ConcernState.uploadedFiles) public uploadedFiles$: Observable<any[]>;
   public acceptedImageTypes: string[] = ACCEPTED_IMAGE_FILE_TYPES;
 
   constructor(private uploadService: UploadService, private store: Store) {}
 
   ngOnInit(): void {
-    this.getFiles();
+    this.listFiles();
   }
 
-  public downloadFile(event: Event): void {
-    event.preventDefault();
-    (window as any).alert("Your download should resume by next sprint 😀");
+  public downloadFile(fileName: string, key: string): Observable<any> {
+    return this.store.dispatch(new DownloadFile(fileName, key));
   }
 
   public deleteFile(event: Event): void {
@@ -36,7 +35,7 @@ export class UploadedFilesListComponent implements OnInit {
     (window as any).alert("Your file will be deleted shortly 😀");
   }
 
-  public getFiles(): Observable<any> {
-    return this.store.dispatch(new GetFiles(this.gmcNumber));
+  public listFiles(): Observable<any> {
+    return this.store.dispatch(new ListFiles(this.gmcNumber));
   }
 }

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -3,9 +3,7 @@ import { IEnvironment } from "./environment.interface";
 export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
   allocateAdmin: `api/v1/doctors/assign-admin`,
   authRedirect: ``,
-  fileDownload: `api/storage/download`,
-  fileList: `api/storage/list`,
-  fileUpload: `api/storage/upload`,
+  downloadFile: `api/storage/download`,
   getConcern: `/api/concerns`,
   getConcerns: `api/concerns`,
   getConnections: `api/v1/connections`,
@@ -13,9 +11,11 @@ export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
   getNotes: `mocky/5ea2da614f00006c00d9f540`, // TODO replace with appropriate api url once is available
   getRecommendation: `api/recommendation`,
   getRecommendations: `api/v1/doctors`,
+  listFiles: `api/storage/list`,
   login: ``,
   saveRecommendation: `api/recommendation`,
-  submitToGMC: `api/recommendation/{gmcNumber}/submit/{recommendationId}`
+  submitToGMC: `api/recommendation/{gmcNumber}/submit/{recommendationId}`,
+  upload: `api/storage/upload`
 };
 
 export const AWS_CONFIG: IEnvironment["awsConfig"] = {

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -13,9 +13,7 @@ export abstract class IEnvironment {
   abstract readonly appUrls: {
     readonly allocateAdmin: string;
     readonly authRedirect: string;
-    readonly fileDownload: string;
-    readonly fileList: string;
-    readonly fileUpload: string;
+    readonly downloadFile: string;
     readonly getConcern: string;
     readonly getConcerns: string;
     readonly getConnections: string;
@@ -23,9 +21,11 @@ export abstract class IEnvironment {
     readonly getNotes: string;
     readonly getRecommendation: string;
     readonly getRecommendations: string;
+    readonly listFiles: string;
     readonly login: string;
     readonly saveRecommendation: string;
     readonly submitToGMC: string;
+    readonly upload: string;
   };
 
   abstract readonly awsConfig: {

--- a/src/environments/environment.mocky.ts
+++ b/src/environments/environment.mocky.ts
@@ -18,7 +18,7 @@ export const environment: IEnvironment = {
     // 5e997dba33000096297b235d = 0 recommendations to simulate no results found
     allocateAdmin: `api/v1/doctors/assignAdmin`, // TODO mock this
     authRedirect: ``,
-    fileUpload: `mocky/c25f77cf-594a-484b-b50b-562aa9438115?mocky-delay=700ms`, // TODO mock this
+    downloadFile: ``, // TODO mock this
     getConcern: `mocky/0a459279-bdca-4b1b-9e07-d55c7f38630e`,
     getConcerns: `mocky/c25f77cf-594a-484b-b50b-562aa9438115?mocky-delay=700ms`,
     getConnections: `mocky/4a202550-2c45-41c8-ab48-91786f8054eb?mocky-delay=700ms`,
@@ -26,9 +26,11 @@ export const environment: IEnvironment = {
     getNotes: `mocky/45017692-2588-48dc-b6c2-c637cd723625`,
     getRecommendation: `mocky/6fd60c05-b4d0-462d-87a8-87402d57bd2e`,
     getRecommendations: `mocky/81267580-411e-4ce6-8dca-2f65f9d2e485?mocky-delay=700ms`,
+    listFiles: ``, // TODO mock this
     login: ``,
     saveRecommendation: `api/recommendation`, // TODO mock this
-    submitToGMC: `api/recommendation/{gmcId}/submit/{recommendationId}` // TODO mock this
+    submitToGMC: `api/recommendation/{gmcId}/submit/{recommendationId}`, // TODO mock this
+    upload: `mocky/c25f77cf-594a-484b-b50b-562aa9438115?mocky-delay=700ms` // TODO mock this
   },
   awsConfig: {
     ...AWS_CONFIG,


### PR DESCRIPTION
TISNEW-5022

feat: consume download api

- added `file-saver` npm package in order to save file
- added `DownloadFile` and `DownloadFileSuccess` actions and relevant listener methods
- created `IListFile` interface and typed list files endpoint response
- extracted common bucket name `FILE_BUCKET_NAME` to a variable 
- added unit tests