### PR TITLE
Âfix: edit recommendation render error

### DIFF
--- a/src/app/details/comments/comments.component.ts
+++ b/src/app/details/comments/comments.component.ts
@@ -36,6 +36,7 @@ export class CommentsComponent implements OnInit {
    * adds an empty comment FormGroup for readily adding comment
    */
   private createCommentControls(): void {
+    if (!this.featureComments) this.featureComments = [];
     this.commentsService.comments = this.comments;
     for (const comment of this.featureComments) {
       this.commentsService.addCommentControl(comment);


### PR DESCRIPTION
Inelegant fix for a UI error. Root cause of the issue is lack of handling of instances where featureComments is null when passed to the comments component. In local builds this does not present an issue but on staging & prod this causes the form rendering to crash.