### PR TITLE
Enable Cypress cross domain tests and link to Cypress dashboard for reports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,5 +180,9 @@ jobs:
           CYPRESS_coverage: false
         with:
           browser: chrome
+          record: true
+        env:
+          # for recording results and videos to Cypress Dashborad
+          CYPRESS_RECORD_KEY: ${{secrets.CYPRESS_RECORD_KEY}}
 
       #TODO: Fix/finish reporting setup

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,14 +1,16 @@
-import { defineConfig } from 'cypress'
+import { defineConfig } from "cypress";
 
 export default defineConfig({
   chromeWebSecurity: false,
   defaultCommandTimeout: 15000,
+  projectId: "eko18a",
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
+    experimentalSessionAndOrigin: true, //required to allow cross origin for hosted ui login
     setupNodeEvents(on, config) {
-      return require('./cypress/plugins/index.js')(on, config)
+      return require("./cypress/plugins/index.js")(on, config);
     },
-    baseUrl: 'https://stage-revalidation.tis.nhs.uk/',
-  },
-})
+    baseUrl: "https://stage-revalidation.tis.nhs.uk/"
+  }
+});

--- a/cypress/e2e/app/recommendations/recommendations-filters/recommendations-filters.cy.ts
+++ b/cypress/e2e/app/recommendations/recommendations-filters/recommendations-filters.cy.ts
@@ -1,5 +1,5 @@
 describe("Recommendations filters", () => {
-  before(() => {
+  beforeEach(() => {
     cy.login();
   });
 
@@ -10,7 +10,6 @@ describe("Recommendations filters", () => {
   });
 
   it("should contain under notice and all doctors buttons", () => {
-    cy.login();
     cy.get(buttons).should("have.length", 2);
     cy.get(buttons).eq(0).should("contain.text", "ALL DOCTORS");
     cy.get(buttons).eq(1).should("contain.text", "UNDER NOTICE");

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "ng lint",
     "lint:styles": "stylelint \"src/**/*.scss\"",
     "cypress": "cypress run --browser chrome",
-    "cypress-open": "cypress open",
+    "cypress:local": "cypress run --browser chrome --config baseUrl=http://localhost:4200",
+    "cypress:open": "cypress open --config baseUrl=http://localhost:4200",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
     "preinstall": "npx npm-force-resolutions"
   },


### PR DESCRIPTION
The E2E tests are failing in the pipeline which I suspect is due to Cognito hosted authentication handled on a separate domain, although there is no way to view the reports or videos. To resolve I have enabled this via a Cypress experimental flag and  connected to Cypress Dashboard to view the reports in the immediate term since the entry tier is free but also investigate as a possible solution for storing reports going forward.    