### PR TITLE
refactor: consume admin endpoints

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -57,7 +57,6 @@
               "@aws-sdk/util-utf8-browser",
               "@aws-sdk/util-utf8-node",
               "@aws-sdk/xml-builder",
-              "aws-sdk",
               "axios",
               "buffer",
               "crypto-js/enc-base64",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1275,14 +1275,13 @@
               },
               "dependencies": {
                 "buffer": {
-                  "version": "4.9.1",
-                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-                  "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+                  "version": "5.6.0",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+                  "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
                   "dev": true,
                   "requires": {
                     "base64-js": "^1.0.2",
-                    "ieee754": "^1.1.4",
-                    "isarray": "^1.0.0"
+                    "ieee754": "^1.1.4"
                   }
                 },
                 "url": {
@@ -1331,14 +1330,13 @@
           },
           "dependencies": {
             "buffer": {
-              "version": "4.9.1",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-              "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+              "version": "5.6.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+              "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
               "dev": true,
               "requires": {
                 "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
+                "ieee754": "^1.1.4"
               }
             }
           }
@@ -6331,6 +6329,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -7371,6 +7377,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -7461,13 +7475,12 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
+            "ieee754": "^1.1.4"
           }
         }
       }
@@ -7936,58 +7949,6 @@
         }
       }
     },
-    "aws-sdk": {
-      "version": "2.727.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.727.1.tgz",
-      "integrity": "sha512-K+XdN11os6hvI9DgWEK9m/fPKHuDDVZalFWPouwqSk0phEdDCJ/K8InHUFL9DMvE4bxyWRuqI9dzNfdmxX0sxQ==",
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "4.9.2",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          }
-        },
-        "events": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-        },
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        },
-        "sax": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-        },
-        "url": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          }
-        }
-      }
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -8077,6 +8038,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -10023,6 +9992,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -13866,7 +13843,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -14054,7 +14032,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-cookie": {
       "version": "2.2.1",
@@ -14404,6 +14383,18 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "18.1.3",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -15498,6 +15489,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -15556,12 +15555,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -16172,14 +16165,13 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "4.9.2",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
+            "ieee754": "^1.1.4"
           }
         },
         "inherits": {
@@ -18343,6 +18335,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -19940,6 +19940,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -20188,6 +20196,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -20211,7 +20227,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "schema-utils": {
       "version": "2.7.0",
@@ -21777,6 +21794,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -23363,6 +23388,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -23891,6 +23924,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "loader-utils": {
@@ -23997,6 +24038,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -24005,7 +24047,8 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
@@ -24100,25 +24143,15 @@
           }
         },
         "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
           }
         }
-      }
-    },
-    "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@sentry/browser": "^5.20.1",
     "angulartics2": "^10.0.0",
     "aws-amplify": "^3.0.22",
-    "aws-sdk": "^2.727.1",
     "browserslist": "^4.13.0",
     "caniuse-lite": "^1.0.30001111",
     "file-saver": "^2.0.2",

--- a/src/app/admins/admins.interfaces.ts
+++ b/src/app/admins/admins.interfaces.ts
@@ -2,3 +2,8 @@ export interface IAllocateAdmin {
   admin: string;
   gmcNumber: number;
 }
+
+export interface IAdmin {
+  fullName: string;
+  username: string;
+}

--- a/src/app/admins/admins.module.ts
+++ b/src/app/admins/admins.module.ts
@@ -21,6 +21,6 @@ const adminComponents = [
 })
 export class AdminsModule {
   constructor(private store: Store) {
-    this.store.dispatch(new Get("reval-site-admin"));
+    this.store.dispatch(new Get());
   }
 }

--- a/src/app/admins/allocate-admin-autocomplete/allocate-admin-autocomplete.component.html
+++ b/src/app/admins/allocate-admin-autocomplete/allocate-admin-autocomplete.component.html
@@ -14,7 +14,7 @@
       (optionSelected)="onOptionSelected($event)"
     >
       <mat-option *ngFor="let i of filteredItems$ | async" [value]="i">
-        {{ i.Username }}
+        {{ i.fullName }}
       </mat-option>
     </mat-autocomplete>
   </mat-form-field>

--- a/src/app/admins/services/admins.service.spec.ts
+++ b/src/app/admins/services/admins.service.spec.ts
@@ -2,27 +2,21 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule } from "@ngxs/store";
-import { ListUsersResponse } from "aws-sdk/clients/cognitoidentityserviceprovider";
 import { MaterialModule } from "../../shared/material/material.module";
+import { IAdmin } from "../admins.interfaces";
 import { AdminsState } from "../state/admins.state";
-
 import { AdminsService } from "./admins.service";
 
-export const mockAdminsResponse: ListUsersResponse = {
-  Users: [
-    {
-      Attributes: [
-        { Name: "sub", Value: "2c6df0c3-ded9-4669-9e89-ac719ad84493" },
-        { Name: "email", Value: "siteadmin@hee.nhs.uk" }
-      ],
-      Enabled: true,
-      UserCreateDate: new Date(),
-      UserLastModifiedDate: new Date(),
-      UserStatus: "CONFIRMED",
-      Username: "siteadmin@hee.nhs.uk"
-    }
-  ]
-};
+export const mockAdminsResponse: IAdmin[] = [
+  {
+    username: "siteadmin@hee.nhs.uk",
+    fullName: "siteadmin@hee.nhs.uk"
+  },
+  {
+    username: "omar_mirza",
+    fullName: "omar_mirza"
+  }
+];
 
 describe("AdminsService", () => {
   let service: AdminsService;

--- a/src/app/admins/services/admins.service.ts
+++ b/src/app/admins/services/admins.service.ts
@@ -2,13 +2,8 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { environment } from "@environment";
 import { Store } from "@ngxs/store";
-import { AWSError, CognitoIdentityServiceProvider } from "aws-sdk";
-import {
-  ListUsersInGroupRequest,
-  ListUsersResponse
-} from "aws-sdk/clients/cognitoidentityserviceprovider";
+import { Observable } from "rxjs";
 import { IAllocateAdmin } from "../admins.interfaces";
-import { GetError, GetSuccess } from "../state/admins.actions";
 
 @Injectable({
   providedIn: "root"
@@ -16,39 +11,12 @@ import { GetError, GetSuccess } from "../state/admins.actions";
 export class AdminsService {
   constructor(private store: Store, private http: HttpClient) {}
 
-  public listUsersInGroupRequest(groupName: string): ListUsersInGroupRequest {
-    return {
-      UserPoolId: environment.awsConfig.userPoolId,
-      GroupName: groupName
-    };
+  public getAdminUsers(): Observable<any> {
+    return this.http.get(environment.appUrls.listAdmins);
   }
 
-  public get awsCognito(): any {
-    return new CognitoIdentityServiceProvider({
-      region: environment.awsConfig.region,
-      credentials: {
-        accessKeyId: environment.awsConfig.accessKeyId,
-        secretAccessKey: environment.awsConfig.secretAccessKey
-      }
-    });
-  }
-
-  public getAdminUsers(groupName: string): void {
-    this.awsCognito.listUsersInGroup(
-      this.listUsersInGroupRequest(groupName),
-      (error: AWSError, response: ListUsersResponse) => {
-        if (error) {
-          const errorMsg = `Error: ${error.message}`;
-          this.store.dispatch(new GetError(errorMsg));
-        } else {
-          this.store.dispatch(new GetSuccess(response.Users));
-        }
-      }
-    );
-  }
-
-  public submitAllocateList(payload: IAllocateAdmin[]) {
-    return this.http.post(`${environment.appUrls.allocateAdmin}`, {
+  public submitAllocateList(payload: IAllocateAdmin[]): Observable<any> {
+    return this.http.post(environment.appUrls.allocateAdmin, {
       traineeAdmins: payload
     });
   }

--- a/src/app/admins/state/admins.actions.ts
+++ b/src/app/admins/state/admins.actions.ts
@@ -1,16 +1,15 @@
-import { UserType } from "aws-sdk/clients/cognitoidentityserviceprovider";
 import { HttpErrorPayload } from "../../shared/services/error/error.service";
+import { IAdmin } from "../admins.interfaces";
 
 const label = `[Admins]`;
 
 export class Get {
   static readonly type = `${label} Get`;
-  constructor(public groupName: string) {}
 }
 
 export class GetSuccess {
   static readonly type = `${label} Get Success`;
-  constructor(public response: UserType[]) {}
+  constructor(public response: IAdmin[]) {}
 }
 
 export class GetError extends HttpErrorPayload {

--- a/src/app/admins/state/admins.state.spec.ts
+++ b/src/app/admins/state/admins.state.spec.ts
@@ -36,17 +36,17 @@ describe("Admins state", () => {
   });
 
   it("should dispatch 'Get' and invoke `adminsService.getAdminUsers()`", () => {
-    spyOn(adminsService, "getAdminUsers");
+    spyOn(adminsService, "getAdminUsers").and.callThrough();
     store
-      .dispatch(new Get("reval-site-admin"))
+      .dispatch(new Get())
       .subscribe(() => expect(adminsService.getAdminUsers).toHaveBeenCalled());
   });
 
   it("should dispatch 'GetSuccess' and select 'items' slice", () => {
-    store.dispatch(new GetSuccess(mockAdminsResponse.Users));
+    store.dispatch(new GetSuccess(mockAdminsResponse));
     const items = store.selectSnapshot(AdminsState.items);
-    expect(items.length).toEqual(1);
-    expect(items[0].Username).toEqual("siteadmin@hee.nhs.uk");
+    expect(items.length).toEqual(2);
+    expect(items[0].username).toEqual("siteadmin@hee.nhs.uk");
   });
 
   it("should dispatch 'GetError' and select 'error' slice", () => {

--- a/src/app/admins/state/admins.state.ts
+++ b/src/app/admins/state/admins.state.ts
@@ -1,10 +1,9 @@
 import { Injectable } from "@angular/core";
 import { Action, Selector, State, StateContext } from "@ngxs/store";
 import { append, patch, removeItem } from "@ngxs/store/operators";
-import { UserType } from "aws-sdk/clients/cognitoidentityserviceprovider";
 import { catchError, switchMap, take } from "rxjs/operators";
 import { SnackBarService } from "../../shared/services/snack-bar/snack-bar.service";
-import { IAllocateAdmin } from "../admins.interfaces";
+import { IAdmin, IAllocateAdmin } from "../admins.interfaces";
 import { AdminsService } from "../services/admins.service";
 import {
   AddToAllocateList,
@@ -20,7 +19,7 @@ import {
 
 export class AdminsStateModel {
   public error?: string;
-  public items: UserType[];
+  public items: IAdmin[];
   public allocateList: IAllocateAdmin[];
 }
 
@@ -49,8 +48,12 @@ export class AdminsState {
   }
 
   @Action(Get)
-  get(ctx: StateContext<AdminsStateModel>, action: Get) {
-    return this.adminsService.getAdminUsers(action.groupName);
+  get(ctx: StateContext<AdminsStateModel>) {
+    return this.adminsService.getAdminUsers().pipe(
+      take(1),
+      switchMap((response: IAdmin[]) => ctx.dispatch(new GetSuccess(response))),
+      catchError((error: string) => ctx.dispatch(new GetError(error)))
+    );
   }
 
   @Action(GetSuccess)

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -12,6 +12,7 @@ export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
   getNotes: `mocky/5ea2da614f00006c00d9f540`, // TODO replace with appropriate api url once is available
   getRecommendation: `api/recommendation`,
   getRecommendations: `api/v1/doctors`,
+  listAdmins: `api/admins`,
   listFiles: `api/storage/list`,
   login: ``,
   saveRecommendation: `api/recommendation`,
@@ -20,7 +21,6 @@ export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
 };
 
 export const AWS_CONFIG: IEnvironment["awsConfig"] = {
-  accessKeyId: "AKIAWISJGQ6JUF3LSWMO",
   authenticationFlowType: "USER_PASSWORD_AUTH",
   bucketName: "",
   domain: "stage-auth.tis.nhs.uk",
@@ -30,7 +30,6 @@ export const AWS_CONFIG: IEnvironment["awsConfig"] = {
   region: "eu-west-2",
   responseType: "token",
   scope: ["openid", "aws.cognito.signin.user.admin"],
-  secretAccessKey: "hriPPZQppD+5DM02iE+wVX1+jOCUyXkqK34Fzfl4",
   userPoolId: "eu-west-2_J8SoC9e1Y",
   userPoolWebClientId: "23mvi31orrlq04ugap61mor8bg"
 };

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -23,6 +23,7 @@ export abstract class IEnvironment {
     readonly getRecommendation: string;
     readonly getRecommendations: string;
     readonly listFiles: string;
+    readonly listAdmins: string;
     readonly login: string;
     readonly saveRecommendation: string;
     readonly submitToGMC: string;
@@ -30,7 +31,6 @@ export abstract class IEnvironment {
   };
 
   abstract readonly awsConfig: {
-    readonly accessKeyId: string;
     readonly authenticationFlowType: string;
     readonly bucketName: string;
     readonly domain: string;
@@ -40,7 +40,6 @@ export abstract class IEnvironment {
     readonly region: string;
     readonly responseType: string;
     readonly scope: string[];
-    readonly secretAccessKey: string;
     readonly userPoolId: string;
     readonly userPoolWebClientId: string;
   };

--- a/src/environments/environment.mocky.ts
+++ b/src/environments/environment.mocky.ts
@@ -28,6 +28,7 @@ export const environment: IEnvironment = {
     getNotes: `mocky/45017692-2588-48dc-b6c2-c637cd723625`,
     getRecommendation: `mocky/6fd60c05-b4d0-462d-87a8-87402d57bd2e`,
     getRecommendations: `mocky/81267580-411e-4ce6-8dca-2f65f9d2e485?mocky-delay=700ms`,
+    listAdmins: ``, // TODO mock this
     listFiles: ``, // TODO mock this
     login: ``,
     saveRecommendation: `api/recommendation`, // TODO mock this


### PR DESCRIPTION
TISNEW-4977

refactor: consume admin endpoints

- strip out aws-sdk, aws secret/s as not needed anymore