### PR TITLE
feat:set label removing the broken conditional and widen field

### DIFF
--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -29,7 +29,7 @@
       disableSearchAndSort: disableSearchAndSort$ | async
     } as data"
   >
-    <mat-form-field>
+    <mat-form-field style="width: 360px">
       <mat-label>{{ searchLabel }}</mat-label>
       <input
         matInput

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -47,13 +47,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   ) {
     this.isConnectionsSummary = this.recordsService.stateName === "connections";
     this.isRevalAdmin = this.authService.isRevalAdmin;
-    this.filter$.subscribe((filterName) => {
-      this.searchLabel =
-        filterName === ConnectionsFilterType.HIDDEN ||
-        ConnectionsFilterType.EXCEPTIONS_QUEUE
-          ? "Enter GMC no"
-          : "Enter name / GMC no";
-    });
+    this.searchLabel = "Search name, programme or GMC no";
   }
 
   ngOnInit() {


### PR DESCRIPTION
Update search box label to include 'programme'. The original code was trying to set the field name conditionally depending upon the current view, although this wasn't working correctly. This has been removed and the label set statically since the name search works from the exceptions queue view and there appears to be no reason to block this or programme name search.

https://hee-tis.atlassian.net/browse/TIS21-3058