### PR TITLE
chore: update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,12 @@ updates:
     schedule:
       interval: weekly
     reviewers:
-      - Health-Education-England/frontend
+      - Health-Education-England/internal-admin-frontend
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     reviewers:
-      - Health-Education-England/frontend
-      - Health-Education-England/operations
+      - Health-Education-England/internal-admin-frontend
+      - Health-Education-England/internal-admin-devops


### PR DESCRIPTION
Update dependabot reviewers to use the new product teams.

TIS21-SHED