### PR TITLE
fix: remove make recommendation from reval admin role

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -4,7 +4,7 @@ import { CognitoUserSession } from "amazon-cognito-identity-js";
 import { Auth } from "aws-amplify";
 import { from, Observable } from "rxjs";
 import { catchError, tap } from "rxjs/operators";
-import { ADMIN_ROLES, LONDON_DBCS } from "src/environments/constants";
+import { ADMIN_ROLES, LONDON_DBCS, APPROVER_ROLES } from "src/environments/constants";
 
 @Injectable({
   providedIn: "root"
@@ -17,6 +17,7 @@ export class AuthService {
   public userDesignatedBodies: string[] = [];
   public inludesLondonDbcs = false;
   public isSuperAdmin = false;
+  public isRevalApprover = false;
 
   constructor() {}
 
@@ -31,6 +32,10 @@ export class AuthService {
         this.roles = cognitoIdToken.payload["cognito:roles"] || [];
         this.isSuperAdmin = this.roles.some((role) =>
           ADMIN_ROLES.includes(role)
+        );
+
+        this.isRevalApprover = this.roles.some((role) =>
+          APPROVER_ROLES.includes(role)
         );
 
         let dbcs: string[] = cognitoIdToken.payload["cognito:groups"] || [];

--- a/src/app/recommendation/create-recommendation/create-recommendation.component.html
+++ b/src/app/recommendation/create-recommendation/create-recommendation.component.html
@@ -85,7 +85,7 @@
     >
       Save draft
     </button>
-    <button
+    <button *ngIf="isRevalApprover"
       type="submit"
       mat-button
       mat-raised-button

--- a/src/app/recommendation/create-recommendation/create-recommendation.component.ts
+++ b/src/app/recommendation/create-recommendation/create-recommendation.component.ts
@@ -57,6 +57,8 @@ export class CreateRecommendationComponent implements OnInit, OnDestroy {
   maxReferralDate: Date;
   deferSelected: boolean;
 
+  isRevalApprover: boolean;
+
   constructor(
     private store: Store,
     private activatedRoute: ActivatedRoute,
@@ -67,6 +69,7 @@ export class CreateRecommendationComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.isRevalApprover = this.auth.isRevalApprover;
     this.recommendationHistory$
       .pipe(take(1))
       .subscribe((recommendationHistory: IRecommendationHistory) => {

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -48,3 +48,7 @@ export const ADMIN_ROLES = [
   "RevalApprover",
   "RevalAdmin"
 ];
+
+export const APPROVER_ROLES = [
+  "RevalApprover"
+];


### PR DESCRIPTION
There are 3 roles in revalidation arena. They are "RevalApprover", "RevalAdmin" and "RevalObserver". Reval approver can read, write and make recommendation, Reval admin can read and write but should not be allowed to make recommendation. This fix will take care of that.

Reval Observer has only read permission, which has already been handled in the app. 

For more info, please refer to this page
https://hee-tis.atlassian.net/wiki/spaces/NTCS/pages/1671495738/Revalidation+-+Access+Permissions

TIS21-2272