### PR TITLE
Update the Cypress github action following Cypress upgrade

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         env:
           CYPRESS_baseUrl: https://stage-revalidation.tis.nhs.uk/
           CYPRESS_password: ${{ secrets.E2E_TEST_PASS }}


### PR DESCRIPTION
The E2E in pipeline failed with the following error.
`You are attempting to use Cypress with an older config file: cypress.json
When you upgraded to Cypress v10.0 the config file was updated and moved to a new location: cypress.config.ts`

cypress.json no has already been updated so maybe a simple fix following upgrade of Cypress from 7 -> 10, as suggested here:-  
https://github.com/cypress-io/github-action/issues/568

NO TICKET