### PR TITLE
refactor | make filters generic | step 2

### DIFF
--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -6,6 +6,7 @@ import { generateColumnData } from "../records/constants";
 import { RecordsResolver } from "../records/records.resolver";
 import { RecordsService } from "../records/services/records.service";
 import { COLUMN_DATA } from "./constants";
+import { RecommendationsFilterType } from "./recommendations.interfaces";
 
 @Injectable()
 export class RecommendationsResolver extends RecordsResolver
@@ -29,6 +30,16 @@ export class RecommendationsResolver extends RecordsResolver
       "lastUpdatedDate"
     ];
     this.recordsService.columnData = generateColumnData(COLUMN_DATA);
+    this.recordsService.filters = [
+      {
+        label: "ALL DOCTORS",
+        name: RecommendationsFilterType.ALL_DOCTORS
+      },
+      {
+        label: "UNDER NOTICE ",
+        name: RecommendationsFilterType.UNDER_NOTICE
+      }
+    ];
   }
 
   resolve(route: ActivatedRouteSnapshot): Observable<any> {

--- a/src/app/recommendations/state/recommendations.state.spec.ts
+++ b/src/app/recommendations/state/recommendations.state.spec.ts
@@ -64,14 +64,15 @@ describe("Recommendations state", () => {
     });
   });
 
-  it("should dispatch 'Get' and select 'countTotal' slice", () => {
+  it("should dispatch 'Get' and select 'allDoctors' slice", () => {
     spyOn(recordsService, "getRecords").and.returnValue(
       of(mockRecommendationsResponse)
     );
 
     store.dispatch(new GetRecommendations()).subscribe(() => {
-      const countTotal = store.snapshot().recommendations.countTotal;
-      expect(countTotal).toEqual(21312);
+      const allDoctors = store.snapshot().recommendations.totalCounts
+        .allDoctors;
+      expect(allDoctors).toEqual(21312);
     });
   });
 

--- a/src/app/records/record-list-filters/record-list-filters.component.html
+++ b/src/app/records/record-list-filters/record-list-filters.component.html
@@ -1,29 +1,23 @@
 <ng-container
   *ngIf="{
-    countTotal: countTotal$ | async,
-    countUnderNotice: countUnderNotice$ | async,
+    totalCounts: totalCounts$ | async,
     filter: filter$ | async,
     enableAllocateAdmin: enableAllocateAdmin$ | async
   } as data"
 >
   <nav mat-tab-nav-bar>
     <a
+      *ngFor="let i of filters"
       mat-tab-link
-      [active]="data.filter === allDoctors"
-      aria-label="Filter all doctors"
-      (click)="filterRecords(allDoctors)"
+      [active]="data.filter === i.name"
+      [attr.aria-label]="'Filter ' + i.label.toLowerCase() + 'records'"
+      (click)="filterRecords(i.name)"
       [disabled]="data.enableAllocateAdmin"
     >
-      ALL DOCTORS - {{ data.countTotal }}
-    </a>
-    <a
-      mat-tab-link
-      [active]="data.filter === underNotice"
-      aria-label="Filter under notice"
-      (click)="filterRecords(underNotice)"
-      [disabled]="data.enableAllocateAdmin"
-    >
-      UNDER NOTICE - {{ data.countUnderNotice }}
+      {{ i.label }} -
+      <ng-container *ngIf="data.totalCounts?.hasOwnProperty(i.name)">
+        {{ data.totalCounts[i.name] }}
+      </ng-container>
     </a>
   </nav>
 </ng-container>

--- a/src/app/records/record-list-filters/record-list-filters.component.ts
+++ b/src/app/records/record-list-filters/record-list-filters.component.ts
@@ -1,30 +1,25 @@
 import { Component } from "@angular/core";
-import { Select, Store } from "@ngxs/store";
+import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
+import { IFilter, ITotalCounts } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
-import { RecommendationsFilterType } from "../../recommendations/recommendations.interfaces";
-import { RecommendationsState } from "../../recommendations/state/recommendations.state";
 
 @Component({
   selector: "app-record-list-filters",
   templateUrl: "./record-list-filters.component.html"
 })
 export class RecordListFiltersComponent {
-  @Select(RecommendationsState.countTotal) countTotal$: Observable<number>;
-  @Select(RecommendationsState.countUnderNotice) countUnderNotice$: Observable<
-    number
-  >;
+  public totalCounts$: Observable<ITotalCounts> = this.store.select(
+    (state) => state[this.recordsService.stateName].totalCounts
+  );
   public filter$: Observable<string> = this.store.select(
     (state) => state[this.recordsService.stateName].filter
   );
   public enableAllocateAdmin$: Observable<boolean> = this.store.select(
     (state) => state[this.recordsService.stateName].enableAllocateAdmin
   );
-  public allDoctors: RecommendationsFilterType =
-    RecommendationsFilterType.ALL_DOCTORS;
-  public underNotice: RecommendationsFilterType =
-    RecommendationsFilterType.UNDER_NOTICE;
+  public filters: IFilter[] = this.recordsService.filters;
 
   constructor(private store: Store, private recordsService: RecordsService) {}
 

--- a/src/app/records/records.interfaces.ts
+++ b/src/app/records/records.interfaces.ts
@@ -9,3 +9,12 @@ export interface IRecordDataCell {
   name: string;
   enableSort?: boolean;
 }
+
+export interface ITotalCounts {
+  [key: string]: number;
+}
+
+export interface IFilter {
+  label: string;
+  name: string;
+}

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -46,7 +46,7 @@ import {
   ToggleAllRecommendationsCheckboxes,
   ToggleRecommendationsCheckbox
 } from "../../recommendations/state/recommendations.actions";
-import { IRecordDataCell } from "../records.interfaces";
+import { IFilter, IRecordDataCell } from "../records.interfaces";
 
 @Injectable({
   providedIn: "root"
@@ -57,6 +57,7 @@ export class RecordsService {
   public dateColumns: string[];
   public columnData: IRecordDataCell[];
   public detailsRoute: string;
+  public filters: IFilter[];
 
   // TODO type these
   public clearSearchAction: any;

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -3,37 +3,46 @@ import { Sort as ISort } from "@angular/material/sort/sort";
 import { createSelector, StateContext } from "@ngxs/store";
 import { patch, updateItem } from "@ngxs/store/operators";
 import { DEFAULT_SORT } from "../constants";
+import { ITotalCounts } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
 
 export class RecordsStateModel<T, F> {
-  public enableAllocateAdmin?: boolean;
   public allChecked: boolean;
-  public someChecked: boolean;
+  public enableAllocateAdmin?: boolean;
   public error?: string;
   public filter: T;
   public items: F;
   public loading: boolean;
   public pageIndex: number;
   public searchQuery: string;
+  public someChecked: boolean;
   public sort: ISort;
   public totalPages: number;
   public totalResults: number;
+  public totalCounts: ITotalCounts;
 }
 
 export const defaultRecordsState = {
-  items: null,
   allChecked: false,
-  someChecked: false,
+  items: null,
   loading: null,
   pageIndex: 0,
   searchQuery: null,
+  someChecked: false,
   sort: DEFAULT_SORT,
   totalPages: null,
-  totalResults: null
+  totalResults: null,
+  totalCounts: null
 };
 
 export class RecordsState {
   constructor(protected recordsService: RecordsService) {}
+
+  static totalCounts<T>() {
+    return createSelector([this], (state: { totalCounts: ITotalCounts }) => {
+      return state.totalCounts;
+    });
+  }
 
   static allChecked<T>() {
     return createSelector([this], (state: { allChecked: boolean }) => {


### PR DESCRIPTION
NO-TICKET

refactor | make filters generic | step 2. Leftover work to complete making filters generic so that the same code can be used across recommendations, concerns and connections