### PR TITLE
feat: add concern

### DIFF
--- a/src/app/concern/concern.interfaces.ts
+++ b/src/app/concern/concern.interfaces.ts
@@ -4,6 +4,27 @@ export interface IGetConcernResponse {
   gmcNumber: number;
   grades: IGrade[];
   sites: ISite[];
+  types: IConcernType[];
+  sources: ISource[];
+}
+
+export interface IEntity {
+  id: number;
+  label: string;
+}
+
+/**
+ * TODO ask BE to uniform the return types so that
+ * `types, sources, sites, grades and employers' are the same i.e `ReferenceDto` in the BE
+ * this will help clean up the below interfaces as well as not needing `IAddConcernRequest`
+ */
+export interface IConcernType extends IEntity {
+  code: string;
+}
+
+export interface ISource {
+  id: number;
+  name: string;
 }
 
 export interface IListFile {
@@ -21,28 +42,39 @@ export interface IFileUploadProgress {
 export interface IConcernSummary {
   admin: string;
   comments: string[];
-  concernId: number;
-  concernType: string; // TODO: use enum IncidentType, check with BE
+  concernId?: number;
+  concernType: IConcernType;
   dateOfIncident: Date;
   dateReported: Date;
-  employer: string;
+  employer: IEmployer;
   followUpDate: Date;
   gmcNumber: number;
-  grade: string;
+  grade: IGrade;
   lastUpdatedDate: Date;
-  site: string;
-  source: string;
+  site: ISite;
+  source: ISource;
+  status: ConcernStatus;
+}
+
+export interface IAddConcernRequest {
+  admin: string;
+  comments: string[];
+  concernType: IEntity;
+  dateOfIncident: Date;
+  dateReported: Date;
+  employer: IEntity;
+  followUpDate: Date;
+  gmcNumber: number;
+  grade: IEntity;
+  lastUpdatedDate: Date;
+  site: IEntity;
+  source: IEntity;
   status: ConcernStatus;
 }
 
 export enum ConcernStatus {
   OPEN = "Open",
   CLOSED = "Closed"
-}
-
-export interface IncidentType {
-  code: string;
-  label: string;
 }
 
 export interface IGrade {

--- a/src/app/concern/constants.ts
+++ b/src/app/concern/constants.ts
@@ -1,21 +1,19 @@
 import { IConcernSummary } from "./concern.interfaces";
 
-// TODO check if being used in app and maybe remove
 export const defaultConcern: IConcernSummary = {
-  concernId: null,
-  gmcNumber: null,
-  dateOfIncident: null,
+  admin: null,
+  comments: [],
   concernType: null,
-  source: null,
+  dateOfIncident: null,
   dateReported: null,
   employer: null,
-  site: null,
-  grade: null,
-  status: null,
-  admin: null,
   followUpDate: null,
+  gmcNumber: null,
+  grade: null,
   lastUpdatedDate: null,
-  comments: []
+  site: null,
+  source: null,
+  status: null
 };
 
 export const ACCEPTED_IMAGE_EXTENSIONS: string[] = [

--- a/src/app/concern/create-concern-forms/concern-detail/concern-detail.component.html
+++ b/src/app/concern/create-concern-forms/concern-detail/concern-detail.component.html
@@ -5,7 +5,13 @@
     >
   </div>
 
-  <div class="d-grid grid-container-2-col">
+  <div
+    class="d-grid grid-container-2-col"
+    *ngIf="{
+      concernTypes: concernTypes$ | async,
+      sources: sources$ | async
+    } as data"
+  >
     <mat-form-field>
       <mat-label>Date of incident</mat-label>
       <input
@@ -14,7 +20,7 @@
         formControlName="dateOfIncident"
         [matDatepicker]="dateOfIncidentPicker"
       />
-      <mat-error *ngIf="dateOfIncident?.hasError('required')">
+      <mat-error *ngIf="form.dateOfIncident?.hasError('required')">
         Date of incident is required
       </mat-error>
       <mat-datepicker-toggle
@@ -28,13 +34,13 @@
       <mat-label>Concern type</mat-label>
       <mat-select formControlName="concernType">
         <mat-option
-          *ngFor="let incidentType of incidentTypes"
-          [value]="incidentType.code"
+          *ngFor="let concernType of data.concernTypes"
+          [value]="concernType"
         >
-          {{ incidentType.label }}
+          {{ concernType.label }}
         </mat-option>
       </mat-select>
-      <mat-error *ngIf="concernType?.hasError('required')">
+      <mat-error *ngIf="form.concernType?.hasError('required')">
         Concern type must be provided
       </mat-error>
     </mat-form-field>
@@ -42,14 +48,11 @@
     <mat-form-field>
       <mat-label>Source</mat-label>
       <mat-select formControlName="source">
-        <mat-option
-          *ngFor="let incidentSource of incidentSources"
-          [value]="incidentSource"
-        >
-          {{ incidentSource }}
+        <mat-option *ngFor="let source of data.sources" [value]="source">
+          {{ source.name }}
         </mat-option>
       </mat-select>
-      <mat-error *ngIf="source?.hasError('required')">
+      <mat-error *ngIf="form.source?.hasError('required')">
         Source must be provided
       </mat-error>
     </mat-form-field>
@@ -62,7 +65,7 @@
         formControlName="dateReported"
         [matDatepicker]="dateReportedPicker"
       />
-      <mat-error *ngIf="dateReported?.hasError('required')">
+      <mat-error *ngIf="form.dateReported?.hasError('required')">
         Date reported is required
       </mat-error>
       <mat-datepicker-toggle
@@ -80,7 +83,7 @@
         formControlName="followUpDate"
         [matDatepicker]="followUpDatePicker"
       />
-      <mat-error *ngIf="followUpDate?.hasError('required')">
+      <mat-error *ngIf="form.followUpDate?.hasError('required')">
         Follow up date is required
       </mat-error>
       <mat-datepicker-toggle

--- a/src/app/concern/create-concern-forms/concern-detail/concern-detail.component.spec.ts
+++ b/src/app/concern/create-concern-forms/concern-detail/concern-detail.component.spec.ts
@@ -1,26 +1,20 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { ConcernHistoryResponse2 } from "src/app/recommendation/mock-data/recommendation-spec-data";
+import { MaterialModule } from "src/app/shared/material/material.module";
+import { ConcernStatus, IConcernSummary } from "../../concern.interfaces";
+import { ConcernState } from "../../state/concern.state";
 
 import { ConcernDetailComponent } from "./concern-detail.component";
-import { NgxsModule, Store } from "@ngxs/store";
-import { ConcernState } from "../../state/concern.state";
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { MaterialModule } from "src/app/shared/material/material.module";
-import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { ReactiveFormsModule } from "@angular/forms";
-import { SetSelectedConcern } from "../../state/concern.actions";
-import { defaultConcern } from "../../constants";
-import { ConcernHistoryResponse2 } from "src/app/recommendation/mock-data/recommendation-spec-data";
-import { Observable } from "rxjs";
-import { IConcernSummary, ConcernStatus } from "../../concern.interfaces";
-import { RouterTestingModule } from "@angular/router/testing";
 
 describe("ConcernDetailComponent", () => {
   let component: ConcernDetailComponent;
   let fixture: ComponentFixture<ConcernDetailComponent>;
   let store: Store;
-  const setSelectedConcern = (concern: IConcernSummary): Observable<any> => {
-    return store.dispatch(new SetSelectedConcern(concern));
-  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -35,13 +29,12 @@ describe("ConcernDetailComponent", () => {
       ]
     }).compileComponents();
     store = TestBed.inject(Store);
-    setSelectedConcern(defaultConcern);
   }));
 
   beforeEach(() => {
     spyOn(
       ConcernDetailComponent.prototype,
-      "initialiseFormControls"
+      "updateFormControls"
     ).and.callThrough();
     spyOn(
       ConcernDetailComponent.prototype,
@@ -59,37 +52,34 @@ describe("ConcernDetailComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should initialise form controls", () => {
-    expect(component.initialiseFormControls).toHaveBeenCalled();
+  it("should update form controls", () => {
+    expect(component.updateFormControls).toHaveBeenCalled();
   });
 
   it("should reflect form values in add mode", () => {
-    fixture.detectChanges();
-    expect(component.dateOfIncident.value).toEqual(
-      defaultConcern.dateOfIncident
-    );
-    expect(component.source.value).toEqual(defaultConcern.source);
-    expect(component.concernType.value).toEqual(defaultConcern.concernType);
-    expect(component.dateReported.value).toEqual(defaultConcern.dateReported);
-    expect(component.followUpDate.value).toEqual(defaultConcern.followUpDate);
-    expect(component.status.value).toEqual(
-      component.getConcernStatus(defaultConcern.status)
-    );
+    expect(component.form.dateOfIncident.value).toBeNull();
+    expect(component.form.source.value).toBeNull();
+    expect(component.form.concernType.value).toBeNull();
+    expect(component.form.dateReported.value).toBeNull();
+    expect(component.form.followUpDate.value).toBeNull();
+    expect(component.form.status.value).toBeNull();
     expect(component.setConcernStatus(true)).toEqual(ConcernStatus.OPEN);
     expect(component.setConcernStatus(false)).toEqual(ConcernStatus.CLOSED);
   });
 
   it("should reflect form values in edit mode", async () => {
-    const newConcern: IConcernSummary = ConcernHistoryResponse2.concerns[0];
-    await setSelectedConcern(newConcern).toPromise();
-    fixture.detectChanges();
-    expect(component.dateOfIncident.value).toEqual(newConcern.dateOfIncident);
-    expect(component.source.value).toEqual(newConcern.source);
-    expect(component.concernType.value).toEqual(newConcern.concernType);
-    expect(component.dateReported.value).toEqual(newConcern.dateReported);
-    expect(component.followUpDate.value).toEqual(newConcern.followUpDate);
-    expect(component.status.value).toEqual(
-      component.getConcernStatus(newConcern.status)
+    const mockConcern: IConcernSummary = ConcernHistoryResponse2.concerns[0];
+    store.reset({ concern: { selected: mockConcern } });
+
+    expect(component.form.dateOfIncident.value).toEqual(
+      mockConcern.dateOfIncident
+    );
+    expect(component.form.source.value).toEqual(mockConcern.source);
+    expect(component.form.concernType.value).toEqual(mockConcern.concernType);
+    expect(component.form.dateReported.value).toEqual(mockConcern.dateReported);
+    expect(component.form.followUpDate.value).toEqual(mockConcern.followUpDate);
+    expect(component.form.status.value).toEqual(
+      component.getConcernStatus(mockConcern.status)
     );
     expect(component.setConcernStatus(true)).toEqual(ConcernStatus.OPEN);
     expect(component.setConcernStatus(false)).toEqual(ConcernStatus.CLOSED);

--- a/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.html
+++ b/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.html
@@ -10,8 +10,8 @@
     <mat-form-field>
       <mat-label>Grade</mat-label>
       <mat-select formControlName="grade">
-        <mat-option *ngFor="let grade of data.grades" [value]="grade.id">
-          {{ grade.name }}
+        <mat-option *ngFor="let grade of data.grades" [value]="grade">
+          {{ grade.label }}
         </mat-option>
       </mat-select>
     </mat-form-field>
@@ -21,7 +21,7 @@
     <mat-form-field>
       <mat-label>Site</mat-label>
       <mat-select formControlName="site">
-        <mat-option *ngFor="let site of data.sites" [value]="site.id">
+        <mat-option *ngFor="let site of data.sites" [value]="site">
           {{ site.siteName }}
         </mat-option>
       </mat-select>
@@ -33,10 +33,7 @@
     <mat-form-field>
       <mat-label>Employer</mat-label>
       <mat-select formControlName="employer">
-        <mat-option
-          *ngFor="let employer of data.employers"
-          [value]="employer.id"
-        >
+        <mat-option *ngFor="let employer of data.employers" [value]="employer">
           {{ employer.trustName }}
         </mat-option>
       </mat-select>
@@ -47,12 +44,7 @@
   </div>
 
   <div class="button-row">
-    <button
-      mat-button
-      mat-raised-button
-      type="button"
-      (click)="stepper.previous()"
-    >
+    <button mat-button mat-raised-button type="button" (click)="previous()">
       Back
     </button>
     <button mat-button mat-raised-button color="primary" type="submit">

--- a/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.spec.ts
+++ b/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.spec.ts
@@ -1,27 +1,21 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { NgxsModule, Store } from "@ngxs/store";
+import { AdminsModule } from "src/app/admins/admins.module";
 import { AdminsState } from "../../../admins/state/admins.state";
+import { ConcernHistoryResponse2 } from "../../../recommendation/mock-data/recommendation-spec-data";
 import { MaterialModule } from "../../../shared/material/material.module";
+import { IConcernSummary } from "../../concern.interfaces";
 import { ConcernState } from "../../state/concern.state";
 
 import { TraineeDetailComponent } from "./trainee-detail.component";
-import { ReactiveFormsModule } from "@angular/forms";
-import { AdminsModule } from "src/app/admins/admins.module";
-import { SetSelectedConcern } from "../../state/concern.actions";
-import { defaultConcern } from "../../constants";
-import { IConcernSummary } from "../../concern.interfaces";
-import { Observable } from "rxjs";
-import { ConcernHistoryResponse2 } from "src/app/recommendation/mock-data/recommendation-spec-data";
 
 describe("TraineeDetailComponent", () => {
   let component: TraineeDetailComponent;
   let fixture: ComponentFixture<TraineeDetailComponent>;
   let store: Store;
-  const setSelectedConcern = (concern: IConcernSummary): Observable<any> => {
-    return store.dispatch(new SetSelectedConcern(concern));
-  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -36,13 +30,12 @@ describe("TraineeDetailComponent", () => {
       ]
     }).compileComponents();
     store = TestBed.inject(Store);
-    setSelectedConcern(defaultConcern);
   }));
 
   beforeEach(() => {
     spyOn(
       TraineeDetailComponent.prototype,
-      "initialiseFormControls"
+      "updateFormControls"
     ).and.callThrough();
   });
 
@@ -56,37 +49,33 @@ describe("TraineeDetailComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should initialise form controls", () => {
-    expect(component.initialiseFormControls).toHaveBeenCalled();
+  it("should update form controls", () => {
+    expect(component.updateFormControls).toHaveBeenCalled();
   });
 
   it("should reflect form values in add mode", () => {
-    fixture.detectChanges();
-    expect(component.form.grade.value).toEqual(defaultConcern.grade);
-    expect(component.form.site.value).toEqual(defaultConcern.site);
-    expect(component.form.employer.value).toEqual(defaultConcern.employer);
+    expect(component.form.grade.value).toBeNull();
+    expect(component.form.site.value).toBeNull();
+    expect(component.form.employer.value).toBeNull();
   });
 
   it("should reflect no form validation when source is not set to `Lead Employer Trust (LET)`", () => {
-    fixture.detectChanges();
     expect(component.form.site.validator).toBeNull();
     expect(component.form.employer.validator).toBeNull();
   });
 
   it("should reflect form values in edit mode", async () => {
-    const newConcern: IConcernSummary = ConcernHistoryResponse2.concerns[0];
-    await setSelectedConcern(newConcern).toPromise();
-    fixture.detectChanges();
-    expect(component.form.grade.value).toEqual(newConcern.grade);
-    expect(component.form.site.value).toEqual(newConcern.site);
-    expect(component.form.employer.value).toEqual(newConcern.employer);
+    const mockConcern: IConcernSummary = ConcernHistoryResponse2.concerns[0];
+    store.reset({ concern: { selected: mockConcern } });
+    expect(component.form.grade.value).toEqual(mockConcern.grade);
+    expect(component.form.site.value).toEqual(mockConcern.site);
+    expect(component.form.employer.value).toEqual(mockConcern.employer);
   });
 
   it("should reflect required fields when source is `Lead Employer Trust (LET)` ", async () => {
-    const newConcern: IConcernSummary = ConcernHistoryResponse2.concerns[0];
-    newConcern.source = `Lead Employer Trust (LET)`;
-    await setSelectedConcern(newConcern).toPromise();
-    fixture.detectChanges();
+    const mockConcern: IConcernSummary = ConcernHistoryResponse2.concerns[0];
+    mockConcern.source.name = `Lead Employer Trust (LET)`;
+    store.reset({ concern: { selected: mockConcern } });
     expect(component.form.site.validator).toBeDefined();
     expect(component.form.employer.validator).toBeDefined();
   });

--- a/src/app/concern/create-concern-forms/upload-documents/upload-documents.component.spec.ts
+++ b/src/app/concern/create-concern-forms/upload-documents/upload-documents.component.spec.ts
@@ -1,4 +1,8 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule } from "@ngxs/store";
+import { ConcernState } from "../../state/concern.state";
 
 import { UploadDocumentsComponent } from "./upload-documents.component";
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
@@ -12,6 +16,9 @@ describe("UploadDocumentsComponent", () => {
   let component: UploadDocumentsComponent;
   let fixture: ComponentFixture<UploadDocumentsComponent>;
   let commentsService: CommentsService;
+  const activatedRoute = {
+    parent: { snapshot: { params: { gmcNumber: 0 } } }
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -20,9 +27,17 @@ describe("UploadDocumentsComponent", () => {
         ReactiveFormsModule,
         MaterialModule,
         NoopAnimationsModule,
-        HttpClientTestingModule
+        HttpClientTestingModule,
+        RouterTestingModule,
+        NgxsModule.forRoot([ConcernState])
       ],
-      providers: [CommentsService],
+      providers: [
+        CommentsService,
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRoute
+        }
+      ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   }));

--- a/src/app/concern/create-concern-forms/upload-documents/upload-documents.component.ts
+++ b/src/app/concern/create-concern-forms/upload-documents/upload-documents.component.ts
@@ -1,9 +1,15 @@
-import { Component, OnInit, Input, OnDestroy } from "@angular/core";
-import { MatStepper } from "@angular/material/stepper";
 import { StepperSelectionEvent } from "@angular/cdk/stepper";
-import { CommentsService } from "src/app/details/comments-tool-bar/comments.service";
+import { Component, Input, OnDestroy, OnInit } from "@angular/core";
 import { FormGroup } from "@angular/forms";
+import { MatStepper } from "@angular/material/stepper";
+import { ActivatedRoute, Router } from "@angular/router";
+import { Store } from "@ngxs/store";
 import { Subscription } from "rxjs";
+import { take } from "rxjs/operators";
+import { CommentsService } from "src/app/details/comments-tool-bar/comments.service";
+import { SnackBarService } from "../../../shared/services/snack-bar/snack-bar.service";
+import { ConcernService } from "../../services/concern/concern.service";
+import { Save } from "../../state/concern.actions";
 
 @Component({
   selector: "app-upload-documents",
@@ -14,7 +20,14 @@ export class UploadDocumentsComponent implements OnInit, OnDestroy {
   formGroup: FormGroup = new FormGroup({});
   subsciptions: Subscription[] = [];
 
-  constructor(private commentsService: CommentsService) {}
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private commentsService: CommentsService,
+    private concernService: ConcernService,
+    private router: Router,
+    private snackBarService: SnackBarService,
+    private store: Store
+  ) {}
 
   ngOnInit(): void {
     this.initialiseToolBarSettings();
@@ -48,5 +61,19 @@ export class UploadDocumentsComponent implements OnInit, OnDestroy {
     }
   }
 
-  saveConcern(): void {}
+  public saveConcern(): void {
+    const isConcernDetailFormValid: boolean = this.concernService.isConcernDetailFormValid.getValue();
+    const isTraineeDetailFormValid: boolean = this.concernService.isTraineeDetailFormValid.getValue();
+
+    if (isConcernDetailFormValid && isTraineeDetailFormValid) {
+      this.store
+        .dispatch(new Save())
+        .pipe(take(1))
+        .subscribe(() => {
+          this.router.navigate(["../"], { relativeTo: this.activatedRoute });
+        });
+    } else {
+      this.snackBarService.openSnackBar("Please ensure all steps are valid.");
+    }
+  }
 }

--- a/src/app/concern/resolvers/create-edit-concern.resolver.spec.ts
+++ b/src/app/concern/resolvers/create-edit-concern.resolver.spec.ts
@@ -71,7 +71,7 @@ describe("CreateEditConcernResolver", () => {
     expect(new CreateEditConcernResolver(store, router)).toBeTruthy();
   });
 
-  it("should create an default concern instance", async () => {
+  it("should create a default concern instance", async () => {
     req.flush(ConcernHistoryResponse1);
     await router.navigate(["create"]);
     const selectedConcern = store.selectSnapshot(ConcernState.selected);

--- a/src/app/concern/resolvers/create-edit-concern.resolver.ts
+++ b/src/app/concern/resolvers/create-edit-concern.resolver.ts
@@ -33,7 +33,6 @@ export class CreateEditConcernResolver implements Resolve<any> {
         return from(this.router.navigate(["/404"]));
       }
     } else {
-      defaultConcern.concernId = Number(route.parent.params.gmcNumber); // TODO: REMOVE AFTER UPLOAD BUG IS RESOLVED
       return this.store.dispatch(new SetSelectedConcern(defaultConcern));
     }
   }

--- a/src/app/concern/services/concern/concern.service.ts
+++ b/src/app/concern/services/concern/concern.service.ts
@@ -1,19 +1,75 @@
-import { Injectable } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
-
-import { Observable } from "rxjs";
+import { Injectable } from "@angular/core";
 import { environment } from "@environment";
-import { IGetConcernResponse } from "../../concern.interfaces";
+import { BehaviorSubject, Observable } from "rxjs";
+import {
+  IAddConcernRequest,
+  IConcernSummary,
+  IGetConcernResponse
+} from "../../concern.interfaces";
 
 @Injectable({
   providedIn: "root"
 })
 export class ConcernService {
+  public isConcernDetailFormValid: BehaviorSubject<
+    boolean
+  > = new BehaviorSubject(false);
+  public isTraineeDetailFormValid: BehaviorSubject<
+    boolean
+  > = new BehaviorSubject(false);
+
   constructor(private http: HttpClient) {}
 
   getConcernHistory(gmcNumber: number): Observable<IGetConcernResponse | any> {
     return this.http.get<IGetConcernResponse>(
       `${environment.appUrls.getConcern}/${gmcNumber}`
+    );
+  }
+
+  /**
+   * This method is needed to massage the POST request data
+   * i.e BE is sending different data type in the GET api
+   * and expect different data type on the POST api
+   * `employer, grade & site` fields are conditionally added as per there validation rules
+   * @param payload - IAddConcernRequest
+   */
+  public generatePayload(payload: IConcernSummary): IAddConcernRequest {
+    return {
+      ...payload,
+      employer: payload.employer
+        ? {
+            id: payload.employer.id,
+            label: payload.employer.trustName
+          }
+        : undefined,
+      grade: payload.grade
+        ? {
+            id: payload.grade.id,
+            label: payload.grade.name
+          }
+        : undefined,
+      site: payload.site
+        ? {
+            id: payload.site.id,
+            label: payload.site.siteName
+          }
+        : undefined,
+      source: {
+        id: payload.source.id,
+        label: payload.source.name
+      },
+      concernType: {
+        id: payload.concernType.id,
+        label: payload.concernType.label
+      }
+    };
+  }
+
+  public addConcern(payload: IConcernSummary): Observable<any> {
+    return this.http.post<any>(
+      environment.appUrls.addConcern,
+      this.generatePayload(payload)
     );
   }
 }

--- a/src/app/concern/state/concern.actions.ts
+++ b/src/app/concern/state/concern.actions.ts
@@ -1,25 +1,18 @@
 import { HttpErrorPayload } from "../../shared/services/error/error.service";
 import { IConcernSummary } from "../concern.interfaces";
-import { HttpEvent, HttpProgressEvent } from "@angular/common/http";
 
 export class Get {
   static readonly type = "[Concern] Get";
   constructor(public payload: number) {}
 }
 
-export class Set {
-  static readonly type = "[Concern] Set";
-  constructor(public payload: IConcernSummary) {}
+export class Save {
+  static readonly type = "[Concern] Save";
 }
 
-export class Add {
-  static readonly type = "[Concern] Add";
-  constructor(public payload: IConcernSummary) {}
-}
-
-export class Post {
-  static readonly type = "[Concern] Post";
-  constructor(public gmcNumber: number, public concernId: string) {}
+export class SaveSuccess {
+  static readonly type = "[Concern] Save Success";
+  constructor(public payload: any) {}
 }
 
 export class Upload {

--- a/src/app/concern/uploaded-files-list/uploaded-files-list.component.ts
+++ b/src/app/concern/uploaded-files-list/uploaded-files-list.component.ts
@@ -15,29 +15,23 @@ import { IConcernSummary } from "../concern.interfaces";
 export class UploadedFilesListComponent implements OnInit {
   public dateFormat = environment.dateFormat;
   public gmcNumber: number = this.store.selectSnapshot(ConcernState.gmcNumber);
+  public concernId: number = this.store.selectSnapshot(ConcernState.selected)
+    .concernId;
   @Select(ConcernState.listFilesInProgress)
   public listFilesInProgress$: Observable<boolean>;
   @Select(ConcernState.uploadedFiles) public uploadedFiles$: Observable<any[]>;
   @Select(ConcernState.selected)
   selectedConcern$: Observable<IConcernSummary>;
   public acceptedImageExtensions: string[] = ACCEPTED_IMAGE_EXTENSIONS;
-  public concernId?: number;
 
   constructor(private store: Store) {}
 
   ngOnInit(): void {
-    this.setConcernId();
+    this.listFiles();
   }
 
   public downloadFile(fileName: string, key: string): Observable<any> {
     return this.store.dispatch(new DownloadFile(fileName, key));
-  }
-
-  public setConcernId(): void {
-    this.selectedConcern$.subscribe((selectedConcern: IConcernSummary) => {
-      this.concernId = selectedConcern.concernId;
-      this.listFiles();
-    });
   }
 
   public deleteFile(fileName: string, key: string): Observable<any> {
@@ -47,6 +41,8 @@ export class UploadedFilesListComponent implements OnInit {
   }
 
   public listFiles(): Observable<any> {
-    return this.store.dispatch(new ListFiles(this.gmcNumber, this.concernId));
+    if (this.concernId) {
+      return this.store.dispatch(new ListFiles(this.gmcNumber, this.concernId));
+    }
   }
 }

--- a/src/app/recommendation/mock-data/recommendation-spec-data.ts
+++ b/src/app/recommendation/mock-data/recommendation-spec-data.ts
@@ -21,5 +21,126 @@ export const notesResponse1 = JSON.parse(`[
 
 export const ConcernHistoryResponse1 = {};
 export const ConcernHistoryResponse2 = JSON.parse(
-  `{"gmcNumber":"65477888","concerns":[{"concernId":"70244","gmcNumber":"65477888","dateOfIncident":"2020-06-28","concernType":"AAAA","source":"BBBBB","dateReported":"2020-06-29","employer":"Royal London Hospital Trust","site":"AAAAA","grade":"Academic Clinical Fellow","status":"CLOSED","admin":"AAAAA","followUpDate":"2020-07-05","lastUpdatedDate":"2020-06-24","comments":["This is a test comment","and more"]},{"concernId":"70245","gmcNumber":"65477888","dateOfIncident":"2020-76-28","concernType":"AAAA","source":"BBBBB","dateReported":"2020-06-29","employer":"Royal London Hospital Trust","site":"AAAAA","grade":"Academic Clinical Fellow","status":"OPEN","admin":"AAAAA","followUpDate":"2020-07-05","lastUpdatedDate":"2020-06-24","comments":["This is a test comment","and less","and very less"]}]}`
+  `{
+    "gmcNumber": "65477888",
+    "concerns": [{
+        "concernId": "70244",
+        "gmcNumber": "65477888",
+        "dateOfIncident": "2020-06-28",
+        "concernType": {
+            "id": 1,
+            "code": "SERIOUS_INCIDENT",
+            "label": "Serious Incident"
+        },
+        "source": {
+            "id": 1,
+            "name": "Lead Employer Trust (LET)"
+        },
+        "dateReported": "2020-06-29",
+        "employer": {
+            "id": 1,
+            "code": "509",
+            "localOffice": null,
+            "status": "CURRENT",
+            "trustKnownAs": "Leicester City Council",
+            "trustName": "Leicester City Council",
+            "trustNumber": "509",
+            "address": null,
+            "postCode": null,
+            "intrepidId": "5526"
+        },
+        "site": {
+            "id": 1,
+            "siteCode": null,
+            "startDate": null,
+            "endDate": null,
+            "localOffice": null,
+            "trustCode": null,
+            "trustId": null,
+            "siteName": "Norfolk PCT",
+            "address": "   ",
+            "postCode": null,
+            "siteKnownAs": "Norfolk PCT",
+            "siteNumber": null,
+            "organisationalUnit": null,
+            "status": "INACTIVE",
+            "intrepidId": "16077"
+        },
+        "grade": {
+            "id": 33,
+            "abbreviation": "LCL",
+            "name": "Local Clinical Lecturer - HENW",
+            "label": "Local Clinical Lecturer - HENW",
+            "trainingGrade": true,
+            "postGrade": false,
+            "placementGrade": true,
+            "status": "CURRENT",
+            "intrepidId": "853256"
+        },
+        "status": "CLOSED",
+        "admin": "AAAAA",
+        "followUpDate": "2020-07-05",
+        "lastUpdatedDate": "2020-06-24",
+        "comments": ["This is a test comment", "and more"]
+    }, {
+        "concernId": "70245",
+        "gmcNumber": "65477888",
+        "dateOfIncident": "2020-76-28",
+        "concernType": {
+            "id": 1,
+            "code": "SERIOUS_INCIDENT",
+            "label": "Serious Incident"
+        },
+        "source": {
+            "id": 1,
+            "name": "Lead Employer Trust (LET)"
+        },
+        "dateReported": "2020-06-29",
+        "employer": {
+            "id": 1,
+            "code": "509",
+            "localOffice": null,
+            "status": "CURRENT",
+            "trustKnownAs": "Leicester City Council",
+            "trustName": "Leicester City Council",
+            "trustNumber": "509",
+            "address": null,
+            "postCode": null,
+            "intrepidId": "5526"
+        },
+        "site": {
+            "id": 1,
+            "siteCode": null,
+            "startDate": null,
+            "endDate": null,
+            "localOffice": null,
+            "trustCode": null,
+            "trustId": null,
+            "siteName": "Norfolk PCT",
+            "address": "   ",
+            "postCode": null,
+            "siteKnownAs": "Norfolk PCT",
+            "siteNumber": null,
+            "organisationalUnit": null,
+            "status": "INACTIVE",
+            "intrepidId": "16077"
+        },
+        "grade": {
+            "id": 33,
+            "abbreviation": "LCL",
+            "name": "Local Clinical Lecturer - HENW",
+            "label": "Local Clinical Lecturer - HENW",
+            "trainingGrade": true,
+            "postGrade": false,
+            "placementGrade": true,
+            "status": "CURRENT",
+            "intrepidId": "853256"
+        },
+        "status": "OPEN",
+        "admin": "AAAAA",
+        "followUpDate": "2020-07-05",
+        "lastUpdatedDate": "2020-06-24",
+        "comments": ["This is a test comment", "and less", "and very less"]
+    }]
+}`
 );

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -1,6 +1,7 @@
 import { IEnvironment } from "./environment.interface";
 
 export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
+  addConcern: "api/concerns",
   allocateAdmin: `api/v1/doctors/assign-admin`,
   authRedirect: ``,
   deleteFile: `api/storage/delete`,

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -11,6 +11,7 @@ export abstract class IEnvironment {
    * Add api urls here as required
    */
   abstract readonly appUrls: {
+    readonly addConcern: string;
     readonly allocateAdmin: string;
     readonly authRedirect: string;
     readonly deleteFile: string;
@@ -22,8 +23,8 @@ export abstract class IEnvironment {
     readonly getNotes: string;
     readonly getRecommendation: string;
     readonly getRecommendations: string;
-    readonly listFiles: string;
     readonly listAdmins: string;
+    readonly listFiles: string;
     readonly login: string;
     readonly saveRecommendation: string;
     readonly submitToGMC: string;

--- a/src/environments/environment.mocky.ts
+++ b/src/environments/environment.mocky.ts
@@ -17,11 +17,12 @@ export const environment: IEnvironment = {
     // 0681fad7-c7b3-4543-83fa-dd4c3ed14e4a = 500 error
     // 5e997d8a33000062007b2354 = 21 recommendations
     // 5e997dba33000096297b235d = 0 recommendations to simulate no results found
+    addConcern: "", // TODO mock this
     allocateAdmin: `api/v1/doctors/assignAdmin`, // TODO mock this
     authRedirect: ``,
     deleteFile: ``, // TODO mock this,
     downloadFile: ``, // TODO mock this
-    getConcern: `mocky/0a459279-bdca-4b1b-9e07-d55c7f38630e`,
+    getConcern: `mocky/f98de467-3291-4ffc-b523-0e99afc005cb`,
     getConcerns: `mocky/c25f77cf-594a-484b-b50b-562aa9438115?mocky-delay=700ms`,
     getConnections: `mocky/8e9b38d0-5d33-479e-bea7-e23b781b5c23?mocky-delay=700ms`,
     getDetails: `mocky/298f7e18-12d4-4e1b-9195-0bba7feb56b0`,


### PR DESCRIPTION
TISNEW-5042

feat: add concern

- consumed add concern api in the FE & only create concern if form steps are valid
- consumed newly exposed list of types and sources to populate dropdowns in the FE & removed hard coded lists
- fixed duplicate list files api call by triggering once `OnInit` instead of listening to create concern state updates
- ensured add concern state is persisted when navigating between steps
- updated FE mocks (mocky & spec data)
- simplified forms and updated unit tests