### PR TITLE
refactor: create generic enum key grabber

### DIFF
--- a/src/app/concern/create-concern-forms/concern-detail/concern-detail.component.ts
+++ b/src/app/concern/create-concern-forms/concern-detail/concern-detail.component.ts
@@ -4,6 +4,7 @@ import { MatStepper } from "@angular/material/stepper";
 import { Select, Store } from "@ngxs/store";
 import { Observable, Subscription } from "rxjs";
 import { filter } from "rxjs/operators";
+import { ApiService } from "../../../shared/services/api/api.service";
 import {
   ConcernStatus,
   IConcernSummary,
@@ -40,7 +41,11 @@ export class ConcernDetailComponent implements OnDestroy {
     return this.formGroup.controls;
   }
 
-  constructor(private store: Store, private concernService: ConcernService) {
+  constructor(
+    private store: Store,
+    private apiService: ApiService,
+    private concernService: ConcernService
+  ) {
     this.setupForm();
     this.subscribeToStatusChanges();
     this.updateFormControls();
@@ -92,7 +97,10 @@ export class ConcernDetailComponent implements OnDestroy {
     const newConcern = {
       ...this.concern,
       ...this.formGroup.value,
-      status: this.setConcernStatus(this.form.status.value)
+      status: this.apiService.getEnumKey(
+        ConcernStatus,
+        this.setConcernStatus(this.form.status.value)
+      )
     };
 
     this.store.dispatch(new SetSelectedConcern(newConcern));

--- a/src/app/concern/services/concern/concern.service.ts
+++ b/src/app/concern/services/concern/concern.service.ts
@@ -66,10 +66,13 @@ export class ConcernService {
     };
   }
 
-  public addConcern(payload: IConcernSummary): Observable<any> {
-    return this.http.post<any>(
+  public addConcern(payload: IConcernSummary): Observable<string> {
+    return this.http.post(
       environment.appUrls.addConcern,
-      this.generatePayload(payload)
+      this.generatePayload(payload),
+      {
+        responseType: "text"
+      }
     );
   }
 }

--- a/src/app/concern/services/upload/upload.service.ts
+++ b/src/app/concern/services/upload/upload.service.ts
@@ -1,15 +1,8 @@
-import {
-  HttpClient,
-  HttpParams,
-  HttpEvent,
-  HttpProgressEvent,
-  HttpEventType
-} from "@angular/common/http";
+import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { environment } from "@environment";
 import { Observable } from "rxjs";
 import { IListFile } from "../../concern.interfaces";
-import { map } from "rxjs/operators";
 
 @Injectable({
   providedIn: "root"

--- a/src/app/shared/services/api/api.service.spec.ts
+++ b/src/app/shared/services/api/api.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { ApiService } from "./api.service";
+
+describe("ApiService", () => {
+  let service: ApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ApiService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/api/api.service.ts
+++ b/src/app/shared/services/api/api.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from "@angular/core";
+
+@Injectable({
+  providedIn: "root"
+})
+export class ApiService {
+  public getEnumKey(enumList: any, enumValue: any): string {
+    return Object.entries(enumList).filter((item: any[]) =>
+      item.includes(enumValue)
+    )[0][0];
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { PageNotFoundComponent } from "./page-not-found/page-not-found.component";
+import { ApiService } from "./services/api/api.service";
 import { StripHtmlPipe } from "./strip-html.pipe";
 import { FileBytesPipe } from "./file-bytes.pipe";
 
@@ -8,6 +9,7 @@ const modulePipes = [StripHtmlPipe, FileBytesPipe];
 @NgModule({
   declarations: [PageNotFoundComponent, ...modulePipes],
   imports: [RouterModule],
-  exports: [...modulePipes]
+  exports: [...modulePipes],
+  providers: [ApiService]
 })
 export class SharedModule {}


### PR DESCRIPTION
TISNEW-5042

refactor: create generic enum key grabber in order to send BE enum keys when invoking api's

- also set responseType to text for add concern api 