### PR TITLE
chore: Set stage task to minimum resource amounts

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -36,6 +36,6 @@
   "placementConstraints": [],
   "executionRoleArn": "ecsTaskExecutionRole",
   "family": "reval-fe",
-  "memory": "2048",
-  "cpu": "1024"
+  "memory": "512",
+  "cpu": "256"
 }


### PR DESCRIPTION
The memory and cpu are set unnecesarily high for the stage tasks, reduce
them down to the smallest allowed values.

NO-TICKET