### PR TITLE
Add page titles to DOM

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,34 @@
-import { Component } from "@angular/core";
-
+import { Component, OnInit } from "@angular/core";
+import { Title } from "@angular/platform-browser";
+import { Router, NavigationEnd, ActivatedRoute } from "@angular/router";
+import { filter, map } from "rxjs/operators";
 @Component({
   selector: "app-root",
   templateUrl: "./app.component.html"
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  constructor(private titleService: Title, private router: Router) {}
+
+  ngOnInit() {
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        map(() => {
+          let route: ActivatedRoute = this.router.routerState.root;
+          let routeTitle = "";
+          while (route!.firstChild) {
+            route = route.firstChild;
+          }
+          if (route.snapshot.data["title"]) {
+            routeTitle = route!.snapshot.data["title"];
+          }
+          return routeTitle;
+        })
+      )
+      .subscribe((title: string) => {
+        if (title) {
+          this.titleService.setTitle(`Revalidation - ${title}`);
+        }
+      });
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,11 +16,11 @@ export class AppComponent implements OnInit {
         map(() => {
           let route: ActivatedRoute = this.router.routerState.root;
           let routeTitle = "";
-          while (route!.firstChild) {
+          while (route.firstChild) {
             route = route.firstChild;
           }
           if (route.snapshot.data["title"]) {
-            routeTitle = route!.snapshot.data["title"];
+            routeTitle = route.snapshot.data["title"];
           }
           return routeTitle;
         })


### PR DESCRIPTION
The HTML page title displays `Revalidation` for all page routes. It would be better to give if this provided more detail for improved UX and analytics data capture. The addition of title custom data properties has already been included in the routes eg  `data: { title: "Connections list" }`. However, the code to actually update the page title was absent.

NO TICKET   