### PR TITLE
fix: e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 ## Running end-to-end tests
 
+Prequisite - set environment variables;
+
+```
+export CYPRESS_username=xxxxxxx
+export CYPRESS_password=xxxxxxx
+export CYPRESS_baseUrl=xxxxxxx
+```
+
 The [Cypress](https://www.cypress.io) e2e tests can be run;
 
 - In headless mode in the electron browser via `npm run cypress` or

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:4200"
+  "baseUrl": "https://stage-revalidation.tis.nhs.uk",
+  "chromeWebSecurity": false
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,3 @@
 {
-  "baseUrl": "https://stage-revalidation.tis.nhs.uk",
   "chromeWebSecurity": false
 }

--- a/cypress/integration/app/app.spec.ts
+++ b/cypress/integration/app/app.spec.ts
@@ -1,5 +1,0 @@
-describe("Revalidation", () => {
-  it("should allow me to visit the app", () => {
-    cy.visit("/");
-  });
-});

--- a/cypress/integration/app/recommendations/recommendations-filters/recommendations-filters.spec.ts
+++ b/cypress/integration/app/recommendations/recommendations-filters/recommendations-filters.spec.ts
@@ -1,5 +1,9 @@
 describe("Recommendations filters", () => {
-  const buttons = "app-recommendations-filters button";
+  before(() => {
+    cy.login();
+  });
+
+  const buttons = "app-recommendations-filters a";
 
   it("should allow me to visit the page", () => {
     cy.visit("/recommendations");
@@ -12,11 +16,11 @@ describe("Recommendations filters", () => {
   });
 
   it("under notice button should be active by default", () => {
-    cy.get(buttons).eq(1).should("have.class", "mat-primary");
+    cy.get(buttons).eq(1).should("have.class", "mat-tab-label-active");
   });
 
   it("clicking on all doctors button should set it as active", () => {
-    cy.get(buttons).eq(0).click().should("have.class", "mat-primary");
+    cy.get(buttons).eq(0).click().should("have.class", "mat-tab-label-active");
   });
 
   it("clicking on all doctors button should update the query parameter in url", () => {

--- a/cypress/integration/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.spec.ts
+++ b/cypress/integration/app/recommendations/recommendations-list-paginator/recommendations-list-paginator.spec.ts
@@ -1,4 +1,8 @@
 describe("Recommendations list paginator", () => {
+  before(() => {
+    cy.login();
+  });
+
   it("should allow me to visit the page", () => {
     cy.visit("/recommendations");
   });
@@ -24,18 +28,11 @@ describe("Recommendations list paginator", () => {
     ).should("be.enabled");
   });
 
-  it("should show loading spinner when next page button is clicked", () => {
+  it("should update pageIndex parameter in url when previous next button is clicked", () => {
     cy.get(
       "app-recommendations-list-paginator .mat-paginator-navigation-next"
     ).click();
-    cy.get("mat-spinner");
-  });
 
-  it("should update pageIndex parameter in url when previous page button is clicked", () => {
-    cy.get(
-      "app-recommendations-list-paginator .mat-paginator-navigation-previous"
-    ).click();
-
-    cy.location().should((loc) => expect(loc.search).to.contain("pageIndex=0"));
+    cy.location().should((loc) => expect(loc.search).to.contain("pageIndex=1"));
   });
 });

--- a/cypress/integration/app/recommendations/recommendations-list/recommendations-list.spec.ts
+++ b/cypress/integration/app/recommendations/recommendations-list/recommendations-list.spec.ts
@@ -1,4 +1,8 @@
 describe("Recommendations list", () => {
+  before(() => {
+    cy.login();
+  });
+
   it("should allow me to visit the page", () => {
     cy.visit("/recommendations");
   });
@@ -13,20 +17,20 @@ describe("Recommendations list", () => {
   });
 
   it("should show recommendations data table with correct column headings", () => {
-    cy.get(".mat-header-cell").eq(0).should("have.text", "First name");
-    cy.get(".mat-header-cell").eq(1).should("have.text", "Last name");
-    cy.get(".mat-header-cell").eq(2).should("have.text", "Gmc no");
+    cy.get(".mat-header-cell").eq(0).should("contain.text", "First name");
+    cy.get(".mat-header-cell").eq(1).should("contain.text", "Last name");
+    cy.get(".mat-header-cell").eq(2).should("contain.text", "GMC No");
     cy.get(".mat-header-cell")
       .eq(3)
-      .should("have.text", "GMC Submission due date");
-    cy.get(".mat-header-cell").eq(4).should("have.text", "Status");
-    cy.get(".mat-header-cell").eq(5).should("have.text", "Programme name");
+      .should("contain.text", "GMC Submission due date");
+    cy.get(".mat-header-cell").eq(4).should("contain.text", "Status");
+    cy.get(".mat-header-cell").eq(5).should("contain.text", "Programme name");
     cy.get(".mat-header-cell")
       .eq(6)
-      .should("have.text", "Programme membership type");
-    cy.get(".mat-header-cell").eq(7).should("have.text", "CCT date");
-    cy.get(".mat-header-cell").eq(8).should("have.text", "Admin");
-    cy.get(".mat-header-cell").eq(9).should("have.text", "Last updated");
+      .should("contain.text", "Programme membership type");
+    cy.get(".mat-header-cell").eq(7).should("contain.text", "CCT date");
+    cy.get(".mat-header-cell").eq(8).should("contain.text", "Admin");
+    cy.get(".mat-header-cell").eq(9).should("contain.text", "Last updated");
   });
 
   it("should show recommendations table with some data", () => {
@@ -42,7 +46,6 @@ describe("Recommendations list", () => {
 
   it("should list recommendations by `First name` when sorted by this column", () => {
     cy.get(".mat-header-cell").eq(0).click();
-    cy.get("mat-spinner");
     cy.get(".mat-header-cell")
       .eq(0)
       .should("have.attr", "aria-sort")

--- a/cypress/integration/app/recommendations/recommendations-search/recommendations-search.spec.ts
+++ b/cypress/integration/app/recommendations/recommendations-search/recommendations-search.spec.ts
@@ -1,4 +1,8 @@
 describe("Recommendations search", () => {
+  before(() => {
+    cy.login();
+  });
+
   const searchForm = "app-record-search form";
 
   it("should allow me to visit the page", () => {
@@ -27,6 +31,7 @@ describe("Recommendations search", () => {
   });
 
   it("should not contain `searchQuery` parameter in url when `Clear all` is clicked", () => {
+    cy.get("app-record-search .mat-menu-trigger").click();
     cy.get("app-reset-record-list button").click();
     cy.location().should((loc) =>
       expect(loc.search).to.not.contain("searchQuery")

--- a/cypress/integration/app/recommendations/reset-recommendations-list/reset-recommendations-list.spec.ts
+++ b/cypress/integration/app/recommendations/reset-recommendations-list/reset-recommendations-list.spec.ts
@@ -13,7 +13,6 @@ describe("Reset recommendations list", () => {
   });
 
   it("should reset recommendations list when `Clear all` is clicked", () => {
-    // cy.get("app-record-search .mat-menu-trigger").click();
     cy.get("app-reset-record-list button").click();
     cy.get(".mat-header-cell")
       .eq(3)

--- a/cypress/integration/app/recommendations/reset-recommendations-list/reset-recommendations-list.spec.ts
+++ b/cypress/integration/app/recommendations/reset-recommendations-list/reset-recommendations-list.spec.ts
@@ -1,18 +1,20 @@
 describe("Reset recommendations list", () => {
+  before(() => {
+    cy.login();
+  });
+
   it("should allow me to visit the page", () => {
     cy.visit("/recommendations");
   });
 
   it("should contain reset recommendations list element", () => {
-    cy.get("app-reset-record-list .mat-button-wrapper").should(
-      "contain.text",
-      "Clear all"
-    );
+    cy.get("app-record-search .mat-menu-trigger").click();
+    cy.get("app-reset-record-list button").should("contain.text", "Clear all");
   });
 
   it("should reset recommendations list when `Clear all` is clicked", () => {
+    // cy.get("app-record-search .mat-menu-trigger").click();
     cy.get("app-reset-record-list button").click();
-    cy.get("mat-spinner");
     cy.get(".mat-header-cell")
       .eq(3)
       .should("have.attr", "aria-sort")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,11 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add("login", () => {
+  cy.visit("https://stage-revalidation.tis.nhs.uk");
+  cy.get("form").eq(1).as("form");
+  cy.get("@form").find("#signInFormUsername").type("demouser@hee.nhs.uk");
+  cy.get("@form").find("#signInFormPassword").type("T3CagXRI7SKgQj9A-");
+  cy.get("@form").submit();
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,10 +24,13 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+const username = Cypress.env("username");
+const password = Cypress.env("password");
+
 Cypress.Commands.add("login", () => {
-  cy.visit("https://stage-revalidation.tis.nhs.uk");
+  cy.visit("/");
   cy.get("form").eq(1).as("form");
-  cy.get("@form").find("#signInFormUsername").type("demouser@hee.nhs.uk");
-  cy.get("@form").find("#signInFormPassword").type("T3CagXRI7SKgQj9A-");
+  cy.get("@form").find("#signInFormUsername").type(username);
+  cy.get("@form").find("#signInFormPassword").type(password);
   cy.get("@form").submit();
 });


### PR DESCRIPTION
NO-TICKET

fix: e2e tests

The pr addresses the issue of login & as well as fixes the broken tests.

- The externally hosted aws cognito login screen is filled in and submitted
- the baseUrl has been set to staging as cypress doesn't allow tests to run on different domains. The only other option I could think of was to progmatically login via `cy.request()` but this would expose AWS secrets which is not a good idea