### PR TITLE
Revert "chore(deps): bump rxjs from 6.6.0 to 6.6.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20158,9 +20158,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+      "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
       "requires": {
         "tslib": "^1.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "caniuse-lite": "^1.0.30001107",
     "file-saver": "^2.0.2",
     "nhsuk-frontend": "^3.1.0",
-    "rxjs": "~6.6.2",
+    "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.3"
   },


### PR DESCRIPTION
Reverts Health-Education-England/TIS-REVALIDATION-V2#310