### PR TITLE
chore(deps): upgrade aws-aplify 3.022 -> 3.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1262,52 +1262,68 @@
       }
     },
     "@aws-amplify/analytics": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-3.2.5.tgz",
-      "integrity": "sha512-g1n4aC+ExjugP7STFs54DIVS7A2BEGvMsyUsAaDSXzKXGOVE5zhQCho68/eFdZUFEaH9euEGAoGyHka31dnbLQ==",
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-4.0.22.tgz",
+      "integrity": "sha512-pbj1CedBW35y3rStVv4GtxjNVBMZZoMu0DBj3XOzqeapXn0XFh0LprPGk4Pz3uqaIVQCMN34UNI/a62z04AbTw==",
       "requires": {
-        "@aws-amplify/cache": "^3.1.21",
-        "@aws-amplify/core": "^3.4.4",
-        "@aws-sdk/client-firehose": "1.0.0-gamma.4",
-        "@aws-sdk/client-kinesis": "1.0.0-gamma.4",
-        "@aws-sdk/client-personalize-events": "1.0.0-gamma.4",
-        "@aws-sdk/client-pinpoint": "1.0.0-gamma.4",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
+        "@aws-amplify/cache": "3.1.57",
+        "@aws-amplify/core": "3.8.24",
+        "@aws-sdk/client-firehose": "3.6.1",
+        "@aws-sdk/client-kinesis": "3.6.1",
+        "@aws-sdk/client-personalize-events": "3.6.1",
+        "@aws-sdk/client-pinpoint": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "lodash": "^4.17.20",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@aws-amplify/api": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-3.1.21.tgz",
-      "integrity": "sha512-K8g82LN7KOEk1aXYyNpVkZHPQstCgWuiD92PdS+ybXW9g5h8vGwfGmMWWhKCW6MQSseMnKHjOaAI4FE5XvfrLg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-3.3.3.tgz",
+      "integrity": "sha512-4gH7HWQCRARnfDtlDv/YxqQ3p0NMqn52KLarLm4wj0iajfztWZUyC3Yanf9srnseoVVrdkNYHV67zHMkpRBVQg==",
       "requires": {
-        "@aws-amplify/api-graphql": "^1.1.4",
-        "@aws-amplify/api-rest": "^1.1.4"
+        "@aws-amplify/api-graphql": "1.3.3",
+        "@aws-amplify/api-rest": "1.2.34"
       }
     },
     "@aws-amplify/api-graphql": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-1.1.4.tgz",
-      "integrity": "sha512-Rn8Jgu47dua1XvbzdIpoHb5aDipqpJVMDfvH0w6OEk9cGwgb7rgHnhBVaRxmO++QiRFwAgqrNsWH74sKOa/qTw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-1.3.3.tgz",
+      "integrity": "sha512-pV+IiQlAgmk6EvIaX0y/sygXS82yeJzft1d/kle9oIA/AP+biTobCF87nweL99A6lXa/Ov1Qf5Sr0PrVNkNmlw==",
       "requires": {
-        "@aws-amplify/api-rest": "^1.1.4",
-        "@aws-amplify/auth": "^3.3.3",
-        "@aws-amplify/cache": "^3.1.21",
-        "@aws-amplify/core": "^3.4.4",
-        "@aws-amplify/pubsub": "^3.0.22",
+        "@aws-amplify/api-rest": "1.2.34",
+        "@aws-amplify/auth": "3.4.34",
+        "@aws-amplify/cache": "3.1.57",
+        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/pubsub": "3.3.3",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
       },
       "dependencies": {
         "@aws-amplify/pubsub": {
-          "version": "3.0.22",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.0.22.tgz",
-          "integrity": "sha512-BKCvfVlH6zr61j44VB+NmeMYh+Q4Lr1T+9XBK0zD+0qm+vAz0J8cYB++oLkroGCLvKcqhjvPbxgEQzdPz05WTA==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.3.3.tgz",
+          "integrity": "sha512-j9PwkOjUhGE1cbExVjVfVeR7aMzlwckbP01K6QHPqOccstS/ZVD3W9ifhVCYJho1TTa6NoT7wn2HromesP2frQ==",
           "requires": {
-            "@aws-amplify/auth": "^3.3.3",
-            "@aws-amplify/cache": "^3.1.21",
-            "@aws-amplify/core": "^3.4.4",
+            "@aws-amplify/auth": "3.4.34",
+            "@aws-amplify/cache": "3.1.57",
+            "@aws-amplify/core": "3.8.24",
             "graphql": "14.0.0",
             "paho-mqtt": "^1.1.0",
             "uuid": "^3.2.1",
@@ -1317,59 +1333,833 @@
       }
     },
     "@aws-amplify/api-rest": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.1.4.tgz",
-      "integrity": "sha512-9o8EqyEDEc2Bb3kk/6ewEGSzdUWfsswQjp9/KvkwwP1IAl8NajnxxnTyVvmZVie6gNYSSrBy+sE5+N55aTcy9g==",
+      "version": "1.2.34",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.2.34.tgz",
+      "integrity": "sha512-6mng+VAaj10xcOQsLZqv4QcAXepehBqU7petsUft26l/cJpva5YbtoJJXmjIJ/tcUEzVRGQwKmUSRYLeN06FLg==",
       "requires": {
-        "@aws-amplify/core": "^3.4.4",
-        "axios": "0.19.0"
+        "@aws-amplify/core": "3.8.24",
+        "axios": "0.21.1"
       }
     },
     "@aws-amplify/auth": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.3.3.tgz",
-      "integrity": "sha512-IyvjCC4WApw77Z1SpOAqba48t2jayiv59eW2bTkuRAB+nSicXWywHiTyuBz/N/duLftJQSzyFNEUijDu2qsw/Q==",
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.4.34.tgz",
+      "integrity": "sha512-6Q+QDjb3ljAh3PptLFpdZn1kXOsv1yAwyvBZdaKP8ZRmgj8yT7yeR3a2nczY7HTj9Vhr4DXqI3rB3YYToJemLQ==",
       "requires": {
-        "@aws-amplify/cache": "^3.1.21",
-        "@aws-amplify/core": "^3.4.4",
-        "amazon-cognito-identity-js": "^4.3.3",
-        "crypto-js": "^3.3.0"
+        "@aws-amplify/cache": "3.1.57",
+        "@aws-amplify/core": "3.8.24",
+        "amazon-cognito-identity-js": "4.6.3",
+        "crypto-js": "^4.0.0"
+      },
+      "dependencies": {
+        "crypto-js": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+          "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+        }
       }
     },
     "@aws-amplify/cache": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.21.tgz",
-      "integrity": "sha512-8xRWnZiwK5L1KKENlhb69u3X5bAu95pt5G95cyH/guikiuqwTNpBMIMr4F/WVoI/vfjDpnCqqtMMklxgk9+VJw==",
+      "version": "3.1.57",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.57.tgz",
+      "integrity": "sha512-BSizxpLeOwZ3rDSznP+PUTxSvdmlSctyBEp5UFa5/m9KKTr/+RKjP0W2xk2thAS9faFiVaXvocf2B/RDs4GqDg==",
       "requires": {
-        "@aws-amplify/core": "^3.4.4"
+        "@aws-amplify/core": "3.8.24"
       }
     },
     "@aws-amplify/core": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.4.4.tgz",
-      "integrity": "sha512-tzBMOCX/w1v7We6+w+t7F324HuxcP3AvXdhC6F37UXiRcAjjLY/6GJ7uy7HwR7g9UUe6OWwagBKU6oGjrnbSUg==",
+      "version": "3.8.24",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.8.24.tgz",
+      "integrity": "sha512-py/M/UKKYSltTikNDEju3kmwDhmMv+qZ5bouSxRwprLTuwDmLzUcIFerPN2g4cmoF9JictlC/+9D3q5Wz7ha5w==",
       "requires": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
-        "@aws-sdk/client-cognito-identity": "1.0.0-gamma.4",
-        "@aws-sdk/credential-provider-cognito-identity": "1.0.0-gamma.4",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/util-hex-encoding": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "url": "^0.11.0",
+        "@aws-sdk/client-cognito-identity": "3.6.1",
+        "@aws-sdk/credential-provider-cognito-identity": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "universal-cookie": "^4.0.4",
         "zen-observable-ts": "0.8.19"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "@aws-crypto/sha256-js": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+              "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+              "requires": {
+                "@aws-crypto/util": "^1.2.2",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/client-cognito-identity": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.6.1.tgz",
+          "integrity": "sha512-FMj2GR9R5oCKb3/NI16GIvWeHcE4uX42fBAaQKPbjg2gALFDx9CcJYsdOtDP37V89GtPyZilLv6GJxrwJKzYGg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.0.0",
+            "@aws-sdk/config-resolver": "3.6.1",
+            "@aws-sdk/credential-provider-node": "3.6.1",
+            "@aws-sdk/fetch-http-handler": "3.6.1",
+            "@aws-sdk/hash-node": "3.6.1",
+            "@aws-sdk/invalid-dependency": "3.6.1",
+            "@aws-sdk/middleware-content-length": "3.6.1",
+            "@aws-sdk/middleware-host-header": "3.6.1",
+            "@aws-sdk/middleware-logger": "3.6.1",
+            "@aws-sdk/middleware-retry": "3.6.1",
+            "@aws-sdk/middleware-serde": "3.6.1",
+            "@aws-sdk/middleware-signing": "3.6.1",
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/middleware-user-agent": "3.6.1",
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/node-http-handler": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/smithy-client": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/url-parser": "3.6.1",
+            "@aws-sdk/url-parser-native": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "@aws-sdk/util-base64-node": "3.6.1",
+            "@aws-sdk/util-body-length-browser": "3.6.1",
+            "@aws-sdk/util-body-length-node": "3.6.1",
+            "@aws-sdk/util-user-agent-browser": "3.6.1",
+            "@aws-sdk/util-user-agent-node": "3.6.1",
+            "@aws-sdk/util-utf8-browser": "3.6.1",
+            "@aws-sdk/util-utf8-node": "3.6.1",
+            "tslib": "^2.0.0"
+          },
+          "dependencies": {
+            "@aws-crypto/sha256-js": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+              "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+              "requires": {
+                "@aws-crypto/util": "^1.2.2",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+              }
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-cognito-identity": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz",
+          "integrity": "sha512-uJ9q+yq+Dhdo32gcv0p/AT7sKSAUH0y4ts9XRK/vx0dW9Q3XJy99mOJlq/6fkh4LfWeavJJlaCo9lSHNMWXx4w==",
+          "requires": {
+            "@aws-sdk/client-cognito-identity": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        }
       }
     },
     "@aws-amplify/datastore": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-2.2.8.tgz",
-      "integrity": "sha512-EfspY8/GuwWrA67/vGQ0OjGwUoWEGEg2tWlYSUWv5l29YiQGa9ctQz2QygQPr+VfvK6HUf03pHwea4cCftFOMA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-2.10.1.tgz",
+      "integrity": "sha512-6t3XygUPDdFbRRrn3kd11+8A30Mh7vzA2zdD+rwc39nZhgb/angmm2bpDSfC5t9tRftv0JBOkAaWOu6nxtLhKw==",
       "requires": {
-        "@aws-amplify/api": "^3.1.21",
-        "@aws-amplify/core": "^3.4.4",
-        "@aws-amplify/pubsub": "^3.0.22",
-        "idb": "5.0.2",
-        "immer": "6.0.1",
+        "@aws-amplify/api": "3.3.3",
+        "@aws-amplify/auth": "3.4.34",
+        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/pubsub": "3.3.3",
+        "amazon-cognito-identity-js": "4.6.3",
+        "idb": "5.0.6",
+        "immer": "8.0.1",
         "ulid": "2.3.0",
         "uuid": "3.3.2",
         "zen-observable-ts": "0.8.19",
@@ -1377,13 +2167,13 @@
       },
       "dependencies": {
         "@aws-amplify/pubsub": {
-          "version": "3.0.22",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.0.22.tgz",
-          "integrity": "sha512-BKCvfVlH6zr61j44VB+NmeMYh+Q4Lr1T+9XBK0zD+0qm+vAz0J8cYB++oLkroGCLvKcqhjvPbxgEQzdPz05WTA==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.3.3.tgz",
+          "integrity": "sha512-j9PwkOjUhGE1cbExVjVfVeR7aMzlwckbP01K6QHPqOccstS/ZVD3W9ifhVCYJho1TTa6NoT7wn2HromesP2frQ==",
           "requires": {
-            "@aws-amplify/auth": "^3.3.3",
-            "@aws-amplify/cache": "^3.1.21",
-            "@aws-amplify/core": "^3.4.4",
+            "@aws-amplify/auth": "3.4.34",
+            "@aws-amplify/cache": "3.1.57",
+            "@aws-amplify/core": "3.8.24",
             "graphql": "14.0.0",
             "paho-mqtt": "^1.1.0",
             "uuid": "^3.2.1",
@@ -1393,29 +2183,62 @@
       }
     },
     "@aws-amplify/interactions": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-3.1.21.tgz",
-      "integrity": "sha512-xiZcDALzf9bBdGfsl0v2k0/tem00fzHOwsI3eDge8wEoT5MpOTuQvXO4lcbCjzo3yQVOBjoymXPNLXMkF9fAEA==",
+      "version": "3.3.34",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-3.3.34.tgz",
+      "integrity": "sha512-152FEwVqtfJ8rDi0VGzqL4CSu44QCiRTHpKyacWMPcxdC6E0DtVdzcNgo94fenpJIQi2LyKuN8UZvK+NnMDENg==",
       "requires": {
-        "@aws-amplify/core": "^3.4.4",
-        "@aws-sdk/client-lex-runtime-service": "1.0.0-gamma.4"
+        "@aws-amplify/core": "3.8.24",
+        "@aws-sdk/client-lex-runtime-service": "3.6.1"
       }
     },
     "@aws-amplify/predictions": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-3.1.21.tgz",
-      "integrity": "sha512-c2DxYABDZs8n0ApCKVVIbecM9ICWSxOisW/iE/bw6hNzIX9P9JnrIuG34a0+TYhl/h+pAbE8JH9b4l/SEXgcdQ==",
+      "version": "3.2.34",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-3.2.34.tgz",
+      "integrity": "sha512-PObKVaW9sq3jnRpY85w6Ns38UItD66R0Yy+HsvcRfNBjIOOQT1bqvEEqLQZad0zP3hBSxnNGvdze4ye3oQZuwg==",
       "requires": {
-        "@aws-amplify/core": "^3.4.4",
-        "@aws-amplify/storage": "^3.2.11",
-        "@aws-sdk/client-comprehend": "1.0.0-gamma.4",
-        "@aws-sdk/client-polly": "1.0.0-gamma.4",
-        "@aws-sdk/client-rekognition": "1.0.0-gamma.4",
-        "@aws-sdk/client-textract": "1.0.0-gamma.4",
-        "@aws-sdk/client-translate": "1.0.0-gamma.4",
-        "@aws-sdk/eventstream-marshaller": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
+        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/storage": "3.4.4",
+        "@aws-sdk/client-comprehend": "3.6.1",
+        "@aws-sdk/client-polly": "3.6.1",
+        "@aws-sdk/client-rekognition": "3.6.1",
+        "@aws-sdk/client-textract": "3.6.1",
+        "@aws-sdk/client-translate": "3.6.1",
+        "@aws-sdk/eventstream-marshaller": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@aws-amplify/pubsub": {
@@ -1507,16 +2330,16 @@
       }
     },
     "@aws-amplify/storage": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.2.11.tgz",
-      "integrity": "sha512-IjXqLz8K85LLfVzB8dj+hJ3kGNwo/J+xRBr5kyHTqR4RJYnA6hewgoIBqNESstTcE/64ehu4aISFl9GPHoCxlA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.4.4.tgz",
+      "integrity": "sha512-Qwh3G0e1UiqDTMnKgkxpM7BPoL9FozfGc2m1yWGT+VFbmVBZmuQyo1p3ENVgIbghQ/TqLpj447mg0Xfl4bZ3cQ==",
       "requires": {
-        "@aws-amplify/core": "^3.4.4",
-        "@aws-sdk/client-s3": "1.0.0-gamma.4",
-        "@aws-sdk/s3-request-presigner": "1.0.0-gamma.3",
-        "@aws-sdk/util-create-request": "1.0.0-gamma.3",
-        "@aws-sdk/util-format-url": "1.0.0-gamma.3",
-        "axios": "0.19.0",
+        "@aws-amplify/core": "3.8.24",
+        "@aws-sdk/client-s3": "3.6.1",
+        "@aws-sdk/s3-request-presigner": "3.6.1",
+        "@aws-sdk/util-create-request": "3.6.1",
+        "@aws-sdk/util-format-url": "3.6.1",
+        "axios": "0.21.1",
         "events": "^3.1.0",
         "sinon": "^7.5.0"
       }
@@ -1527,25 +2350,32 @@
       "integrity": "sha512-OLdZmUCVK29+JV8PrkgVPjg+GIFtBnNjhC0JSRgrps+ynOFkibMQQPKeFXlTYtlukuCuepCelPSkjxvhcLq2ZA=="
     },
     "@aws-amplify/xr": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-2.1.21.tgz",
-      "integrity": "sha512-W2F8OZKqlWLvnUFdAmtiZ715PBwKjWvj5DETjRQOy1XCLk2bBEMxgYG2DaW8ZwXV+rJYP1IqyQjtxWT0IGtJ7g==",
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-2.2.34.tgz",
+      "integrity": "sha512-EooROlYAPQ6ty5lB7tRjXiXPtTIMsgDXidKUmNG8UPMbjbSYGQUVWA8TSYc18tJ/zYyiDYHCFH7MzIzv425FNQ==",
       "requires": {
-        "@aws-amplify/core": "^3.4.4"
+        "@aws-amplify/core": "3.8.24"
       }
     },
     "@aws-crypto/crc32": {
-      "version": "1.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.0.0-alpha.0.tgz",
-      "integrity": "sha512-n4OJttn49liBR0CVdK7dAvkTaP8jLiRRekdA0wunTEELIIwjC4c60YODADbqR2Hug4dtzQ6huJTgyFeHIaYPHg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.2.2.tgz",
+      "integrity": "sha512-8K0b1672qbv05chSoKpwGZ3fhvVp28Fg3AVHVkEHFl2lTLChO7wD/hTyyo8ING7uc31uZRt7bNra/hA74Td7Tw==",
       "requires": {
-        "tslib": "^1.9.3"
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.0.tgz",
+          "integrity": "sha512-ljxyrASkxCsgPXW/jRGGokNtjOql4RbzEl23HEliDmmETlKOrUKVDa2iqhnz5nvqVTc1MgOQv/dr9YBO1LHHIQ=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -1553,6 +2383,7 @@
       "version": "1.0.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0-alpha.0.tgz",
       "integrity": "sha512-TQ55S96+aD/iZF/VdgbLqCm2um8mQhjNrlFqQEJkXc12L4taF0wz0FfdFSJ9Uuy6EIf4GjgvbLExgJwxmFqL5A==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       },
@@ -1560,7 +2391,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -1568,6 +2400,7 @@
       "version": "1.0.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.0.0-alpha.0.tgz",
       "integrity": "sha512-ZhULGaJKI/o8KROknqvnmYX3gphPQL5HLoMdVD5yPEsEsFG7rEIu4ORv2s6uaiqkdEkXZcdS+CNC8ekIndr9QA==",
+      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^1.0.0-alpha.0",
         "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
@@ -1581,7 +2414,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -1606,6 +2440,7 @@
       "version": "1.0.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0-alpha.0.tgz",
       "integrity": "sha512-jVWjNCoEKY49NIWyU1ia1RvtupEZEzOTkYZ1kRH+Z0RqIg9DZksQ7PbSRvxtAv8rTBdyGSgQdEpbFtQtm/ZiRQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       },
@@ -1613,7 +2448,45 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.0.tgz",
+          "integrity": "sha512-ljxyrASkxCsgPXW/jRGGokNtjOql4RbzEl23HEliDmmETlKOrUKVDa2iqhnz5nvqVTc1MgOQv/dr9YBO1LHHIQ=="
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.0.tgz",
+          "integrity": "sha512-qOYj00VqTVyUVb9gndS9yGHB/tRuK7EPGFvnhRh4VEkwVymH8ywyoFntRhWS/hSrrcQp0W35iS+fJPqdQ1nGWg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -1621,6 +2494,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-1.0.0-gamma.3.tgz",
       "integrity": "sha512-iu3eXUlfrYa4hSlxuz93/3oLZwHYkvCGRapb5Mpv30V2+qKaoggQ9q1txycAqm0Pg+NpZgNJgYhSsMEGE775sA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -1629,38 +2503,47 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-C0s1DcSTF+mhD47LFsoa2AvvMIhJE3J1x1JTRGeDcJ7bo60Fv4lF4ocsl77VgshZ4TlKvHGKdgNCCHsm22wMcg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.6.1.tgz",
+      "integrity": "sha512-QBGUBoD8D5nsM/EKoc0rjpApa5NE5pQVzw1caE8sG00QMMPkCXWSB/gTVKVY0GOAhJFoA/VpVPQchIlZcOrBFg==",
       "requires": {
         "tslib": "^1.8.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-QDGxdZWMFrxAwRa39xlm1kvBO/Nsz/ppTupK6MPRaUB0nk5NkoKwIZM9KQKb/UvcsQ+r74/Xh9S9Mr7ySgmuyQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.6.1.tgz",
+      "integrity": "sha512-vP6bc2v9h442Srmo7t2QcIbPjk5IqLSf4jGnKDAes8z+7eyjCtKugRP3lOM1fJCfGlPIsJGYnexxYdEGw008vA==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
+        "@aws-sdk/util-base64-browser": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -1668,6 +2551,7 @@
       "version": "1.0.0-gamma.4",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-1.0.0-gamma.4.tgz",
       "integrity": "sha512-NHXKW3rGzV1/g45thfY5CqHrHcMbTbKhzlAzjABtdDFBe7K+dIC/HVV0veJHMsX5ac/Wruu57kiWz7bleeP9wA==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
         "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
@@ -1705,521 +2589,8137 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/client-comprehend": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-comprehend/-/client-comprehend-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-WxT04/xTHNYQiGBy46OD8bbKJfgdu/4mKsP5jTPk/1Za9gnmW3ivpLlmMT4KJmKvG169Cdd6uYwmz8CivDEHbw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-comprehend/-/client-comprehend-3.6.1.tgz",
+      "integrity": "sha512-Y2ixlSTjjAp2HJhkUArtYqC/X+zG5Qqu3Bl+Ez22u4u4YnG8HsNFD6FE1axuWSdSa5AFtWTEt+Cz2Ghj/tDySA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0",
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0",
         "uuid": "^3.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-firehose": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-1of4j5K2JEZItRRvvTydfee3UwGqydLUi1O14A7bBJdEXnLBBDDdM3gM2gj7UQNYcAx7DouGOwDG0SdEbN+J5Q==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-3.6.1.tgz",
+      "integrity": "sha512-KhiKCm+cJmnRFuAEyO3DBpFVDNix1XcVikdxk2lvYbFWkM1oUZoBpudxaJ+fPf2W3stF3CXIAOP+TnGqSZCy9g==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-kinesis": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-u4c3F7iNqcIti4g36VQP+jcE5jB5MyhxvFz9+ZrOpfbwysx3aKzt8EgA/cm/MeZ3yz59sXkHDmPeD1VHPeWvwg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.6.1.tgz",
+      "integrity": "sha512-Ygo+92LxHeUZmiyhiHT+k7hIOhJd6S7ckCEVUsQs2rfwe9bAygUY/3cCoZSqgWy7exFRRKsjhzStcyV6i6jrVQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-browser": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/eventstream-serde-browser": "3.6.1",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.6.1",
+        "@aws-sdk/eventstream-serde-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "@aws-sdk/util-waiter": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-lex-runtime-service": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-vcpQkWDyMHu/4RzR3SFRz7tQop2/IEFx8WMUQRUKFrgxwGKFcirFof4QXycoN5Pr17aUaE17bGbW9nroIDfrrw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-3.6.1.tgz",
+      "integrity": "sha512-xi3m3f3G9KEKdziOFyynkfvN7OzdT9T8V3wkM4x+Zhid9v1K4Rg7OvbBb5oG9UicLz54tcZGkt0VN4ldEB/XLQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-personalize-events": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-personalize-events/-/client-personalize-events-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-IjkGksADl/NaPmlxOZDl+4xazs4Hk2SraF0Kr6XayGKHhlUu1SgpI/qNFmNyaNnW3x56F9VVV2tAnV4L9Z9uqg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-personalize-events/-/client-personalize-events-3.6.1.tgz",
+      "integrity": "sha512-x9Jl/7emSQsB6GwBvjyw5BiSO26CnH4uvjNit6n54yNMtJ26q0+oIxkplnUDyjLTfLRe373c/z5/4dQQtDffkw==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-pinpoint": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pinpoint/-/client-pinpoint-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-YAoz84AUGyYIVlajwoKSewWcPgcHXS3OXp+jJ36eWTgiImRVAmJlRzYn1ZYxeFo+2/x8jF6mG+5WDRBgP7H9iw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pinpoint/-/client-pinpoint-3.6.1.tgz",
+      "integrity": "sha512-dueBedp91EKAHxcWLR3aNx/eUEdxdF9niEQTzOO2O4iJL2yvO2Hh7ZYiO7B3g7FuuICTpWSHd//Y9mGmSVLMCg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-polly": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-polly/-/client-polly-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-dhxLkGrMP74IkTIPP3BLLAnsZdiLQphL+dWeEFdlwy0CGfccsssVcJ9EIGD/K++9F9E9265GQzm6fQ54g/t3LA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-polly/-/client-polly-3.6.1.tgz",
+      "integrity": "sha512-y6fxVYndGS7z2KqHViPCqagBEOsZlxBUYUJZuD6WWTiQrI0Pwe5qG02oKJVaa5OmxE20QLf6bRBWj2rQpeF4IQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-rekognition": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rekognition/-/client-rekognition-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-01syRSoCEjqnaSR0YksTrWwzkB+YG6E6JfzZyDzQ4RguT08X+MVUhvdrHYrftIeenNYTc90hR0qza0+CLMn5MQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rekognition/-/client-rekognition-3.6.1.tgz",
+      "integrity": "sha512-Ia4FEog9RrI0IoDRbOJO6djwhVAAaEZutxEKrWbjrVz4bgib28L+V+yAio2SUneeirj8pNYXwBKPfoYOUqGHhA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "@aws-sdk/util-waiter": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-nnCeduoL25HRq/F1McYl0k/gqFfKhEWjOE/+XpvkKGLx62XAQutbw26GveLk2HOyul9p7FO4nJbk9iECejpLLw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.6.1.tgz",
+      "integrity": "sha512-59cTmZj92iwgNoAeJirK5sZNQNXLc/oI3luqrEHRNLuOh70bjdgad70T0a5k2Ysd/v/QNamqJxnCJMPuX1bhgw==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-browser": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-blob-browser": "1.0.0-gamma.3",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/hash-stream-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/md5-js": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-apply-body-checksum": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-bucket-endpoint": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-expect-continue": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-location-constraint": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-sdk-s3": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-ssec": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "@aws-sdk/xml-builder": "1.0.0-gamma.3",
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/eventstream-serde-browser": "3.6.1",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.6.1",
+        "@aws-sdk/eventstream-serde-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-blob-browser": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/hash-stream-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/md5-js": "3.6.1",
+        "@aws-sdk/middleware-apply-body-checksum": "3.6.1",
+        "@aws-sdk/middleware-bucket-endpoint": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-expect-continue": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-location-constraint": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-sdk-s3": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-ssec": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "@aws-sdk/util-waiter": "3.6.1",
+        "@aws-sdk/xml-builder": "3.6.1",
         "fast-xml-parser": "^3.16.0",
-        "tslib": "^1.8.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-textract": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-textract/-/client-textract-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-nDijsSaYlSBgVEgo8T+N19U9VJ6J2RbE0C87sR9XoPUnnWcna1MCyoy5iMVIHX182H20DOZsjyCdwP1RtqhsLw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-textract/-/client-textract-3.6.1.tgz",
+      "integrity": "sha512-nLrBzWDt3ToiGVFF4lW7a/eZpI2zjdvu7lwmOWyXX8iiPzhBVVEfd5oOorRyJYBsGMslp4sqV8TBkU5Ld/a97Q==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
     "@aws-sdk/client-translate": {
-      "version": "1.0.0-gamma.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-translate/-/client-translate-1.0.0-gamma.4.tgz",
-      "integrity": "sha512-8wYXlG3rJHeehG1ZOreEETlPgdqDk5CGf1Yh2IG46TdVBoltqnRxz6xS05dddKNyM1G+DhUnECj1ec1JIrc3uQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-translate/-/client-translate-3.6.1.tgz",
+      "integrity": "sha512-RIHY+Og1i43B5aWlfUUk0ZFnNfM7j2vzlYUwOqhndawV49GFf96M3pmskR5sKEZI+5TXY77qR9TgZ/r3UxVCRQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
-        "@aws-sdk/config-resolver": "1.0.0-gamma.3",
-        "@aws-sdk/credential-provider-node": "1.0.0-gamma.3",
-        "@aws-sdk/fetch-http-handler": "1.0.0-gamma.4",
-        "@aws-sdk/hash-node": "1.0.0-gamma.3",
-        "@aws-sdk/invalid-dependency": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-content-length": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-host-header": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-serde": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-signing": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/middleware-user-agent": "1.0.0-gamma.3",
-        "@aws-sdk/node-http-handler": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/region-provider": "1.0.0-gamma.3",
-        "@aws-sdk/retry-config-provider": "1.0.0-gamma.2",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-browser": "1.0.0-gamma.3",
-        "@aws-sdk/url-parser-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-base64-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-body-length-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-user-agent-node": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-node": "1.0.0-gamma.3",
-        "tslib": "^1.8.0",
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.6.1",
+        "@aws-sdk/credential-provider-node": "3.6.1",
+        "@aws-sdk/fetch-http-handler": "3.6.1",
+        "@aws-sdk/hash-node": "3.6.1",
+        "@aws-sdk/invalid-dependency": "3.6.1",
+        "@aws-sdk/middleware-content-length": "3.6.1",
+        "@aws-sdk/middleware-host-header": "3.6.1",
+        "@aws-sdk/middleware-logger": "3.6.1",
+        "@aws-sdk/middleware-retry": "3.6.1",
+        "@aws-sdk/middleware-serde": "3.6.1",
+        "@aws-sdk/middleware-signing": "3.6.1",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/middleware-user-agent": "3.6.1",
+        "@aws-sdk/node-config-provider": "3.6.1",
+        "@aws-sdk/node-http-handler": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/url-parser": "3.6.1",
+        "@aws-sdk/url-parser-native": "3.6.1",
+        "@aws-sdk/util-base64-browser": "3.6.1",
+        "@aws-sdk/util-base64-node": "3.6.1",
+        "@aws-sdk/util-body-length-browser": "3.6.1",
+        "@aws-sdk/util-body-length-node": "3.6.1",
+        "@aws-sdk/util-user-agent-browser": "3.6.1",
+        "@aws-sdk/util-user-agent-node": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
+        "@aws-sdk/util-utf8-node": "3.6.1",
+        "tslib": "^2.0.0",
         "uuid": "^3.0.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-crypto/ie11-detection": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+          "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
+          "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.2.2",
+            "@aws-crypto/supports-web-crypto": "^1.0.0",
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+          "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+          "requires": {
+            "@aws-crypto/util": "^1.2.2",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+          "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
+          "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
+          "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
+          "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
+          "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
+          "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.6.1",
+            "@aws-sdk/credential-provider-imds": "3.6.1",
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/credential-provider-process": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
+          "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
+          "requires": {
+            "@aws-sdk/credential-provider-ini": "3.6.1",
+            "@aws-sdk/property-provider": "3.6.1",
+            "@aws-sdk/shared-ini-file-loader": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
+          "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-base64-browser": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
+          "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
+          "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
+          "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
+          "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
+          "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/service-error-classification": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "react-native-get-random-values": "^1.4.0",
+            "tslib": "^1.8.0",
+            "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
+          "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
+          "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/signature-v4": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
+          "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
+          "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.6.1",
+            "@aws-sdk/protocol-http": "3.6.1",
+            "@aws-sdk/querystring-builder": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
+          "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
+          "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
+          "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
+          "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
+          "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
+          "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-locate-window": {
+          "version": "3.47.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+          "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+              "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            }
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
+          "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "bowser": "^2.11.0",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
+          "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
+          "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.6.1",
+            "tslib": "^1.8.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         }
       }
     },
@@ -2227,6 +10727,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-1.0.0-gamma.3.tgz",
       "integrity": "sha512-rn2Pa3BtZnpHCGdv2GarX6z/XAWetEtF42w1TEZGI5qJRMg8ZDCJihUNEwLI3n2NB1SKmQMQ5eh0KJ/nmM1KMQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/signature-v4": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2236,7 +10737,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2244,6 +10746,7 @@
       "version": "1.0.0-gamma.4",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-1.0.0-gamma.4.tgz",
       "integrity": "sha512-+m+Ifgs4x9ZF6u00wv9//zrKPPlHbRFl3s68HP/bdmERkvAAtqMzRKBO1dVbCC0ymsQuR/+1DmnEspfljNmMzQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/client-cognito-identity": "1.0.0-gamma.4",
         "@aws-sdk/property-provider": "1.0.0-gamma.3",
@@ -2254,7 +10757,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2262,6 +10766,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-1.0.0-gamma.3.tgz",
       "integrity": "sha512-LAT36m8mAd9kf8o4zvNGWkgt/9K8w9fUV79UW2iFDR77goZeEVhNcDqtoU49x8p/eJdH3mh3LuF5gOY5iQZJAQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2271,7 +10776,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2279,6 +10785,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-1.0.0-gamma.3.tgz",
       "integrity": "sha512-rI25N7K8H1b0oiyR9+8Xx1vgh3/NlXm5wWF4G0HRg4WVl4jGj/pRGYcZhNZZvzCjrF2hIquj+17SMtv6E9tx4g==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2288,7 +10795,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2296,6 +10804,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-1.0.0-gamma.3.tgz",
       "integrity": "sha512-kf2ZjscM460jn01JqEfWfzq6VsmKtfD3JM9zMRyE7JyNIwW8tS+saljqNGcv0fzJdgA2aBA2cqOLHxQ5I8Va7w==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "1.0.0-gamma.3",
         "@aws-sdk/shared-ini-file-loader": "1.0.0-gamma.3",
@@ -2306,7 +10815,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2314,6 +10824,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-1.0.0-gamma.3.tgz",
       "integrity": "sha512-hkqOULwckbv3DgNsG3D6az6ZETbDLPIW5+4SLjNH7MbCdB4HkT0KW0WDwE0QkdlcvQlKg1pfNIzolxDbv8VZCQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "1.0.0-gamma.3",
         "@aws-sdk/credential-provider-imds": "1.0.0-gamma.3",
@@ -2327,7 +10838,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2335,6 +10847,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-1.0.0-gamma.3.tgz",
       "integrity": "sha512-zHkna6XakaOHkb56TR7vTQxA97tmaKYH00EEeIVkWZUu6/QFBOFoSZbQBUxVWdvlIcPDbKwr2Pth7OahsEGmIg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-ini": "1.0.0-gamma.3",
         "@aws-sdk/property-provider": "1.0.0-gamma.3",
@@ -2346,94 +10859,128 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-EZaNxRW17SX8eqbRhMsoFXdHp2XTwGmtz89DK6pC+i2OWIQSLskOAYYp0UPWZdeEk9FHk1gmdaY/oDeeeMS1oA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.6.1.tgz",
+      "integrity": "sha512-ZvN3Nvxn2Gul08L9MOSN123LwSO0E1gF/CqmOGZtEWzPnoSX/PWM9mhPPeXubyw2KdlXylOodYYw3EAATk3OmA==",
       "requires": {
-        "@aws-crypto/crc32": "^1.0.0-alpha.0",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/util-hex-encoding": "1.0.0-gamma.3",
+        "@aws-crypto/crc32": "^1.0.0",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-wDJLKAB88HE6Sf80R1CTXRig+v8AkugGRfrDheSde15DLh8Xfo4INkCRxxWF0P1OENVcUFF9MUo8IahyjGck/g==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.6.1.tgz",
+      "integrity": "sha512-J8B30d+YUfkBtgWRr7+9AfYiPnbG28zjMlFGsJf8Wxr/hDCfff+Z8NzlBYFEbS7McXXhRiIN8DHUvCtolJtWJQ==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-universal": "1.0.0-gamma.2",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/eventstream-marshaller": "3.6.1",
+        "@aws-sdk/eventstream-serde-universal": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-fuYWrJhukxEHEoSR4IqWUWTHONOOEqJ+yMNA6yt+/oKC/HZGkW0SaOS8PYIG3+9tJHVr5S4f4uHRSmnm+Xhkpw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.6.1.tgz",
+      "integrity": "sha512-72pCzcT/KeD4gPgRVBSQzEzz4JBim8bNwPwZCGaIYdYAsAI8YMlvp0JNdis3Ov9DFURc87YilWKQlAfw7CDJxA==",
       "requires": {
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-50e8wnyOBXsrLsJQbGV3SAGbhFXmo6RV+mwrEiXTNkIY/1T6/LkTIhEdyeFvUZI2qCUL2c4ucJYtbN4zpZLB2A==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.6.1.tgz",
+      "integrity": "sha512-rjBbJFjCrEcm2NxZctp+eJmyPxKYayG3tQZo8PEAQSViIlK5QexQI3fgqNAeCtK7l/SFAAvnOMRZF6Z3NdUY6A==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "1.0.0-gamma.3",
-        "@aws-sdk/eventstream-serde-universal": "1.0.0-gamma.2",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/eventstream-marshaller": "3.6.1",
+        "@aws-sdk/eventstream-serde-universal": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "1.0.0-gamma.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-1.0.0-gamma.2.tgz",
-      "integrity": "sha512-ZIUqI/DyYmlXJleUWaP0wiNgy125m/5lOCnv1t0bi/R+aIIrAlWey1Z97O8u4MdTTtF6i09RQv1Zfh7eVOn81g==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.6.1.tgz",
+      "integrity": "sha512-rpRu97yAGHr9GQLWMzcGICR2PxNu1dHU/MYc9Kb6UgGeZd4fod4o1zjhAJuj98cXn2xwHNFM4wMKua6B4zKrZg==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/eventstream-marshaller": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2441,6 +10988,7 @@
       "version": "1.0.0-gamma.4",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-1.0.0-gamma.4.tgz",
       "integrity": "sha512-l5I8rMqkPfjz7UfQDw2HoDpnwoduWwwlciG9glS+m6lcSek3K9TK2BGjA0WUc2xd+1M11eCKZ5GqvcQYFc3ziw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "1.0.0-gamma.3",
         "@aws-sdk/querystring-builder": "1.0.0-gamma.3",
@@ -2452,25 +11000,31 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-Ewg8DQnl9JHR5lVjp5DjPkhKCupAOzXuMwHV7gN9FSog/bwyuKhwG0Isr9JvilM2qwyMgPh46hEaE+H3r34MZQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.6.1.tgz",
+      "integrity": "sha512-9jPaZ/e3F8gf9JZd44DD6MvbYV6bKnn99rkG3GFIINOy9etoxPrLehp2bH2DK/j0ow60RNuwgUjj5qHV/zF67g==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "1.0.0-gamma.3",
-        "@aws-sdk/chunked-blob-reader-native": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/chunked-blob-reader": "3.6.1",
+        "@aws-sdk/chunked-blob-reader-native": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2478,6 +11032,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-1.0.0-gamma.3.tgz",
       "integrity": "sha512-AgkpRJtFXMRtVQLYLcW3uzHbKx6GNtcmvC6LhMAm7qiaCY4Z6J5PbjJzcQA4xEbKj53MW+LPPU6PDwGhca6fCw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "@aws-sdk/util-buffer-from": "1.0.0-gamma.3",
@@ -2487,23 +11042,29 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-13hxtdbYdFjKyQLV2R/D8ZLXB8k7BVS5edDcFCOD64YJz/2JnX+oxz0sHtIgdtta7pBlGCuHw70NtKchrmH4rg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.6.1.tgz",
+      "integrity": "sha512-ePaWjCItIWxuSxA/UnUM/keQ3IAOsQz3FYSxu0KK8K0e1bKTEUgDIG9oMLBq7jIl9TzJG0HBXuPfMe73QHUNug==",
       "requires": {
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2511,6 +11072,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-1.0.0-gamma.3.tgz",
       "integrity": "sha512-dxMxL6x1E5xjaSmwbshLH+NX+5R3qzMemn6/kwIs22EVq89ALZc+oQbG4cEit276/GHgcTBlOc0BpD5/crwpdw==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -2518,7 +11080,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2526,6 +11089,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-1.0.0-gamma.3.tgz",
       "integrity": "sha512-OWewCesYIYG3yNDxHCgK+E37QBbe/m6AV3jFAKtrW4bS2BybzDz1Id7D8FbLDycR2MmU4CoX5rGfEHZkE8ApdQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -2533,59 +11097,110 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-vYcWVsE8Q5yqj0eruaz1PJc8fzIKSNRuiZ2RdruNQ2X5dv0zUk9wIGotyRzmM5zgaONagmePnSIom54CRA7GKQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.6.1.tgz",
+      "integrity": "sha512-lzCqkZF1sbzGFDyq1dI+lR3AmlE33rbC/JhZ5fzw3hJZvfZ6Beq3Su7YwDo65IWEu0zOKYaNywTeOloXP/CkxQ==",
       "requires": {
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/util-utf8-browser": "1.0.0-gamma.3",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-utf8-browser": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+          "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-m2+53oN9EW3c4JP1NMmR9cZv4G5mN4JuWGtDdIbSJulmcDPZ+koF2978VW775EbvfjUmOfjx5GK6yxj59u9kdg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.6.1.tgz",
+      "integrity": "sha512-IncmXR1MPk6aYvmD37It8dP6wVMzaxxzgrkIU2ACkN5UVwA+/0Sr3ZNd9dNwjpyoH1AwpL9BetnlJaWtT6K5ew==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/is-array-buffer": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-xmSbrUFTdebhxJTwW70mO52wq6Y8d3TsIukuvFQaNbT+0tfOm0wLZA2mm7Q+WPkwxUhjdwL19+es5KxVEA9EGw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.6.1.tgz",
+      "integrity": "sha512-Frcqn2RQDNHy+e2Q9hv3ejT3mQWtGlfZESbXEF6toR4M0R8MmEVqIB/ohI6VKBj11lRmGwvpPsR6zz+PJ8HS7A==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-arn-parser": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2593,6 +11208,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-1.0.0-gamma.3.tgz",
       "integrity": "sha512-uqBaDyYi3+XyBKpJDN45aRuioL96gxpb5rAYmSn0oeAZSUKh25Yxp9c131e1LV0JmHto5mztgoLWjoq5r4CjSQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2602,42 +11218,71 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-J43w0c6DIVQvF4PNXmR6ANo3zwqvT3rUDSyqyUOTGybdRer4ctXxywCB/W3sHVaDX6R8dwCaZA3NOC24omDxlA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.6.1.tgz",
+      "integrity": "sha512-vvMOqVYU3uvdJzg/X6NHewZUEBZhSqND1IEcdahLb6RmvDhsS39iS97VZmEFsjj/UFGoePtYjrrdEgRG9Rm1kQ==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "1.0.0-gamma.3",
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/middleware-header-default": "3.6.1",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-NgXxWENL9MqVbB6op+d4SZ/Ht9JQhoh2F0+YN/PG1JpCmwPmi6EyErsgW79MI1wdHG/H/bCQ4Ezgpv86xW1qVg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.6.1.tgz",
+      "integrity": "sha512-YD137iIctXVH8Eut0WOBalvvA+uL0jM0UXZ9N2oKrC8kPQPpqjK9lYGFKZQFsl/XlQHAjJi+gCAFrYsBntRWJQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2645,6 +11290,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-1.0.0-gamma.3.tgz",
       "integrity": "sha512-YqDiMe3Rw7/XZ2aDRNSsHHIePQapRq4Qx2jv/6WWslg4zU3lI/8i1I00l0TlB6gcxP5phWZ9kIjL6b55vUBQkQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2654,23 +11300,50 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-U1Tyio81AMDFaaDfIMc/gFHUhc0Hhaerr7UrlDEmBPAZT4y20vvyazGeYr5tkSPl3pj48mugxWVIetpqF86XOA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.6.1.tgz",
+      "integrity": "sha512-nFisTc0O5D+4I+sRxiiLPasC/I4NDc3s+hgbPPt/b3uAdrujJjhwFBOSaTx8qQvz/xJPAA8pUA/bfWIyeZKi/w==",
       "requires": {
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
+      "integrity": "sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==",
+      "requires": {
+        "@aws-sdk/types": "3.6.1",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2678,6 +11351,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-1.0.0-gamma.3.tgz",
       "integrity": "sha512-XtrVkQ92lAeJxsw9SsKDevbW3WU/LnoKafKWCmbZnM1ygm7cpbHh9cuEFD8RR169scHR3BkARKZe8rwaMFUEIg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "1.0.0-gamma.3",
         "@aws-sdk/service-error-classification": "1.0.0-gamma.3",
@@ -2690,22 +11364,40 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-XvThcJdKAQuDm0TD1JlCrFjJ4otYxPZSHsSOA1WpSt/5dEcmaXOh1+H4Gd4iCcJJh9gpVyCwIRFGHrDBXnAyIA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.6.1.tgz",
+      "integrity": "sha512-HEA9kynNTsOSIIz8p5GEEAH03pnn+SSohwPl80sGqkmI1yl1tzjqgYZRii0e6acJTh4j9655XFzSx36hYPeB2w==",
       "requires": {
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-arn-parser": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2713,6 +11405,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-1.0.0-gamma.3.tgz",
       "integrity": "sha512-IESS+/uvRJeORZs4Td2ZAxys0iFYGCOvh5lxqGN7mwE4GLrviJPVJkuYnFgOYSRao5LdxzLmmCcMQYdZxVNSDA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -2721,7 +11414,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2729,6 +11423,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-1.0.0-gamma.3.tgz",
       "integrity": "sha512-0H+QF5hu3e+qr6CIWl64NdX1wygFuFvukpYN84WfLcig0xTB3qduE0Z6TucBYigiK8xNSeKVtrDj9Mz/VGQJ2A==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "1.0.0-gamma.3",
         "@aws-sdk/signature-v4": "1.0.0-gamma.3",
@@ -2739,23 +11434,29 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-JVlLuOwcCl9mj0+VluhX3dN5yQ3kx8rM7sBWD7l2gYsresHmFHwJpyZC+Cd34lSnIMsx19Q5x9FcLeFcO6Y7eA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.6.1.tgz",
+      "integrity": "sha512-svuH6s91uKUTORt51msiL/ZBjtYSW32c3uVoWxludd/PEf6zO5wCmUEsKoyVwa88L7rrCq+81UBv5A8S5kc3Cw==",
       "requires": {
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2763,6 +11464,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-1.0.0-gamma.3.tgz",
       "integrity": "sha512-csiZhFxK6HWy3MDUZHr6saOdoT9CgAp8ifp1/HegZAZ+LhmADq4LNqtMqQaODyEXqxTSIjXBbIzq5vrs3qXwGw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -2771,7 +11473,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2779,6 +11482,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-1.0.0-gamma.3.tgz",
       "integrity": "sha512-0utMFeSOQ+VodNSCmjP0uWdgks36qGwY4B1EwwlZekzebEF1sqpBxFrzPreK1VEyv8wUG9drDjIy14khO1S2Kw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2788,7 +11492,48 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
+      "integrity": "sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.6.1",
+        "@aws-sdk/shared-ini-file-loader": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
+          "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
+          "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2796,6 +11541,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-1.0.0-gamma.3.tgz",
       "integrity": "sha512-cUka0oYYhqrY3Vif5Re9PASPau0Eu3ygGAjozppTzK0W5HE2yjMYM73PCwIyPO/B6qdzv8hTbJe7F/uM24TNmw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/abort-controller": "1.0.0-gamma.3",
         "@aws-sdk/protocol-http": "1.0.0-gamma.3",
@@ -2807,7 +11553,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2815,6 +11562,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-1.0.0-gamma.3.tgz",
       "integrity": "sha512-8SOLgaZeniK6uuzurKjeb4LV9d+AyLC/3UTnLNwIvrC2QTfKfLm9S9YMj4kbgwuI/hCu7hhsOVpha7YKRP82lA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -2823,7 +11571,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2831,6 +11580,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-1.0.0-gamma.3.tgz",
       "integrity": "sha512-RuXocAa90OFo+Es2sD0jaswTgnYUOg4eTXacm6vHGZhj1aYY7+JZsiZkRms53OwIuKrloo+974jQpIBS+DTT+A==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -2839,7 +11589,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2847,6 +11598,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-1.0.0-gamma.3.tgz",
       "integrity": "sha512-EUheuS+HlYDbfOKi5WQ9De5VJTUe0Ew+EE/xMRjXyZ5SQyEuIlK9OwwKZy3A4DKDBo6rTiifxk6C0ZuE4kVNww==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "@aws-sdk/util-uri-escape": "1.0.0-gamma.3",
@@ -2856,7 +11608,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2864,6 +11617,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-1.0.0-gamma.3.tgz",
       "integrity": "sha512-flAcTz2TitaLFEcc02AJESGbUS6n2ayQp5F7LBF2FSDAFq8E+Ysi/n/jh8xx8IglURrvoIzpGfem3J1Zm9djeQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -2872,7 +11626,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2880,6 +11635,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-provider/-/region-provider-1.0.0-gamma.3.tgz",
       "integrity": "sha512-a7pT+t0tfV2hKgB2db+peMhdFew7ztgS7+bIscFxY5Ce2xqwrgbKOBDEfmgGbx4H3xoPZpa2JrfU1BK43NzjNA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "1.0.0-gamma.3",
         "@aws-sdk/shared-ini-file-loader": "1.0.0-gamma.3",
@@ -2890,7 +11646,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2898,6 +11655,7 @@
       "version": "1.0.0-gamma.2",
       "resolved": "https://registry.npmjs.org/@aws-sdk/retry-config-provider/-/retry-config-provider-1.0.0-gamma.2.tgz",
       "integrity": "sha512-7brOLUXkTc/rA+AbMGzRdlTB16/KeQhaa+2/ozf7ZjKsEhfVW2ymw9y+H7yfZ5MHaJ2ml/WsXjk/7EYP7k4FTQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-retry": "1.0.0-gamma.3",
         "@aws-sdk/property-provider": "1.0.0-gamma.3",
@@ -2909,38 +11667,111 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-e5qwTYOraLljAA30v1B7fjyYBHuU2wUiTimAgzThE2P/9k4wM924Q0i0DAa7hSaIdlUdiGKUFX4hP2UyID3bIg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.6.1.tgz",
+      "integrity": "sha512-OI7UHCKBwuiO/RmHHewBKnL2NYqdilXRmpX67TJ4tTszIrWP2+vpm3lIfrx/BM8nf8nKTzgkO98uFhoJsEhmTg==",
       "requires": {
-        "@aws-sdk/signature-v4": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
-        "@aws-sdk/util-create-request": "1.0.0-gamma.3",
-        "@aws-sdk/util-format-url": "1.0.0-gamma.3",
+        "@aws-sdk/protocol-http": "3.6.1",
+        "@aws-sdk/signature-v4": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-create-request": "3.6.1",
+        "@aws-sdk/util-format-url": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
+          "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
+          "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
+          "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
+          "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/service-error-classification": {
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-O/CsFVWZyfhNIvzDAfNHJ3Uao/9+E5MNek0/jDW2ezZhmPZumW7tQgZ7CrFmPW9o9J5YWjozGaOuF3kuadBGkg=="
+      "integrity": "sha512-O/CsFVWZyfhNIvzDAfNHJ3Uao/9+E5MNek0/jDW2ezZhmPZumW7tQgZ7CrFmPW9o9J5YWjozGaOuF3kuadBGkg==",
+      "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-1.0.0-gamma.3.tgz",
       "integrity": "sha512-oujkYSHTlX3bHwA6hhAAnRtzrDSxMH3p0EEluD0QmhI5U89AhN5aP9b6FdPev+p4TC7TBv42jnRKwEo+NWvTlA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -2948,7 +11779,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2956,6 +11788,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-1.0.0-gamma.3.tgz",
       "integrity": "sha512-LUH0Oq8YDWNydvhDmlFzyUBMx1/jHwxufgnptm6FpfDs6ueZ4OWD4XKqSI8cAFE3DXBaHW8/sIhoUZw4imY/0g==",
+      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2967,7 +11800,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2975,6 +11809,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-1.0.0-gamma.3.tgz",
       "integrity": "sha512-emEqdzh7Dy3pAPE1HzgKNqw+7xeGaaVQ8XA++1gXL8ht8DFMN6YiV97/Yg0NtBt0oeiVaxlL0plNd/oyx9e3cA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -2984,7 +11819,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -2993,10 +11829,42 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-gamma.3.tgz",
       "integrity": "sha512-6Zu64X/6I8Y0gO/+J2CGXjYUmYkiI89MX3BEgRcQRh3jUNpKnOm1j4r40w4qsu1QAYxwWJL1M/rjLJPOQPV7zw=="
     },
+    "@aws-sdk/url-parser": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.6.1.tgz",
+      "integrity": "sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/querystring-parser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
+          "integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "@aws-sdk/url-parser-browser": {
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-browser/-/url-parser-browser-1.0.0-gamma.3.tgz",
       "integrity": "sha512-wo0SwwuFluTIjt2+j49GNQ0Vza+UVOirz2Up0VCbp7aqyMirIzDA66fQWXfzPiDvo0xV80TA7/P4/oyrrGhdbg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/querystring-parser": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -3006,7 +11874,40 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/url-parser-native": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz",
+      "integrity": "sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "tslib": "^1.8.0",
+        "url": "^0.11.0"
+      },
+      "dependencies": {
+        "@aws-sdk/querystring-parser": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
+          "integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3014,6 +11915,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-1.0.0-gamma.3.tgz",
       "integrity": "sha512-sq779pjaFlQEEFBToNb3m7J1h84Jk9ZcXj+VUixjjUwi8ieDCgea8zMQUAtkaHe0OU6FRcFp4WTadFr0sNrLnQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/querystring-parser": "1.0.0-gamma.3",
         "@aws-sdk/types": "1.0.0-gamma.3",
@@ -3024,7 +11926,23 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.6.1.tgz",
+      "integrity": "sha512-NFdYeuhaSrgnBG6Pt3zHNU7QwvhHq6sKUTWZShUayLMJYYbQr6IjmYVlPST4c84b+lyDoK68y/Zga621VfIdBg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3032,6 +11950,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-1.0.0-gamma.3.tgz",
       "integrity": "sha512-VOhetzPDQMgZERY37B6k1Dy/idhirLJk/5EvTDaL78QkihfoWa4N/58Td821WDgY/oaZNV0N4ul61tk0/n65QQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -3039,7 +11958,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3047,6 +11967,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-1.0.0-gamma.3.tgz",
       "integrity": "sha512-n2bxJXaSD+1pe3bKeFDWNO3UFnahNKVCqU/I2AKa6ZsWnEWhb8PuUu6A6BvCVdOGYqn77x3sLJvhOxLbsjjU4Q==",
+      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -3055,7 +11976,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3063,6 +11985,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-1.0.0-gamma.3.tgz",
       "integrity": "sha512-5mkzClLPvo763FeLEsd8RKBHBMQSijuEz2uCG/UNI6SYjzl0tx0RQiK24DoMMVLJq+TQ7goMMJK0REqnGOGYqA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -3070,7 +11993,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3078,6 +12002,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-1.0.0-gamma.3.tgz",
       "integrity": "sha512-ugDiAA1ivTalwIEH8TX/gshFwpuGs02+vULUyDmL/RQU7VhWR145k+fnoMfP3y1geAwUvudrqS01ZpCUX9w+5g==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -3085,7 +12010,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3093,6 +12019,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-1.0.0-gamma.3.tgz",
       "integrity": "sha512-v6z3b2mjdzSBWgMPwgdb821zFrxvVxILRIPVPe3E2ijnRaQfB4hVSaVHuogZuI949p/Pp4ctcZswwKRJEXIWVw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -3101,42 +12028,89 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/util-create-request": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-ShEj88J+0tZiZAvUgS6PaLkvBFOrHTJqxsM6DusrA3pmZIavdLS4cUtnp+28VK2Op3HRnL5UkTgjJG/zLAd+UQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.6.1.tgz",
+      "integrity": "sha512-jR1U8WpwXl+xZ9ThS42Jr5MXuegQ7QioHsZjQn3V5pbm8CXTkBF0B2BcULQu/2G1XtHOJb8qUZQlk/REoaORfQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "1.0.0-gamma.3",
-        "@aws-sdk/smithy-client": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/middleware-stack": "3.6.1",
+        "@aws-sdk/smithy-client": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/middleware-stack": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
+          "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
+          "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-MERO4Zty7BSshScyrigXPpqCSxKixqUHIJ3912TuUF8F3MAf3LM6CgDiaJ19a8KkXdKFglp/8apDWdV5+FmyUg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.6.1.tgz",
+      "integrity": "sha512-FvhcXcqLyJ0j0WdlmGs7PtjCCv8NaY4zBuXYO2iwAmqoy2SIZXQL63uAvmilqWj25q47ASAsUwSFLReCCfMklQ==",
       "requires": {
-        "@aws-sdk/querystring-builder": "1.0.0-gamma.3",
-        "@aws-sdk/types": "1.0.0-gamma.3",
+        "@aws-sdk/querystring-builder": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/querystring-builder": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
+          "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-uri-escape": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
+          "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3144,6 +12118,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-1.0.0-gamma.3.tgz",
       "integrity": "sha512-wappzF+OLeFtCGdRVxmKQoCCIotlOwe+zAJSVqymTFR94D2CtreIZo1azum6PxHbPiSzRFJs7KxgboHJ9pd18Q==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -3151,7 +12126,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3159,6 +12135,7 @@
       "version": "1.0.0-gamma.4",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-gamma.4.tgz",
       "integrity": "sha512-vWhGXPttXrvZhBeTjebbc5XZfRbwhlzzFHMkiMqvZ+m29ztS+EawtA3s3TArTIrBOLq7ciG6rX+FoI0//55G1Q==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -3166,7 +12143,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3174,6 +12152,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-1.0.0-gamma.3.tgz",
       "integrity": "sha512-4iH08ZsB2/OFLFpjyQ0MHd3yPeOl7h8D6fY9zHjyHN62+syPNNH5jYwFCxyBhwx/SXWVddwPzIqBD5VY4JkR4w==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -3181,7 +12160,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3189,6 +12169,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-1.0.0-gamma.3.tgz",
       "integrity": "sha512-//iH3jfxDLylUBmf6kbE19tm/aXGUf65CV6oal+Fgx8QqQJBCDgXdsl/aWWxr54EbANR6Gf/daw+EM7gGVOmPA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -3197,7 +12178,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3205,6 +12187,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-1.0.0-gamma.3.tgz",
       "integrity": "sha512-n2+yTdRioPjn2LyMlR+1faB5G0bP35vhEwW1JtZess7UnScUUcieMiRvdIqiH9ZRApsoIhW7zDjtFZQ7nBpHXg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -3213,7 +12196,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -3236,6 +12220,7 @@
       "version": "1.0.0-gamma.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-1.0.0-gamma.3.tgz",
       "integrity": "sha512-JmJMfupYQr6MeB9ww8Jm5Gwvx3xfHGrY4HJxw1e7EnFHUwFUyevd3lVcBgKJEy2OSXwzDOt2XOTeDFkMcjiVuA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "1.0.0-gamma.3",
         "tslib": "^1.8.0"
@@ -3244,22 +12229,54 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.6.1.tgz",
+      "integrity": "sha512-CQMRteoxW1XZSzPBVrTsOTnfzsEGs8N/xZ8BuBnXLBjoIQmRKVxIH9lgphm1ohCtVHoSWf28XH/KoOPFULQ4Tg==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
+          "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
+          "requires": {
+            "@aws-sdk/types": "3.6.1",
+            "tslib": "^1.8.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "1.0.0-gamma.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-1.0.0-gamma.3.tgz",
-      "integrity": "sha512-h36zfSXsSyTQWjLP54ik0Ocbb/6+o3GvDWpMe7in//+pog0jH6fSoeoagLikLuKTNJ9lDhtY0RtClcNQ7LkVXQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.6.1.tgz",
+      "integrity": "sha512-+HOCH4a0XO+I09okd0xdVP5Q5c9ZsEsDvnogiOcBQxoMivWhPUCo9pjXP3buCvVKP2oDHXQplBKSjGHvGaKFdg==",
       "requires": {
         "tslib": "^1.8.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -7038,9 +16055,9 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -7592,24 +16609,31 @@
       "dev": true
     },
     "amazon-cognito-identity-js": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.3.3.tgz",
-      "integrity": "sha512-LrOJU8zhRrfO9C+zYNYbLYg67i607eVWQW1kQXuxMieq0e9i/ThAuZoUq8OV/rprmjQRFvg9EHhY24OlmC7OAA==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.6.3.tgz",
+      "integrity": "sha512-MPVJfirbdmSGo7l4h7Kbn3ms1eJXT5Xq8ly+mCPPi8yAxaxdg7ouMUUNTqtDykoZxIdDLF/P6F3Zbg3dlGKOWg==",
       "requires": {
-        "buffer": "4.9.1",
-        "crypto-js": "^3.3.0",
-        "js-cookie": "^2.1.4"
+        "buffer": "4.9.2",
+        "crypto-js": "^4.0.0",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
       },
       "dependencies": {
         "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4",
             "isarray": "^1.0.0"
           }
+        },
+        "crypto-js": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+          "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
         }
       }
     },
@@ -7977,32 +17001,32 @@
       }
     },
     "aws-amplify": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-3.0.22.tgz",
-      "integrity": "sha512-nkw9OLDuMsNvgHmO1nUm9q9pkoLajKSmraJBxTGHZIF4ntC0vJceqcTVOOcmAU+OaZsh7tiniEzvBevd+7Q4uw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-3.4.3.tgz",
+      "integrity": "sha512-eLWQ+2aLlnpWIK+5OGzlut9z/zZWcxVia4JOYbT3lrIMCsLRUZzqGioBsEg7XCggHSJMXIBkwLMMzuTZK/dQ1w==",
       "requires": {
-        "@aws-amplify/analytics": "^3.2.5",
-        "@aws-amplify/api": "^3.1.21",
-        "@aws-amplify/auth": "^3.3.3",
-        "@aws-amplify/cache": "^3.1.21",
-        "@aws-amplify/core": "^3.4.4",
-        "@aws-amplify/datastore": "^2.2.8",
-        "@aws-amplify/interactions": "^3.1.21",
-        "@aws-amplify/predictions": "^3.1.21",
-        "@aws-amplify/pubsub": "^3.0.22",
-        "@aws-amplify/storage": "^3.2.11",
-        "@aws-amplify/ui": "^2.0.2",
-        "@aws-amplify/xr": "^2.1.21"
+        "@aws-amplify/analytics": "4.0.22",
+        "@aws-amplify/api": "3.3.3",
+        "@aws-amplify/auth": "3.4.34",
+        "@aws-amplify/cache": "3.1.57",
+        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/datastore": "2.10.1",
+        "@aws-amplify/interactions": "3.3.34",
+        "@aws-amplify/predictions": "3.2.34",
+        "@aws-amplify/pubsub": "3.3.3",
+        "@aws-amplify/storage": "3.4.4",
+        "@aws-amplify/ui": "2.0.2",
+        "@aws-amplify/xr": "2.2.34"
       },
       "dependencies": {
         "@aws-amplify/pubsub": {
-          "version": "3.0.22",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.0.22.tgz",
-          "integrity": "sha512-BKCvfVlH6zr61j44VB+NmeMYh+Q4Lr1T+9XBK0zD+0qm+vAz0J8cYB++oLkroGCLvKcqhjvPbxgEQzdPz05WTA==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.3.3.tgz",
+          "integrity": "sha512-j9PwkOjUhGE1cbExVjVfVeR7aMzlwckbP01K6QHPqOccstS/ZVD3W9ifhVCYJho1TTa6NoT7wn2HromesP2frQ==",
           "requires": {
-            "@aws-amplify/auth": "^3.3.3",
-            "@aws-amplify/cache": "^3.1.21",
-            "@aws-amplify/core": "^3.4.4",
+            "@aws-amplify/auth": "3.4.34",
+            "@aws-amplify/cache": "3.1.57",
+            "@aws-amplify/core": "3.8.24",
             "graphql": "14.0.0",
             "paho-mqtt": "^1.1.0",
             "uuid": "^3.2.1",
@@ -8024,40 +17048,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "follow-redirects": "^1.10.0"
       }
     },
     "axobject-query": {
@@ -8337,6 +17332,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -9500,8 +18500,7 @@
     "cookie": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "dev": true
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -9755,7 +18754,8 @@
     "crypto-js": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==",
+      "dev": true
     },
     "css": {
       "version": "2.2.4",
@@ -11563,9 +20563,12 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz",
-      "integrity": "sha512-qudnQuyYBgnvzf5Lj/yxMcf4L9NcVWihXJg7CiU1L+oUCq8MUnFEfH2/nXR/W5uq+yvUN1h7z6s7vs2v1WkL1A=="
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "requires": {
+        "strnum": "^1.0.4"
+      }
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -11871,7 +20874,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
       "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "dev": true,
       "requires": {
         "debug": "^3.0.0"
       },
@@ -11880,7 +20882,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -12681,9 +21682,9 @@
       }
     },
     "idb": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.2.tgz",
-      "integrity": "sha512-53yU1RbSPkSkQxufmNgcBkxxnbsTMGaYCv2NwQDmBP75muYj4Z75DsvCqhCCivYcC1XaXDi9tZSUOfDQFxuABA=="
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.6.tgz",
+      "integrity": "sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw=="
     },
     "ieee754": {
       "version": "1.1.13",
@@ -12719,9 +21720,9 @@
       "optional": true
     },
     "immer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.1.tgz",
-      "integrity": "sha512-oXwigCKgznQywsXi1VgrqgWbQEU3wievNCVc4Fcwky6mwXU6YHj6JuYp0WEM/B1EphkqsLr0x18lm5OiuemPcA=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -13559,6 +22560,15 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -13842,9 +22852,9 @@
       }
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
     },
     "karma": {
       "version": "6.3.2",
@@ -15479,8 +24489,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -15764,6 +24773,35 @@
       "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-fetch-npm": {
@@ -20779,6 +29817,11 @@
         "min-indent": "^1.0.0"
       }
     },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "style-loader": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
@@ -21926,6 +30969,11 @@
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -22057,6 +31105,22 @@
         "debug": "^4.1.1",
         "request": "^2.88.2",
         "uuid": "^3.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      },
+      "dependencies": {
+        "@types/cookie": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+          "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+        }
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngxs/store": "^3.7.2",
     "@sentry/browser": "^6.3.5",
     "angulartics2": "^10.0.0",
-    "aws-amplify": "^3.0.22",
+    "aws-amplify": "^3.4.3",
     "browserslist": "^4.16.6",
     "caniuse-lite": "^1.0.30001133",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
There is a critical security vulnerability in a transitive dependency.

**N.B.** I've had a quick look through the aws-aplify/auth changelog but haven't managed to test this locally so there is a greater chance of problems with the app, which we have some E2E tests for.