### PR TITLE
chore: hide concern and connection from main and navigation menu

### DIFF
--- a/src/app/details/nav-bar/nav-bar.component.spec.ts
+++ b/src/app/details/nav-bar/nav-bar.component.spec.ts
@@ -28,7 +28,7 @@ describe("NavBarComponent", () => {
 
   it("should create navLinks", () => {
     expect(component.navLinks).toBeInstanceOf(Array);
-    expect(component.navLinks.length).toEqual(3);
+    expect(component.navLinks.length).toEqual(1);
   });
 
   it("navLinks should have a label", () => {

--- a/src/app/details/nav-bar/nav-bar.component.ts
+++ b/src/app/details/nav-bar/nav-bar.component.ts
@@ -18,15 +18,6 @@ export class NavBarComponent implements OnInit {
         label: "Recommendation",
         path: `/recommendation/${gmcNumber}`
       }
-      // },
-      // {
-      //   label: "Concern",
-      //   path: `/concern/${gmcNumber}`
-      // },
-      // {
-      //   label: "Connection",
-      //   path: `/connection/${gmcNumber}`
-      // }
     ];
   }
 }

--- a/src/app/details/nav-bar/nav-bar.component.ts
+++ b/src/app/details/nav-bar/nav-bar.component.ts
@@ -17,15 +17,16 @@ export class NavBarComponent implements OnInit {
       {
         label: "Recommendation",
         path: `/recommendation/${gmcNumber}`
-      },
-      {
-        label: "Concern",
-        path: `/concern/${gmcNumber}`
-      },
-      {
-        label: "Connection",
-        path: `/connection/${gmcNumber}`
       }
+      // },
+      // {
+      //   label: "Concern",
+      //   path: `/concern/${gmcNumber}`
+      // },
+      // {
+      //   label: "Connection",
+      //   path: `/connection/${gmcNumber}`
+      // }
     ];
   }
 }

--- a/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
@@ -93,17 +93,17 @@ export const menuItems: IMenuItem[] = JSON.parse(
                 "description": ""
             },
             {
-                "type": 0,
+                "type": 9,
                 "route": "/concerns",
                 "name": "Concerns",
                 "description": ""
             },
             {
-                "type": 0,
+                "type": 9,
                 "route": "/connections",
                 "name": "Connections",
                 "description": ""
-            }                    
+            }                   
         ]
     },
     {

--- a/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
@@ -91,19 +91,7 @@ export const menuItems: IMenuItem[] = JSON.parse(
                 "route": "/recommendations",
                 "name": "Recommendations",
                 "description": ""
-            },
-            {
-                "type": 9,
-                "route": "/concerns",
-                "name": "Concerns",
-                "description": ""
-            },
-            {
-                "type": 9,
-                "route": "/connections",
-                "name": "Connections",
-                "description": ""
-            }                   
+            }                
         ]
     },
     {


### PR DESCRIPTION
TIS21-2021

- hiding from main menu by changing the "type" to 9, so that desktop-menu.component.html file's logic does not match
- hiding from the navigation bar by commenting the code, we will need this code later