### PR TITLE
fix: clear pending admin changes

### DIFF
--- a/src/app/admins/state/admins.state.ts
+++ b/src/app/admins/state/admins.state.ts
@@ -43,6 +43,11 @@ export class AdminsState {
   }
 
   @Selector()
+  public static allocateList(state: AdminsStateModel) {
+    return state.allocateList;
+  }
+
+  @Selector()
   public static error(state: AdminsStateModel) {
     return state.error;
   }

--- a/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.spec.ts
+++ b/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.spec.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { NgxsModule, Store } from "@ngxs/store";
 import { AdminsModule } from "src/app/admins/admins.module";
+import { ClearAllocateList } from "../../../admins/state/admins.actions";
 import { AdminsState } from "../../../admins/state/admins.state";
 import { ConcernHistoryResponse2 } from "../../../recommendation/mock-data/recommendation-spec-data";
 import { MaterialModule } from "../../../shared/material/material.module";
@@ -78,5 +79,11 @@ describe("TraineeDetailComponent", () => {
     store.reset({ concern: { selected: mockConcern } });
     expect(component.form.site.validator).toBeDefined();
     expect(component.form.employer.validator).toBeDefined();
+  });
+
+  it("should dispatch `ClearAllocateList` onDestroy lifecycle", () => {
+    spyOn(store, "dispatch");
+    component.ngOnDestroy();
+    expect(store.dispatch).toHaveBeenCalledWith(new ClearAllocateList());
   });
 });

--- a/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.ts
+++ b/src/app/concern/create-concern-forms/trainee-detail/trainee-detail.component.ts
@@ -6,6 +6,7 @@ import { Select, Store } from "@ngxs/store";
 import { Observable, Subscription } from "rxjs";
 import { filter } from "rxjs/operators";
 import { IAllocateAdmin } from "src/app/admins/admins.interfaces";
+import { ClearAllocateList } from "../../../admins/state/admins.actions";
 import { AdminsState } from "../../../admins/state/admins.state";
 import { IConcernSummary, IEntity } from "../../concern.interfaces";
 import { ConcernService } from "../../services/concern/concern.service";
@@ -60,6 +61,8 @@ export class TraineeDetailComponent implements OnDestroy {
         subscribed.unsubscribe();
       }
     });
+
+    this.store.dispatch(new ClearAllocateList());
   }
 
   private setupForm(): void {

--- a/src/app/concern/create-concern-forms/upload-documents/upload-documents.component.ts
+++ b/src/app/concern/create-concern-forms/upload-documents/upload-documents.component.ts
@@ -1,24 +1,21 @@
-import { StepperSelectionEvent } from "@angular/cdk/stepper";
 import {
+  AfterViewInit,
   Component,
   Input,
   OnDestroy,
-  OnInit,
-  ViewChild,
-  AfterViewInit
+  ViewChild
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { MatStepper } from "@angular/material/stepper";
-import { Store, Select } from "@ngxs/store";
-import { Subscription, Observable } from "rxjs";
-import { CommentsService } from "src/app/details/comments/comments.service";
+import { Select, Store } from "@ngxs/store";
+import { Observable, Subscription } from "rxjs";
+import { filter } from "rxjs/operators";
+import { CommentsComponent } from "src/app/details/comments/comments.component";
 import { SnackBarService } from "../../../shared/services/snack-bar/snack-bar.service";
+import { IConcernSummary } from "../../concern.interfaces";
 import { ConcernService } from "../../services/concern/concern.service";
 import { Save, SetSelectedConcern } from "../../state/concern.actions";
-import { CommentsComponent } from "src/app/details/comments/comments.component";
 import { ConcernState } from "../../state/concern.state";
-import { IConcernSummary } from "../../concern.interfaces";
-import { take, filter } from "rxjs/operators";
 
 @Component({
   selector: "app-upload-documents",

--- a/src/app/records/record-list/record-list.component.spec.ts
+++ b/src/app/records/record-list/record-list.component.spec.ts
@@ -6,6 +6,7 @@ import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
 import { AdminsModule } from "../../admins/admins.module";
+import { ClearAllocateList } from "../../admins/state/admins.actions";
 import { AdminsState } from "../../admins/state/admins.state";
 import { COLUMN_DATA } from "../../concerns/constants";
 import { RecommendationStatus } from "../../recommendation/recommendation-history.interface";
@@ -127,5 +128,11 @@ describe("RecordListComponent", () => {
     );
     expect(recordsService.resetPaginator).toHaveBeenCalled();
     expect(recordsService.updateRoute).toHaveBeenCalled();
+  });
+
+  it("should dispatch `ClearAllocateList` onDestroy lifecycle", () => {
+    spyOn(store, "dispatch");
+    component.ngOnDestroy();
+    expect(store.dispatch).toHaveBeenCalledWith(new ClearAllocateList());
   });
 });

--- a/src/app/records/record-list/record-list.component.ts
+++ b/src/app/records/record-list/record-list.component.ts
@@ -1,10 +1,11 @@
-import { Component } from "@angular/core";
+import { Component, OnDestroy } from "@angular/core";
 import { Sort as ISort } from "@angular/material/sort/sort";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { environment } from "@environment";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
+import { ClearAllocateList } from "../../admins/state/admins.actions";
 import { IRecordDataCell } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
 
@@ -13,7 +14,7 @@ import { RecordsService } from "../services/records.service";
   templateUrl: "./record-list.component.html",
   styleUrls: ["./record-list.component.scss"]
 })
-export class RecordListComponent {
+export class RecordListComponent implements OnDestroy {
   public columnData: IRecordDataCell[] = this.recordsService.columnData;
   public dateColumns: string[] = this.recordsService.dateColumns;
   public detailsRoute: string = this.recordsService.detailsRoute;
@@ -89,5 +90,9 @@ export class RecordListComponent {
 
   public toggleCheckbox(gmcReferenceNumber: string): void {
     this.recordsService.toggleCheckbox(gmcReferenceNumber);
+  }
+
+  ngOnDestroy() {
+    this.store.dispatch(new ClearAllocateList());
   }
 }

--- a/src/environments/environment.mocky.ts
+++ b/src/environments/environment.mocky.ts
@@ -15,10 +15,10 @@ export const environment: IEnvironment = {
   appUrls: {
     // 665938a6-29d2-4199-a2d8-364f520b298c = 404 error
     // 0681fad7-c7b3-4543-83fa-dd4c3ed14e4a = 500 error
-    // 5e997d8a33000062007b2354 = 21 recommendations
-    // 5e997dba33000096297b235d = 0 recommendations to simulate no results found
+    // 81267580-411e-4ce6-8dca-2f65f9d2e485 = 21 recommendations
+    // b51bc121-4687-4e3e-a181-a178874121a2 = 0 recommendations to simulate no results found
     addConcern: "", // TODO mock this
-    allocateAdmin: `api/v1/doctors/assignAdmin`, // TODO mock this
+    allocateAdmin: `mocky/0bd1baab-9912-4806-be6d-f680725174b4?mocky-delay=700ms`,
     authRedirect: ``,
     deleteFile: ``, // TODO mock this,
     downloadFile: ``, // TODO mock this
@@ -29,7 +29,7 @@ export const environment: IEnvironment = {
     getNotes: `mocky/45017692-2588-48dc-b6c2-c637cd723625`,
     getRecommendation: `mocky/6fd60c05-b4d0-462d-87a8-87402d57bd2e`,
     getRecommendations: `mocky/81267580-411e-4ce6-8dca-2f65f9d2e485?mocky-delay=700ms`,
-    listAdmins: ``, // TODO mock this
+    listAdmins: `mocky/a087f46e-e788-4d62-b452-f3fec748f51d?mocky-delay=700ms`,
     listFiles: ``, // TODO mock this
     login: ``,
     saveRecommendation: `api/recommendation`, // TODO mock this


### PR DESCRIPTION
NO-TICKET

fix: clear any pending admin changes on summary and create concern screens when components are destroyed  

- update mock endpoints
- remove unused imports