### PR TITLE
Feat/records filtering

### DIFF
--- a/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
+++ b/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
@@ -1,0 +1,18 @@
+describe("Recommendations", () => {
+  describe("Filter summary records list table", () => {
+    beforeEach(() => {
+      cy.login();
+      cy.visit("/recommendations");
+    });
+
+    it("should open filter panel when button is clicked", () => {
+      const toggleFiltersButton = cy.get(
+        "[data-cy='toggleTableFiltersButton']"
+      );
+      toggleFiltersButton.click();
+      cy.get(".filters-drawer-container .mat-drawer-opened").should(
+        "be.visible"
+      );
+    });
+  });
+});

--- a/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
+++ b/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
@@ -1,18 +1,170 @@
 describe("Recommendations", () => {
-  describe("Filter summary records list table", () => {
+  describe("Apply filtering to summary records list table", () => {
     beforeEach(() => {
-      cy.login();
-      cy.visit("/recommendations");
+      cy.loginSession();
     });
 
-    it("should open filter panel when button is clicked", () => {
-      const toggleFiltersButton = cy.get(
-        "[data-cy='toggleTableFiltersButton']"
-      );
-      toggleFiltersButton.click();
+    it("should open and close filter panel when toggle button is clicked", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+      cy.wait(3000);
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
       cy.get(".filters-drawer-container .mat-drawer-opened").should(
-        "be.visible"
+        "not.exist"
       );
+    });
+
+    it("should display 'programme name' filter field", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+      cy.get("[data-cy='formfield_programmeName']").should("exist");
+    });
+
+    it("should display 'Apply filters' and 'Clear filters' buttons disabled by default", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+      cy.get("[data-cy='tableFiltersForm'] button").should("have.length", 2);
+      cy.get(
+        "[data-cy='tableFiltersForm'] button[data-jasmine='clearFiltersButton']"
+      ).should(($el) => expect($el.text().trim()).to.equal("Clear filters"));
+      cy.get(
+        "[data-cy='tableFiltersForm'] button[data-jasmine='clearFiltersButton']"
+      ).should("be.disabled");
+
+      cy.get(
+        "[data-cy='tableFiltersForm'] button[data-jasmine='submitFormButton']"
+      ).should(($el) => expect($el.text().trim()).to.equal("Apply filters"));
+      cy.get(
+        "[data-cy='tableFiltersForm'] button[data-jasmine='submitFormButton']"
+      ).should("be.disabled");
+    });
+
+    it("should display list containing matching options when the text 'clin' is entered", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+
+      cy.get("mat-option").should("not.exist");
+      cy.get("[data-cy='formfield_programmeName'] input").type("Clin");
+      cy.wait(1000);
+      cy.get("mat-option").should("have.length.above", 1);
+    });
+
+    it("should display error message when no matching options found", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+
+      cy.get("mat-option").should("not.exist");
+      cy.get("[data-cy='formfield_programmeName'] input").type("qwert");
+      cy.wait(1000);
+
+      cy.get("[data-cy='formFieldWrapper'] div.mat-error").should(
+        "contain",
+        "No matches found"
+      );
+    });
+
+    it("should set value of textbox matching selected item from list", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+
+      cy.get("mat-option").should("not.exist");
+      cy.get("[data-cy='formfield_programmeName'] input").type("clin");
+      cy.wait(1000);
+      cy.get("mat-option")
+        .first()
+        .invoke("text")
+        .then((value) => {
+          cy.get("mat-option").first().click();
+          cy.wait(1000);
+          cy.get("[data-cy='formfield_programmeName'] input").should(
+            "have.value",
+            value
+          );
+        });
+    });
+
+    it("should enable both buttons when item selected from list", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+
+      cy.get("mat-option").should("not.exist");
+      cy.get("[data-cy='formfield_programmeName'] input").type("clin");
+      cy.wait(1000);
+      cy.get("mat-option").first().click();
+      cy.wait(1000);
+      cy.get(
+        "[data-cy='tableFiltersForm'] [data-jasmine='clearFiltersButton']"
+      ).should("not.be.disabled");
+      cy.get(
+        "[data-cy='tableFiltersForm'] [data-jasmine='submitFormButton']"
+      ).should("not.be.disabled");
+    });
+
+    it("should update summary table displaying trainees with matching programme name only", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+
+      cy.get("mat-option").should("not.exist");
+      cy.get("[data-cy='formfield_programmeName'] input").type("clin");
+      cy.wait(1000);
+      cy.get("mat-option")
+        .first()
+        .invoke("text")
+        .then((value) => {
+          cy.get("mat-option").first().click();
+          cy.wait(1000);
+          cy.get(
+            "[data-cy='tableFiltersForm'] button[data-jasmine='submitFormButton']"
+          ).click();
+          cy.wait(1000);
+
+          cy.get("td.cdk-column-programmeName").each(($el, index, $list) => {
+            expect($el.text()).to.equal(value);
+          });
+        });
+    });
+
+    it("should reset summary table results when 'Clear fliters' button is clicked", () => {
+      cy.visit("/recommendations");
+      cy.get("[data-cy='toggleTableFiltersButton']").click();
+      cy.wait(1000);
+      cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
+      cy.get("[data-cy='formfield_programmeName'] input").type("clin");
+      cy.wait(1000);
+      cy.get("mat-option").first().click();
+      cy.wait(1000);
+      cy.get(".mat-paginator-range-label")
+        .invoke("text")
+        .then((paginatorText) => {
+          cy.get(
+            "[data-cy='tableFiltersForm'] button[data-jasmine='submitFormButton']"
+          ).click();
+          cy.wait(1000);
+          cy.get(".mat-paginator-range-label").should(
+            "not.contain",
+            paginatorText
+          );
+          cy.get(
+            "[data-cy='tableFiltersForm'] [data-jasmine='clearFiltersButton']"
+          ).click();
+          cy.wait(1000);
+          cy.get(".mat-paginator-range-label").should("contain", paginatorText);
+        });
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -34,4 +34,17 @@ Cypress.Commands.add("login", () => {
   cy.get("#kc-form-wrapper").find("#username").type(username);
   cy.get("#kc-form-wrapper").find("#password").type(password);
   cy.get("#kc-form-wrapper").find("#kc-login").click();
+  cy.wait(3000);
+});
+
+Cypress.Commands.add("loginSession", () => {
+  cy.session([username, password], () => {
+    cy.visit("/");
+    cy.get("form").eq(1).as("form");
+    cy.get("@form").find(".idpButton-customizable").click();
+    cy.get("#kc-form-wrapper").find("#username").type(username);
+    cy.get("#kc-form-wrapper").find("#password").type(password);
+    cy.get("#kc-form-wrapper").find("#kc-login").click();
+    cy.wait(3000);
+  });
 });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -5,5 +5,6 @@
 declare namespace Cypress {
   interface Chainable {
     login: any;
+    loginSession: any;
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_DISABLE,
     browserConsoleLogOptions: {
-      level: "error",
+      level: "debug",
       format: "%b %T: %m",
       terminal: true
     },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_DISABLE,
     browserConsoleLogOptions: {
-      level: "debug",
+      level: "error",
       format: "%b %T: %m",
       terminal: true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21063,9 +21063,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-      "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
       "dev": true
     },
     "circular-dependency-plugin": {
@@ -21119,9 +21119,9 @@
       "dev": true
     },
     "cli-table3": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
-      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
       "dev": true,
       "requires": {
         "@colors/colors": "1.5.0",
@@ -22126,9 +22126,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.3.tgz",
-      "integrity": "sha512-8C82XTybsEmJC9POYSNITGUhMLCRwB9LadP0x33H+52QVoBjhsWvIzrI+ybCe0+TyxaF0D5/9IL2kSTgjqCB9A==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.8.0.tgz",
+      "integrity": "sha512-QVse0dnLm018hgti2enKMVZR9qbIO488YGX06nH5j3Dg1isL38DwrBtyrax02CANU6y8F4EJUuyW6HJKw1jsFA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -22150,7 +22150,7 @@
         "dayjs": "^1.10.4",
         "debug": "^4.3.2",
         "enquirer": "^2.3.6",
-        "eventemitter2": "^6.4.3",
+        "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
@@ -22176,9 +22176,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.21.tgz",
-          "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==",
+          "version": "14.18.29",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+          "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
           "dev": true
         },
         "ansi-styles": {
@@ -22283,12 +22283,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-          "dev": true
-        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -22340,9 +22334,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+      "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==",
       "dev": true
     },
     "debug": {
@@ -23482,9 +23476,9 @@
       "dev": true
     },
     "eventemitter2": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
-      "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
       "dev": true
     },
     "eventemitter3": {
@@ -27060,9 +27054,9 @@
       },
       "dependencies": {
         "colorette": {
-          "version": "2.0.17",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
-          "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==",
+          "version": "2.0.19",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+          "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
           "dev": true
         },
         "p-map": {
@@ -27075,9 +27069,9 @@
           }
         },
         "rxjs": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+          "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
           "dev": true,
           "requires": {
             "tslib": "^2.1.0"
@@ -31206,9 +31200,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "pump": {
@@ -33659,7 +33653,7 @@
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "integrity": "sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==",
       "dev": true
     },
     "through": {
@@ -33881,7 +33875,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -33890,7 +33884,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "type-check": {
@@ -34313,7 +34307,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -34975,7 +34969,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "browserslist-useragent-regexp": "^3.0.2",
     "buffer": "^6.0.3",
     "codelyzer": "^6.0.0",
-    "cypress": "^10.0.3",
+    "cypress": "^10.8.0",
     "eslint": "^8.17.0",
     "husky": "^6.0.0",
     "jasmine-core": "~4.2.0",

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -11,5 +11,15 @@
     "target": "https://stage-revalidation.tis.nhs.uk/",
     "secure": true,
     "changeOrigin": true
+  },
+
+  "/nymovies": {
+    "target": "https://api.nytimes.com/svc/movies/v2/reviews/search.json",
+    "secure": true,
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/nymovies": ""
+    },
+    "logLevel": "debug"
   }
 }

--- a/src/app/admins/allocate-admin-btn/allocate-admin-btn.component.html
+++ b/src/app/admins/allocate-admin-btn/allocate-admin-btn.component.html
@@ -1,19 +1,27 @@
 <ng-container *ngIf="enableAllocateAdmin$ | async; else isDisabled">
   <button
-    mat-menu-item
+    color="primary"
+    mat-icon-button
     aria-label="Disable allocate admin"
     (click)="disableAllocateAdmin()"
+    matTooltip="Disable allocate admin"
+    matTooltipPosition="below"
+    matTooltipShowDelay="500"
   >
-    Disable allocate admin
+    <mat-icon>person_add_disabled</mat-icon>
   </button>
 </ng-container>
 
 <ng-template #isDisabled>
   <button
-    mat-menu-item
+    mat-icon-button
+    color="primary"
     aria-label="Enable allocate admin"
     (click)="enableAllocateAdmin()"
+    matTooltip="Enable allocate admin"
+    matTooltipPosition="below"
+    matTooltipShowDelay="500"
   >
-    Enable allocate admin
+    <mat-icon>person_add</mat-icon>
   </button>
 </ng-template>

--- a/src/app/admins/allocate-admin-btn/allocate-admin-btn.component.spec.ts
+++ b/src/app/admins/allocate-admin-btn/allocate-admin-btn.component.spec.ts
@@ -1,4 +1,5 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { MaterialModule } from "../../shared/material/material.module";
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NgxsModule, Store } from "@ngxs/store";
@@ -18,6 +19,7 @@ describe("AllocateAdminBtnComponent", () => {
       declarations: [AllocateAdminBtnComponent],
       imports: [
         HttpClientTestingModule,
+        MaterialModule,
         RouterTestingModule,
         NgxsModule.forRoot([RecommendationsState])
       ]

--- a/src/app/concerns/concerns.resolver.ts
+++ b/src/app/concerns/concerns.resolver.ts
@@ -23,6 +23,7 @@ export class ConcernsResolver extends RecordsResolver implements Resolve<any> {
   private initialiseData(): void {
     this.recordsService.stateName = "concerns";
     this.recordsService.detailsRoute = "/concern";
+    this.recordsService.showTableFilters = false;
     this.recordsService.setConcernsActions();
     this.recordsService.dateColumns = [
       "closedDate",

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -26,6 +26,7 @@ export class ConnectionsResolver
   private initialiseData(): void {
     this.recordsService.stateName = stateName.CONNECTIONS;
     this.recordsService.detailsRoute = "/connection";
+    this.recordsService.showTableFilters = false;
     this.recordsService.setConnectionsActions();
     this.recordsService.dateColumns = [
       "submissionDate",

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -8,7 +8,7 @@ import { RecordsService } from "../records/services/records.service";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { ConnectionsFilterType } from "./connections.interfaces";
 import { COLUMN_DATA } from "./constants";
-
+import { stateName } from "../records/records.interfaces";
 @Injectable()
 export class ConnectionsResolver
   extends RecordsResolver
@@ -24,7 +24,7 @@ export class ConnectionsResolver
   }
 
   private initialiseData(): void {
-    this.recordsService.stateName = "connections";
+    this.recordsService.stateName = stateName.CONNECTIONS;
     this.recordsService.detailsRoute = "/connection";
     this.recordsService.setConnectionsActions();
     this.recordsService.dateColumns = [

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -4,8 +4,9 @@ import { HttpClient } from "@angular/common/http";
 import { Auth } from "aws-amplify";
 import { CognitoUserSession } from "amazon-cognito-identity-js";
 import { AuthService } from "./auth.service";
+import { EMPTY, of } from "rxjs";
 
-describe("AuthService", () => {
+fdescribe("AuthService", () => {
   let service: AuthService;
   let http: HttpClient;
   const defaultPayload: { [key: string]: any } = {
@@ -96,10 +97,9 @@ describe("AuthService", () => {
     });
   });
 
-  it("should invoke Auth federated signin when currentsession is not avaialbel", () => {
-    spyOn(Auth, "currentSession").and.callFake(() =>
-      Promise.reject("Session not available")
-    );
+  fit("should invoke Auth federated signin when currentsession is not avaialbel", () => {
+    spyOn(service, "currentSession").and.returnValue(EMPTY);
+
     spyOn(service, "signIn");
 
     service.currentSession().subscribe(

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -6,7 +6,7 @@ import { CognitoUserSession } from "amazon-cognito-identity-js";
 import { AuthService } from "./auth.service";
 import { EMPTY, of } from "rxjs";
 
-fdescribe("AuthService", () => {
+describe("AuthService", () => {
   let service: AuthService;
   let http: HttpClient;
   const defaultPayload: { [key: string]: any } = {
@@ -97,7 +97,7 @@ fdescribe("AuthService", () => {
     });
   });
 
-  fit("should invoke Auth federated signin when currentsession is not avaialbel", () => {
+  it("should invoke Auth federated signin when currentsession is not avaialbel", () => {
     spyOn(service, "currentSession").and.returnValue(EMPTY);
 
     spyOn(service, "signIn");

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -4,7 +4,7 @@ import { HttpClient } from "@angular/common/http";
 import { Auth } from "aws-amplify";
 import { CognitoUserSession } from "amazon-cognito-identity-js";
 import { AuthService } from "./auth.service";
-import { EMPTY, of } from "rxjs";
+import { EMPTY } from "rxjs";
 
 describe("AuthService", () => {
   let service: AuthService;

--- a/src/app/details/comments/comments.component.spec.ts
+++ b/src/app/details/comments/comments.component.spec.ts
@@ -1,4 +1,5 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
@@ -17,7 +18,8 @@ describe("CommentsComponent", () => {
         MaterialModule,
         NoopAnimationsModule,
         HttpClientTestingModule
-      ]
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   }));
 

--- a/src/app/details/tool-bar/tool-bar.component.spec.ts
+++ b/src/app/details/tool-bar/tool-bar.component.spec.ts
@@ -61,15 +61,15 @@ describe("NoteCardComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should display 'speaker_notes' mat-icon by default", waitForAsync(() => {
+  it("should display 'speaker_notes' mat-icon by default", () => {
     const { debugElement } = fixture;
     const { nativeElement } = debugElement;
     const el = nativeElement.querySelector(".note-icon-open");
     fixture.detectChanges();
     expect(el).toBeTruthy();
-  }));
+  });
 
-  it("should display 'speaker_notes_OFF' mat-icon when drawer is open", waitForAsync(() => {
+  it("should display 'speaker_notes_OFF' mat-icon when drawer is open", () => {
     const { debugElement } = fixture;
     const { nativeElement } = debugElement;
     const button = nativeElement.querySelector("button.toggle-drawer");
@@ -77,16 +77,16 @@ describe("NoteCardComponent", () => {
     fixture.detectChanges();
     const el = nativeElement.querySelector(".note-icon-close");
     expect(el).toBeTruthy();
-  }));
+  });
 
-  it("should display the number of notes in the icon badge", waitForAsync(() => {
+  it("should display the number of notes in the icon badge", () => {
     const { debugElement } = fixture;
     const { nativeElement } = debugElement;
     const el = nativeElement.querySelector(".mat-badge-content");
     expect(el.innerText).toContain("3");
-  }));
+  });
 
-  it("should display '' in the icon badge when no notes", waitForAsync(() => {
+  it("should display '' in the icon badge when no notes", () => {
     store.reset({
       ...store.snapshot(),
       traineeDetails: {
@@ -101,5 +101,5 @@ describe("NoteCardComponent", () => {
     const { nativeElement } = debugElement;
     const el = nativeElement.querySelector(".mat-badge-content");
     expect(el.innerText).toContain("");
-  }));
+  });
 });

--- a/src/app/recommendation/services/recommendation-history.service.spec.ts
+++ b/src/app/recommendation/services/recommendation-history.service.spec.ts
@@ -2,7 +2,7 @@ import {
   HttpClientTestingModule,
   HttpTestingController
 } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
+import { TestBed, waitForAsync } from "@angular/core/testing";
 import {
   ActivatedRouteSnapshot,
   Router,
@@ -75,14 +75,13 @@ describe("RecommendationHistoryService", () => {
     http.verify();
   });
 
-  it("should call submit recommendation to GMC api", (done: DoneFn) => {
+  it("should call submit recommendation to GMC api", waitForAsync(() => {
     service.submitRecommendationToGMC(null, "", "").subscribe({
       error: (err) => {
         expect(err).toEqual("gmcNumber and recommendationId are required");
-        done();
       }
     });
-  });
+  }));
 
   it("should call submit recommendation to GMC api", () => {
     const designatedBody = "DBC";

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -1,5 +1,8 @@
 import { Sort } from "@angular/material/sort";
-import { ControlBase } from "../shared/form-controls/contol-base.model";
+import {
+  ControlBase,
+  MaterialAutocompleteControl
+} from "../shared/form-controls/contol-base.model";
 
 export const COLUMN_DATA: [string, string, boolean][] = [
   ["GMC Submission due date", "submissionDate", true],
@@ -21,7 +24,9 @@ export const DEFERRAL_MIN_DAYS = 120;
 export const DEFERRAL_MAX_DAYS = 365;
 export const DEFERRAL_PERMITTED_MAX_DAYS = 120;
 
-export const TABLE_FILTERS_FORM_BASE: ControlBase[] = [
+export const TABLE_FILTERS_FORM_BASE: Array<
+  ControlBase | MaterialAutocompleteControl
+> = [
   {
     key: "gmcStatus",
     label: "GMC Status",
@@ -46,6 +51,16 @@ export const TABLE_FILTERS_FORM_BASE: ControlBase[] = [
     order: 2,
     controlType: "selectionList",
     initialValue: []
+  },
+  {
+    key: "programmeName",
+    label: "Programme name",
+    order: 4,
+    initialValue: [],
+    controlType: "autocomplete",
+    allowMultipleSelections: false,
+    serviceMethod: "loadMovies",
+    placeholder: "Start typing..."
   }
 ];
 

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -28,51 +28,10 @@ export const TABLE_FILTERS_FORM_BASE: Array<
   FormControlBase | AutocompleteControl
 > = [
   {
-    key: "gmcStatus",
-    label: "GMC Status",
-    options: [
-      { key: "Approved", value: "Approved" },
-      { key: "Rejected", value: "Rejected" },
-      { key: "Under Review", value: "Under Review" }
-    ],
-    order: 1,
-    controlType: "selectionList",
-    initialValue: []
-  },
-  {
-    key: "tisStatus",
-    label: "TIS Status",
-    options: [
-      { key: "Not started", value: "Not started" },
-      { key: "Submitted to GMC", value: "Submitted to GMC" },
-      { key: "Draft", value: "Draft" },
-      { key: "Complete", value: "Complete" }
-    ],
-    order: 2,
-    controlType: "selectionList",
-    initialValue: []
-  },
-  {
     key: "programmeName",
     label: "Programme name",
-    order: 4,
-    initialValue: "",
+    order: 1,
     controlType: "autocomplete",
-    serviceMethod: "loadMovies",
     placeholder: "Start typing..."
   }
 ];
-
-export const TABLE_FILTERS_FORM_DBC: FormControlBase = {
-  key: "dbc",
-  label: "Designated Body",
-  options: [
-    { key: "KSS", value: "Kent, Surrey and Sussex" },
-    { key: "NCEL", value: "North Central and East London" },
-    { key: "NWL", value: "North West London" },
-    { key: "SL", value: "South London" }
-  ],
-  order: 3,
-  controlType: "selectionList",
-  initialValue: []
-};

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -1,8 +1,8 @@
 import { Sort } from "@angular/material/sort";
 import {
-  ControlBase,
-  MaterialAutocompleteControl
-} from "../shared/form-controls/contol-base.model";
+  FormControlBase,
+  AutocompleteControl
+} from "../shared/form-controls/form-contol-base.model";
 
 export const COLUMN_DATA: [string, string, boolean][] = [
   ["GMC Submission due date", "submissionDate", true],
@@ -25,7 +25,7 @@ export const DEFERRAL_MAX_DAYS = 365;
 export const DEFERRAL_PERMITTED_MAX_DAYS = 120;
 
 export const TABLE_FILTERS_FORM_BASE: Array<
-  ControlBase | MaterialAutocompleteControl
+  FormControlBase | AutocompleteControl
 > = [
   {
     key: "gmcStatus",
@@ -58,13 +58,12 @@ export const TABLE_FILTERS_FORM_BASE: Array<
     order: 4,
     initialValue: [],
     controlType: "autocomplete",
-    allowMultipleSelections: false,
     serviceMethod: "loadMovies",
     placeholder: "Start typing..."
   }
 ];
 
-export const TABLE_FILTERS_FORM_DBC: ControlBase = {
+export const TABLE_FILTERS_FORM_DBC: FormControlBase = {
   key: "dbc",
   label: "Designated Body",
   options: [

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -1,4 +1,5 @@
 import { Sort } from "@angular/material/sort";
+import { ControlBase } from "../shared/form-controls/contol-base.model";
 
 export const COLUMN_DATA: [string, string, boolean][] = [
   ["GMC Submission due date", "submissionDate", true],
@@ -19,3 +20,45 @@ export const RECOMMENDATION_SORT: Sort = {
 export const DEFERRAL_MIN_DAYS = 120;
 export const DEFERRAL_MAX_DAYS = 365;
 export const DEFERRAL_PERMITTED_MAX_DAYS = 120;
+
+export const TABLE_FILTERS_FORM_BASE: ControlBase[] = [
+  {
+    key: "gmcStatus",
+    label: "GMC Status",
+    options: [
+      { key: "Approved", value: "Approved" },
+      { key: "Rejected", value: "Rejected" },
+      { key: "Under Review", value: "Under Review" }
+    ],
+    order: 1,
+    controlType: "selectionList",
+    initialValue: []
+  },
+  {
+    key: "tisStatus",
+    label: "TIS Status",
+    options: [
+      { key: "Not started", value: "Not started" },
+      { key: "Submitted to GMC", value: "Submitted to GMC" },
+      { key: "Draft", value: "Draft" },
+      { key: "Complete", value: "Complete" }
+    ],
+    order: 2,
+    controlType: "selectionList",
+    initialValue: []
+  }
+];
+
+export const TABLE_FILTERS_FORM_DBC: ControlBase = {
+  key: "dbc",
+  label: "Designated Body",
+  options: [
+    { key: "KSS", value: "Kent, Surrey and Sussex" },
+    { key: "NCEL", value: "North Central and East London" },
+    { key: "NWL", value: "North West London" },
+    { key: "SL", value: "South London" }
+  ],
+  order: 3,
+  controlType: "selectionList",
+  initialValue: []
+};

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -56,7 +56,7 @@ export const TABLE_FILTERS_FORM_BASE: Array<
     key: "programmeName",
     label: "Programme name",
     order: 4,
-    initialValue: [],
+    initialValue: "",
     controlType: "autocomplete",
     serviceMethod: "loadMovies",
     placeholder: "Start typing..."

--- a/src/app/recommendations/recommendations.interfaces.ts
+++ b/src/app/recommendations/recommendations.interfaces.ts
@@ -29,6 +29,11 @@ export interface IGetRecommendationsResponse extends IGetRecordsResponse {
   recommendationInfo: IRecommendation[];
 }
 
+export interface IRecommendationsTableFilters {
+  programmeName: string;
+  gmcStatus: string;
+}
+
 export enum RecommendationsFilterType {
   UNDER_NOTICE = "underNotice",
   ALL_DOCTORS = "allDoctors"

--- a/src/app/recommendations/recommendations.interfaces.ts
+++ b/src/app/recommendations/recommendations.interfaces.ts
@@ -1,4 +1,7 @@
-import { IGetRecordsResponse } from "../records/records.interfaces";
+import {
+  IGetRecordsResponse,
+  ITableFilters
+} from "../records/records.interfaces";
 import {
   RecommendationStatus,
   RecommendationGmcOutcome
@@ -29,9 +32,10 @@ export interface IGetRecommendationsResponse extends IGetRecordsResponse {
   recommendationInfo: IRecommendation[];
 }
 
-export interface IRecommendationsTableFilters {
-  programmeName: string;
-  gmcStatus: string;
+export interface IRecommendationsTableFilters extends ITableFilters {
+  programmeName?: string;
+  gmcStatus?: string[];
+  tisStatus?: string[];
 }
 
 export enum RecommendationsFilterType {

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { ActivatedRouteSnapshot, Resolve } from "@angular/router";
+import { ActivatedRouteSnapshot, Params, Resolve } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { generateColumnData } from "../records/constants";
@@ -10,11 +10,15 @@ import {
   TABLE_FILTERS_FORM_BASE,
   TABLE_FILTERS_FORM_DBC
 } from "./constants";
-import { RecommendationsFilterType } from "./recommendations.interfaces";
+import {
+  IRecommendationsTableFilters,
+  RecommendationsFilterType
+} from "./recommendations.interfaces";
 import { AuthService } from "../core/auth/auth.service";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { stateName } from "../records/records.interfaces";
 import { FormControlBase } from "../shared/form-controls/form-contol-base.model";
+import { RecommendationsStateModel } from "./state/recommendations.state";
 @Injectable()
 export class RecommendationsResolver
   extends RecordsResolver
@@ -69,6 +73,22 @@ export class RecommendationsResolver
   }
 
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    const paramsExist: boolean = Object.keys(route.queryParams).length > 0;
+    if (paramsExist) {
+      const state: RecommendationsStateModel = this.store.selectSnapshot(
+        (snapshot) => snapshot.recommendations
+      );
+
+      const filters: IRecommendationsTableFilters = {};
+      if (
+        route.queryParams.programmeName !== state.tableFilters?.programmeName
+      ) {
+        filters.programmeName = route.queryParams.programmeName;
+
+        this.recordsService.setTableFilters(filters);
+        this.recordsService.toggleTableFilterPanel$.next(true);
+      }
+    }
     return super.resolve(route);
   }
 }

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -9,11 +9,12 @@ import { COLUMN_DATA } from "./constants";
 import { RecommendationsFilterType } from "./recommendations.interfaces";
 import { AuthService } from "../core/auth/auth.service";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
-
+import { stateName } from "../records/records.interfaces";
 @Injectable()
 export class RecommendationsResolver
   extends RecordsResolver
-  implements Resolve<any> {
+  implements Resolve<any>
+{
   constructor(
     protected store: Store,
     protected recordsService: RecordsService,
@@ -25,7 +26,7 @@ export class RecommendationsResolver
   }
 
   private initialiseData(): void {
-    this.recordsService.stateName = "recommendations";
+    this.recordsService.stateName = stateName.RECOMMENDATIONS;
     this.recordsService.detailsRoute = "/recommendation";
     this.recordsService.setRecommendationsActions();
     this.recordsService.dateColumns = [

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -5,11 +5,7 @@ import { Observable } from "rxjs";
 import { generateColumnData } from "../records/constants";
 import { RecordsResolver } from "../records/records.resolver";
 import { RecordsService } from "../records/services/records.service";
-import {
-  COLUMN_DATA,
-  TABLE_FILTERS_FORM_BASE,
-  TABLE_FILTERS_FORM_DBC
-} from "./constants";
+import { COLUMN_DATA, TABLE_FILTERS_FORM_BASE } from "./constants";
 import {
   IRecommendationsTableFilters,
   RecommendationsFilterType
@@ -37,6 +33,7 @@ export class RecommendationsResolver
   private initialiseData(): void {
     this.recordsService.stateName = stateName.RECOMMENDATIONS;
     this.recordsService.detailsRoute = "/recommendation";
+    this.recordsService.showTableFilters = true;
     this.recordsService.setRecommendationsActions();
     this.recordsService.dateColumns = [
       "curriculumEndDate",
@@ -47,14 +44,13 @@ export class RecommendationsResolver
 
     if (this.authService.inludesLondonDbcs) {
       const statusIndex = COLUMN_DATA.findIndex((dbc) => dbc[0] === "Status");
-      TABLE_FILTERS_FORM_BASE.push(TABLE_FILTERS_FORM_DBC);
       COLUMN_DATA.splice(statusIndex + 1, 0, [
         "Designated body",
         "designatedBody",
         false
       ]);
     }
-    this.recordsService.showTableFilters = true;
+
     this.recordsService.tableFiltersFormData = TABLE_FILTERS_FORM_BASE.sort(
       (a: FormControlBase, b: FormControlBase) => a.order - b.order
     );

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -49,7 +49,8 @@ export class RecommendationsResolver
         false
       ]);
     }
-    this.recordsService.tableFiltersForm = TABLE_FILTERS_FORM_BASE;
+    this.recordsService.showTableFilters = true;
+    this.recordsService.tableFiltersFormData = TABLE_FILTERS_FORM_BASE;
 
     this.recordsService.columnData = generateColumnData(COLUMN_DATA);
     this.recordsService.filters = [

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -14,6 +14,7 @@ import { RecommendationsFilterType } from "./recommendations.interfaces";
 import { AuthService } from "../core/auth/auth.service";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { stateName } from "../records/records.interfaces";
+import { FormControlBase } from "../shared/form-controls/form-contol-base.model";
 @Injectable()
 export class RecommendationsResolver
   extends RecordsResolver
@@ -50,7 +51,9 @@ export class RecommendationsResolver
       ]);
     }
     this.recordsService.showTableFilters = true;
-    this.recordsService.tableFiltersFormData = TABLE_FILTERS_FORM_BASE;
+    this.recordsService.tableFiltersFormData = TABLE_FILTERS_FORM_BASE.sort(
+      (a: FormControlBase, b: FormControlBase) => a.order - b.order
+    );
 
     this.recordsService.columnData = generateColumnData(COLUMN_DATA);
     this.recordsService.filters = [

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -5,7 +5,11 @@ import { Observable } from "rxjs";
 import { generateColumnData } from "../records/constants";
 import { RecordsResolver } from "../records/records.resolver";
 import { RecordsService } from "../records/services/records.service";
-import { COLUMN_DATA } from "./constants";
+import {
+  COLUMN_DATA,
+  TABLE_FILTERS_FORM_BASE,
+  TABLE_FILTERS_FORM_DBC
+} from "./constants";
 import { RecommendationsFilterType } from "./recommendations.interfaces";
 import { AuthService } from "../core/auth/auth.service";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
@@ -38,13 +42,14 @@ export class RecommendationsResolver
 
     if (this.authService.inludesLondonDbcs) {
       const statusIndex = COLUMN_DATA.findIndex((dbc) => dbc[0] === "Status");
-
+      TABLE_FILTERS_FORM_BASE.push(TABLE_FILTERS_FORM_DBC);
       COLUMN_DATA.splice(statusIndex + 1, 0, [
         "Designated body",
         "designatedBody",
         false
       ]);
     }
+    this.recordsService.tableFiltersForm = TABLE_FILTERS_FORM_BASE;
 
     this.recordsService.columnData = generateColumnData(COLUMN_DATA);
     this.recordsService.filters = [

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { ActivatedRouteSnapshot, Params, Resolve } from "@angular/router";
+import { ActivatedRouteSnapshot, Resolve } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { generateColumnData } from "../records/constants";
@@ -51,9 +51,9 @@ export class RecommendationsResolver
       ]);
     }
 
-    this.recordsService.tableFiltersFormData = TABLE_FILTERS_FORM_BASE.sort(
-      (a: FormControlBase, b: FormControlBase) => a.order - b.order
-    );
+    this.recordsService.tableFiltersFormData = [
+      ...TABLE_FILTERS_FORM_BASE
+    ].sort((a: FormControlBase, b: FormControlBase) => a.order - b.order);
 
     this.recordsService.columnData = generateColumnData(COLUMN_DATA);
     this.recordsService.filters = [

--- a/src/app/recommendations/services/recommendations.service.ts
+++ b/src/app/recommendations/services/recommendations.service.ts
@@ -17,8 +17,8 @@ export class RecommendationsService {
   ) {}
 
   public generateParams(): HttpParams {
-    const snapshot: RecommendationsStateModel = this.store.snapshot()
-      .recommendations;
+    const snapshot: RecommendationsStateModel =
+      this.store.snapshot().recommendations;
     let params: HttpParams = this.recordsService.generateParams(snapshot);
 
     params = params
@@ -28,7 +28,8 @@ export class RecommendationsService {
           ? "true"
           : "false"
       )
-      .append("dbcs", this.authService.userDesignatedBodies.join(","));
+      .append("dbcs", this.authService.userDesignatedBodies.join(","))
+      .append("programmeName", snapshot.tableFilters?.programmeName || "");
 
     return params;
   }

--- a/src/app/recommendations/state/recommendations.actions.ts
+++ b/src/app/recommendations/state/recommendations.actions.ts
@@ -5,21 +5,21 @@ import {
   PaginatePayload,
   SearchPayload,
   SortPayload,
-  ToggleCheckboxPayload
+  ToggleCheckboxPayload,
+  TableFiltersPayload
 } from "../../records/state/records.actions";
 import { HttpErrorPayload } from "../../shared/services/error/error.service";
 import {
   IGetRecommendationsResponse,
-  RecommendationsFilterType
+  RecommendationsFilterType,
+  IRecommendationsTableFilters
 } from "../recommendations.interfaces";
 
 export class GetRecommendations {
   static readonly type = `[Recommendations] Get`;
 }
 
-export class GetRecommendationsSuccess extends GetSuccessPayload<
-  IGetRecommendationsResponse
-> {
+export class GetRecommendationsSuccess extends GetSuccessPayload<IGetRecommendationsResponse> {
   static readonly type = `[Recommendations] Get Success`;
 }
 
@@ -35,9 +35,7 @@ export class ResetRecommendationsSort {
   static readonly type = `[Recommendations] Reset Sort`;
 }
 
-export class FilterRecommendations extends FilterPayload<
-  RecommendationsFilterType
-> {
+export class FilterRecommendations extends FilterPayload<RecommendationsFilterType> {
   static readonly type = `[Recommendations] Filter`;
 }
 
@@ -51,6 +49,14 @@ export class RecommendationsSearch extends SearchPayload {
 
 export class ClearRecommendationsSearch {
   static readonly type = `[Recommendations] Clear Search`;
+}
+
+export class SetRecommendationsTableFilters extends TableFiltersPayload<IRecommendationsTableFilters> {
+  static readonly type = `[Recommendations] Filter Table`;
+}
+
+export class ClearRecommendationsTableFilters {
+  static readonly type = `[Recommendations] Clear Table Filters`;
 }
 
 export class PaginateRecommendations extends PaginatePayload {

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -159,18 +159,14 @@ export class RecommendationsState extends RecordsState {
     ctx: StateContext<RecommendationsStateModel>,
     action: SetRecommendationsTableFilters
   ) {
-    return ctx.patchState({
-      tableFilters: action.tableFilter
-    });
+    return super.setTableFiltersHandler(ctx, action);
   }
 
   @Action(ClearRecommendationsTableFilters)
   clearRecommendationsTableFilters(
     ctx: StateContext<RecommendationsStateModel>
   ) {
-    return ctx.patchState({
-      tableFilters: null
-    });
+    return super.clearTableFiltersHandler(ctx);
   }
 
   @Action(FilterRecommendations)

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -14,6 +14,7 @@ import {
 import {
   IGetRecommendationsResponse,
   IRecommendation,
+  IRecommendationsTableFilters,
   RecommendationsFilterType
 } from "../recommendations.interfaces";
 import { RecommendationsService } from "../services/recommendations.service";
@@ -26,6 +27,8 @@ import {
   GetRecommendationsSuccess,
   PaginateRecommendations,
   RecommendationsSearch,
+  SetRecommendationsTableFilters,
+  ClearRecommendationsTableFilters,
   ResetRecommendationsFilter,
   ResetRecommendationsPaginator,
   ResetRecommendationsSort,
@@ -36,7 +39,8 @@ import {
 
 export class RecommendationsStateModel extends RecordsStateModel<
   RecommendationsFilterType,
-  IRecommendation[]
+  IRecommendation[],
+  IRecommendationsTableFilters
 > {}
 
 @State<RecommendationsStateModel>({
@@ -148,6 +152,25 @@ export class RecommendationsState extends RecordsState {
   @Action(ClearRecommendationsSearch)
   clearSearch(ctx: StateContext<RecommendationsStateModel>) {
     return super.clearSearchHandler(ctx);
+  }
+
+  @Action(SetRecommendationsTableFilters)
+  setRecommendationsTableFilters(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: SetRecommendationsTableFilters
+  ) {
+    return ctx.patchState({
+      tableFilters: action.tableFilter
+    });
+  }
+
+  @Action(ClearRecommendationsTableFilters)
+  clearRecommendationsTableFilters(
+    ctx: StateContext<RecommendationsStateModel>
+  ) {
+    return ctx.patchState({
+      tableFilters: null
+    });
   }
 
   @Action(FilterRecommendations)

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -11,7 +11,7 @@
 
       <div class="d-flex justify-content-end">
         <button
-          [disabled]="!form.valid"
+          [disabled]="!form.valid || !form.dirty"
           type="button"
           mat-button
           mat-raised-button
@@ -21,7 +21,7 @@
           Clear filters
         </button>
         <button
-          [disabled]="!form.valid"
+          [disabled]="!form.valid || !form.dirty"
           type="submit"
           mat-button
           mat-raised-button

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -9,13 +9,27 @@
         ></app-form-controller>
       </div>
 
-      <div class="form-row">
-        <button type="submit" class="btn btn-primary" [disabled]="!form.valid">
-          Filter
+      <div class="d-flex justify-content-end">
+        <button
+          [disabled]="!form.valid"
+          type="button"
+          mat-button
+          mat-raised-button
+          color="secondary"
+          (click)="clearFilters()"
+        >
+          Clear filters
+        </button>
+        <button
+          [disabled]="!form.valid"
+          type="submit"
+          mat-button
+          mat-raised-button
+          color="primary"
+        >
+          Apply filters
         </button>
       </div>
     </form>
-
-    {{ filters | json }}
   </div>
 </div>

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -6,5 +6,8 @@
       nobis. Facilis nostrum fugiat nobis ullam quam soluta expedita est nam ut
       officiis, dolor sequi consectetur ab? Ipsa, deleniti et.
     </p>
+    <button (click)="onFilter()">Show</button>
+    <button (click)="clearFilters()">Clear</button>
+    {{ filters | json }}
   </div>
 </div>

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -1,7 +1,7 @@
 <div class="filters-wrapper">
   <div class="mb-20">
     <h2>Filters</h2>
-    <form (ngSubmit)="onSubmit()" [formGroup]="form">
+    <form (ngSubmit)="onSubmit()" *ngIf="form" [formGroup]="form">
       <div *ngFor="let control of formControls" class="form-row">
         <app-form-controller
           [control]="control"
@@ -11,6 +11,7 @@
 
       <div class="d-flex justify-content-end">
         <button
+          data-jasmine="clearFiltersButton"
           class="mr-10"
           [disabled]="!form.valid || !form.dirty"
           type="button"
@@ -22,6 +23,7 @@
           Clear filters
         </button>
         <button
+          data-jasmine="submitFormButton"
           [disabled]="!form.valid || !form.dirty"
           type="submit"
           mat-button

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -10,18 +10,12 @@
       </div>
 
       <div class="form-row">
-        <button type="submit" class="btn btn-primary" [disabled]="form?.valid">
-          Save
+        <button type="submit" class="btn btn-primary" [disabled]="!form.valid">
+          Filter
         </button>
       </div>
     </form>
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore, neque
-      nobis. Facilis nostrum fugiat nobis ullam quam soluta expedita est nam ut
-      officiis, dolor sequi consectetur ab? Ipsa, deleniti et.
-    </p>
-    <button (click)="onFilter()">Show</button>
-    <button (click)="clearFilters()">Clear</button>
+
     {{ filters | json }}
   </div>
 </div>

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -1,6 +1,20 @@
 <div class="filters-wrapper">
   <div class="mb-20">
     <h2>Filters</h2>
+    <form (ngSubmit)="onSubmit()" [formGroup]="form">
+      <div *ngFor="let control of meta" class="form-row">
+        <app-form-controller
+          [control]="control"
+          [form]="form"
+        ></app-form-controller>
+      </div>
+
+      <div class="form-row">
+        <button type="submit" class="btn btn-primary" [disabled]="form?.valid">
+          Save
+        </button>
+      </div>
+    </form>
     <p>
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore, neque
       nobis. Facilis nostrum fugiat nobis ullam quam soluta expedita est nam ut

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -2,7 +2,7 @@
   <div class="mb-20">
     <h2>Filters</h2>
     <form (ngSubmit)="onSubmit()" [formGroup]="form">
-      <div *ngFor="let control of meta" class="form-row">
+      <div *ngFor="let control of formControls" class="form-row">
         <app-form-controller
           [control]="control"
           [form]="form"
@@ -11,6 +11,7 @@
 
       <div class="d-flex justify-content-end">
         <button
+          class="mr-10"
           [disabled]="!form.valid || !form.dirty"
           type="button"
           mat-button

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -1,7 +1,12 @@
 <div class="filters-wrapper">
   <div class="mb-20">
     <h2>Filters</h2>
-    <form (ngSubmit)="onSubmit()" *ngIf="form" [formGroup]="form">
+    <form
+      data-cy="tableFiltersForm"
+      (ngSubmit)="onSubmit()"
+      *ngIf="form"
+      [formGroup]="form"
+    >
       <div *ngFor="let control of formControls" class="form-row">
         <app-form-controller
           [control]="control"

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.html
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.html
@@ -1,0 +1,10 @@
+<div class="filters-wrapper">
+  <div class="mb-20">
+    <h2>Filters</h2>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolore, neque
+      nobis. Facilis nostrum fugiat nobis ullam quam soluta expedita est nam ut
+      officiis, dolor sequi consectetur ab? Ipsa, deleniti et.
+    </p>
+  </div>
+</div>

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.scss
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.scss
@@ -2,7 +2,8 @@
   background-color: #fafafa;
   padding: 10px;
 }
-h2 {
+h2,
+.h2 {
   font-size: 12px;
   font-weight: bold;
   padding-bottom: 10px;

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.scss
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.scss
@@ -2,9 +2,3 @@
   background-color: #fafafa;
   padding: 10px;
 }
-h2,
-.h2 {
-  font-size: 12px;
-  font-weight: bold;
-  padding-bottom: 10px;
-}

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.scss
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.scss
@@ -1,0 +1,9 @@
+.filters-wrapper {
+  background-color: #fafafa;
+  padding: 10px;
+}
+h2 {
+  font-size: 12px;
+  font-weight: bold;
+  padding-bottom: 10px;
+}

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -85,7 +85,6 @@ describe("Record List Table FIlters", () => {
       order: 4,
       initialValue: "",
       controlType: "autocomplete",
-      serviceMethod: "loadMovies",
       placeholder: "Start typing..."
     }
   ];

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecordListTableFiltersComponent } from './record-list-table-filters.component';
+
+describe('RecordListTableFiltersComponent', () => {
+  let component: RecordListTableFiltersComponent;
+  let fixture: ComponentFixture<RecordListTableFiltersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecordListTableFiltersComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecordListTableFiltersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -229,8 +229,6 @@ describe("Record List Table FIlters", () => {
         ...(snapshot.searchQuery && { searchQuery: snapshot.searchQuery })
       }
     });
-    console.log("#######################", location.path());
-
     flush();
   }));
 });

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -23,7 +23,6 @@ import {
   AutocompleteControl,
   FormControlBase
 } from "src/app/shared/form-controls/form-contol-base.model";
-import { Location } from "@angular/common";
 import { Router } from "@angular/router";
 import { of } from "rxjs";
 
@@ -32,7 +31,6 @@ describe("Record List Table FIlters", () => {
   let recordsService: RecordsService;
   let fixture: ComponentFixture<RecordListTableFiltersComponent>;
   let component: RecordListTableFiltersComponent;
-  let location: Location;
   let router: Router;
   const formControls: (FormControlBase | AutocompleteControl)[] = [
     {
@@ -107,7 +105,6 @@ describe("Record List Table FIlters", () => {
     store = TestBed.inject(Store);
     recordsService = TestBed.inject(RecordsService);
     router = TestBed.inject(Router);
-    location = TestBed.inject(Location);
   }));
 
   beforeEach(() => {

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -1,16 +1,15 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 
-import { RecordListTableFiltersComponent } from './record-list-table-filters.component';
+import { RecordListTableFiltersComponent } from "./record-list-table-filters.component";
 
-describe('RecordListTableFiltersComponent', () => {
+xdescribe("RecordListTableFiltersComponent", () => {
   let component: RecordListTableFiltersComponent;
   let fixture: ComponentFixture<RecordListTableFiltersComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ RecordListTableFiltersComponent ]
-    })
-    .compileComponents();
+      declarations: [RecordListTableFiltersComponent]
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe('RecordListTableFiltersComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -1,24 +1,236 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
-
+import {
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+  tick,
+  waitForAsync
+} from "@angular/core/testing";
+import { RecordsModule } from "../records.module";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { NgxsModule, Store } from "@ngxs/store";
+import {
+  RecommendationsState,
+  RecommendationsStateModel
+} from "src/app/recommendations/state/recommendations.state";
+import { MaterialModule } from "src/app/shared/material/material.module";
+import { RecordsService } from "../services/records.service";
 import { RecordListTableFiltersComponent } from "./record-list-table-filters.component";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { By } from "@angular/platform-browser";
+import {
+  AutocompleteControl,
+  FormControlBase
+} from "src/app/shared/form-controls/form-contol-base.model";
+import { Location } from "@angular/common";
+import { Router } from "@angular/router";
+import { of } from "rxjs";
 
-xdescribe("RecordListTableFiltersComponent", () => {
-  let component: RecordListTableFiltersComponent;
+describe("Record List Table FIlters", () => {
+  let store: Store;
+  let recordsService: RecordsService;
   let fixture: ComponentFixture<RecordListTableFiltersComponent>;
+  let component: RecordListTableFiltersComponent;
+  let location: Location;
+  let router: Router;
+  const formControls: (FormControlBase | AutocompleteControl)[] = [
+    {
+      key: "selectionList1_Key",
+      label: "selection List 1 Label",
+      options: [
+        {
+          key: "selectionList1_OptionKey1",
+          value: "selection List 1 Option Value 1"
+        },
+        {
+          key: "selectionList1_OptionKey2",
+          value: "selection List 1 Option Value 2"
+        },
+        {
+          key: "selectionList1_OptionKey3",
+          value: "selection List 1 Option Value 3"
+        }
+      ],
+      order: 1,
+      controlType: "selectionList",
+      initialValue: []
+    },
+    {
+      key: "selectionList2_Key",
+      label: "selection List 2 Label",
+      options: [
+        {
+          key: "selectionList2_OptionKey1",
+          value: "selection List 2 Option Value 1"
+        },
+        {
+          key: "selectionList2_OptionKey2",
+          value: "selection List 2 Option Value 2"
+        },
+        {
+          key: "selectionList2_OptionKey3",
+          value: "selection List 2 Option Value 3"
+        },
+        {
+          key: "selectionList2_OptionKey4",
+          value: "selection List 2 Option Value 4"
+        }
+      ],
+      order: 4,
+      controlType: "selectionList",
+      initialValue: []
+    },
+    {
+      key: "autocomplete_key",
+      label: "autocomplete label",
+      order: 4,
+      initialValue: "",
+      controlType: "autocomplete",
+      serviceMethod: "loadMovies",
+      placeholder: "Start typing..."
+    }
+  ];
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RecordsModule,
+        NoopAnimationsModule,
+        MaterialModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        NgxsModule.forRoot([RecommendationsState])
+      ],
       declarations: [RecordListTableFiltersComponent]
     }).compileComponents();
-  });
+    store = TestBed.inject(Store);
+    recordsService = TestBed.inject(RecordsService);
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RecordListTableFiltersComponent);
     component = fixture.componentInstance;
+    recordsService.stateName = "recommendations";
+    recordsService.setRecommendationsActions();
+    store.reset({
+      recommendations: {
+        filter: "underNotice",
+        sort: {
+          active: "submissionDate",
+          direction: "asc"
+        },
+        pageIndex: 1,
+        tableFilters: null
+      }
+    });
+
+    component.form = recordsService.toFormGroup(
+      formControls as FormControlBase[],
+      []
+    );
+    component.formControls = formControls;
+
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  it("should display correct number of controls when data passed", () => {
+    expect(
+      fixture.debugElement.queryAll(By.css("[data-jasmine='formControl']"))
+        .length
+    ).toBe(3);
   });
+
+  it("should display correct type of controls when data passed", () => {
+    expect(
+      fixture.debugElement.queryAll(By.css("mat-selection-list")).length
+    ).toBe(2);
+    expect(
+      fixture.debugElement.queryAll(By.css("mat-autocomplete")).length
+    ).toBe(1);
+  });
+
+  it("should reset form when 'Clear filters' button is clicked", fakeAsync(() => {
+    const spyClearTableFilters = spyOn(
+      recordsService,
+      "clearTableFilters"
+    ).and.returnValue(of(true));
+    const matOptions = fixture.debugElement.queryAll(By.css("mat-list-option"));
+
+    matOptions.forEach((matOption) => {
+      const matOptionElement = matOption.nativeElement;
+      matOptionElement.click();
+      tick(500);
+      fixture.detectChanges();
+      expect(matOptionElement.getAttribute("aria-selected")).toEqual("true");
+    });
+
+    const clearFiltersButton = fixture.debugElement.query(
+      By.css("[data-jasmine='clearFiltersButton']")
+    ).nativeElement;
+
+    clearFiltersButton.click();
+
+    matOptions.forEach((matOption) => {
+      const matOptionElement = matOption.nativeElement;
+      tick(500);
+      fixture.detectChanges();
+      expect(matOptionElement.getAttribute("aria-selected")).toEqual("false");
+    });
+
+    expect(spyClearTableFilters).toHaveBeenCalled();
+
+    flush();
+  }));
+
+  it("should disable submit button when form is blank", () => {
+    component.clearFilters();
+    fixture.detectChanges();
+    const submitFormButton = fixture.debugElement.query(
+      By.css("[data-jasmine='submitFormButton']")
+    ).nativeElement;
+    expect(submitFormButton.getAttribute("disabled")).toEqual("true");
+  });
+
+  it("should call onSubmit when submit button is clicked", () => {
+    const spySubmitForm = spyOn(component, "onSubmit");
+    const matOption = fixture.debugElement.query(By.css("mat-list-option"));
+    matOption.nativeElement.click();
+    fixture.detectChanges();
+    const submitFormButton = fixture.debugElement.query(
+      By.css("[data-jasmine='submitFormButton']")
+    ).nativeElement;
+    submitFormButton.click();
+    fixture.detectChanges();
+    expect(spySubmitForm).toHaveBeenCalled();
+  });
+
+  it("should reset form when 'Clear filters' button is clicked", fakeAsync(() => {
+    spyOn(router, "navigate");
+    const snapshot: RecommendationsStateModel =
+      store.snapshot().recommendations;
+    const matOption = fixture.debugElement.query(By.css("mat-list-option"));
+    matOption.nativeElement.click();
+    fixture.detectChanges();
+
+    component.onSubmit();
+    fixture.detectChanges();
+    expect(router.navigate).toHaveBeenCalledWith(["/"], {
+      queryParams: {
+        active: snapshot.sort.active,
+        direction: snapshot.sort.direction,
+        pageIndex: snapshot.pageIndex,
+        filter: snapshot.filter,
+        selectionList1_Key: "selectionList1_OptionKey1",
+        selectionList2_Key: "",
+        autocomplete_key: "",
+        ...(snapshot.searchQuery && { searchQuery: snapshot.searchQuery })
+      }
+    });
+    console.log("#######################", location.path());
+
+    flush();
+  }));
 });

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -16,7 +16,7 @@ import { RecordsService } from "../services/records.service";
 })
 export class RecordListTableFiltersComponent implements OnInit {
   activeTableFilters: ITableFilters;
-  meta: (FormControlBase | AutocompleteControl)[] = [];
+  formControls: (FormControlBase | AutocompleteControl)[] = [];
   form!: FormGroup;
   payLoad = "";
   constructor(private recordsService: RecordsService, private store: Store) {}
@@ -45,9 +45,9 @@ export class RecordListTableFiltersComponent implements OnInit {
     });
 
     if (this.recordsService.tableFiltersFormData) {
-      this.meta = this.recordsService.tableFiltersFormData;
+      this.formControls = this.recordsService.tableFiltersFormData;
       this.form = this.recordsService.toFormGroup(
-        this.meta,
+        this.formControls,
         this.activeTableFilters
       );
       this.activeTableFilters && this.form.markAsDirty();

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -3,7 +3,10 @@ import { FormGroup } from "@angular/forms";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { IRecommendationsTableFilters } from "src/app/recommendations/recommendations.interfaces";
-import { ControlBase } from "src/app/shared/form-controls/contol-base.model";
+import {
+  ControlBase,
+  MaterialAutocompleteControl
+} from "src/app/shared/form-controls/contol-base.model";
 import { RecordsService } from "../services/records.service";
 
 @Component({
@@ -13,7 +16,7 @@ import { RecordsService } from "../services/records.service";
 })
 export class RecordListTableFiltersComponent implements OnInit {
   filters: any;
-  meta: ControlBase[] = [];
+  meta: (ControlBase | MaterialAutocompleteControl)[] = [];
   @Input() data: any = {};
   form!: FormGroup;
   payLoad = "";
@@ -36,12 +39,16 @@ export class RecordListTableFiltersComponent implements OnInit {
     });
   }
   ngOnInit(): void {
-    this.meta = this.recordsService.tableFiltersForm.sort(
-      (a: ControlBase, b: ControlBase) => a.order - b.order
-    );
-    this.form = this.recordsService.toFormGroup(this.meta, this.data);
-    this.tableFilters$.subscribe((val) => {
-      this.filters = val;
-    });
+    if (this.recordsService.tableFiltersFormData) {
+      this.meta = this.recordsService.tableFiltersFormData;
+      this.form = this.recordsService.toFormGroup(
+        this.recordsService.tableFiltersFormData,
+        this.data
+      );
+      console.log(this.form);
+      this.tableFilters$.subscribe((val) => {
+        this.filters = val;
+      });
+    }
   }
 }

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -1,12 +1,12 @@
-import { Component, OnInit, Input } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
-import { IRecommendationsTableFilters } from "src/app/recommendations/recommendations.interfaces";
 import {
-  ControlBase,
-  MaterialAutocompleteControl
-} from "src/app/shared/form-controls/contol-base.model";
+  FormControlBase,
+  AutocompleteControl
+} from "src/app/shared/form-controls/form-contol-base.model";
+import { ITableFilters } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
 
 @Component({
@@ -15,16 +15,14 @@ import { RecordsService } from "../services/records.service";
   styleUrls: ["./record-list-table-filters.component.scss"]
 })
 export class RecordListTableFiltersComponent implements OnInit {
-  filters: any;
-  meta: (ControlBase | MaterialAutocompleteControl)[] = [];
-  @Input() data: any = {};
+  activeTableFilters: ITableFilters;
+  meta: (FormControlBase | AutocompleteControl)[] = [];
   form!: FormGroup;
   payLoad = "";
   constructor(private recordsService: RecordsService, private store: Store) {}
-  public tableFilters$: Observable<IRecommendationsTableFilters> =
-    this.store.select(
-      (state) => state[this.recordsService.stateName].tableFilters
-    );
+  public tableFilters$: Observable<any> = this.store.select(
+    (state) => state[this.recordsService.stateName].tableFilters
+  );
 
   clearFilters() {
     this.form.reset();
@@ -38,17 +36,21 @@ export class RecordListTableFiltersComponent implements OnInit {
       this.recordsService.updateRoute();
     });
   }
+
   ngOnInit(): void {
+    this.tableFilters$.subscribe((filters) => {
+      if (filters) {
+        this.activeTableFilters = filters;
+      }
+    });
+
     if (this.recordsService.tableFiltersFormData) {
       this.meta = this.recordsService.tableFiltersFormData;
       this.form = this.recordsService.toFormGroup(
-        this.recordsService.tableFiltersFormData,
-        this.data
+        this.meta,
+        this.activeTableFilters
       );
-      console.log(this.form);
-      this.tableFilters$.subscribe((val) => {
-        this.filters = val;
-      });
+      this.activeTableFilters && this.form.markAsDirty();
     }
   }
 }

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -25,6 +25,7 @@ export class RecordListTableFiltersComponent implements OnInit {
 
   clearFilters() {
     this.form.reset();
+    this.recordsService.resetPaginator();
     this.recordsService.clearTableFilters().subscribe(() => {
       this.recordsService.updateRoute();
     });

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -13,19 +13,7 @@ import { RecordsService } from "../services/records.service";
 })
 export class RecordListTableFiltersComponent implements OnInit {
   filters: any;
-  @Input() meta: ControlBase[] = [
-    {
-      key: "country",
-      options: [
-        { key: "IN", value: "India" },
-        { key: "USA", value: "United States of America" },
-        { key: "UK", value: "United Kingdom" }
-      ],
-      order: 8,
-      controlType: "selectionList",
-      initialValue: []
-    }
-  ];
+  meta: ControlBase[] = [];
   @Input() data: any = {};
   form!: FormGroup;
   payLoad = "";
@@ -34,22 +22,20 @@ export class RecordListTableFiltersComponent implements OnInit {
     this.store.select(
       (state) => state[this.recordsService.stateName].tableFilters
     );
-  onFilter() {
-    this.recordsService
-      .setTableFilters({
-        programeName: "HELLO",
-        gmcStatus: "BUM"
-      })
-      .subscribe(() => this.recordsService.updateRoute());
-  }
+
   clearFilters() {
     this.recordsService.clearTableFilters();
   }
 
   onSubmit() {
-    alert("Show button clicked!");
+    this.recordsService.setTableFilters(this.form.value).subscribe(() => {
+      this.recordsService.updateRoute();
+    });
   }
   ngOnInit(): void {
+    this.meta = this.recordsService.tableFiltersForm.sort(
+      (a: ControlBase, b: ControlBase) => a.order - b.order
+    );
     this.form = this.recordsService.toFormGroup(this.meta, this.data);
     this.tableFilters$.subscribe((val) => {
       this.filters = val;

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -38,7 +38,7 @@ export class RecordListTableFiltersComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.tableFilters$.subscribe((filters) => {
+    this.tableFilters$.subscribe((filters: ITableFilters) => {
       if (filters) {
         this.activeTableFilters = filters;
       }

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -1,15 +1,39 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit } from "@angular/core";
+import { Store } from "@ngxs/store";
+import { Observable } from "rxjs";
+import { IRecommendationsTableFilters } from "src/app/recommendations/recommendations.interfaces";
+import { RecordsService } from "../services/records.service";
 
 @Component({
-  selector: 'app-record-list-table-filters',
-  templateUrl: './record-list-table-filters.component.html',
-  styleUrls: ['./record-list-table-filters.component.scss']
+  selector: "app-record-list-table-filters",
+  templateUrl: "./record-list-table-filters.component.html",
+  styleUrls: ["./record-list-table-filters.component.scss"]
 })
 export class RecordListTableFiltersComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
+  filters: any;
+  constructor(private recordsService: RecordsService, private store: Store) {}
+  public tableFilters$: Observable<IRecommendationsTableFilters> =
+    this.store.select(
+      (state) => state[this.recordsService.stateName].tableFilters
+    );
+  onFilter() {
+    this.recordsService
+      .setTableFilters({
+        programeName: "HELLO",
+        gmcStatus: "BUM"
+      })
+      .subscribe(() => this.recordsService.updateRoute());
+  }
+  clearFilters() {
+    this.recordsService.clearTableFilters();
   }
 
+  onShow() {
+    alert("Show button clicked!");
+  }
+  ngOnInit(): void {
+    this.tableFilters$.subscribe((val) => {
+      this.filters = val;
+    });
+  }
 }

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -18,7 +18,6 @@ export class RecordListTableFiltersComponent implements OnInit {
   activeTableFilters: ITableFilters;
   formControls: (FormControlBase | AutocompleteControl)[] = [];
   form!: FormGroup;
-  payLoad = "";
   constructor(private recordsService: RecordsService, private store: Store) {}
   public tableFilters$: Observable<any> = this.store.select(
     (state) => state[this.recordsService.stateName].tableFilters
@@ -43,7 +42,6 @@ export class RecordListTableFiltersComponent implements OnInit {
         this.activeTableFilters = filters;
       }
     });
-
     if (this.recordsService.tableFiltersFormData) {
       this.formControls = this.recordsService.tableFiltersFormData;
       this.form = this.recordsService.toFormGroup(

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -24,7 +24,10 @@ export class RecordListTableFiltersComponent implements OnInit {
     );
 
   clearFilters() {
-    this.recordsService.clearTableFilters();
+    this.form.reset();
+    this.recordsService.clearTableFilters().subscribe(() => {
+      this.recordsService.updateRoute();
+    });
   }
 
   onSubmit() {

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -1,7 +1,9 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, Input } from "@angular/core";
+import { FormGroup } from "@angular/forms";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { IRecommendationsTableFilters } from "src/app/recommendations/recommendations.interfaces";
+import { ControlBase } from "src/app/shared/form-controls/contol-base.model";
 import { RecordsService } from "../services/records.service";
 
 @Component({
@@ -11,6 +13,22 @@ import { RecordsService } from "../services/records.service";
 })
 export class RecordListTableFiltersComponent implements OnInit {
   filters: any;
+  @Input() meta: ControlBase[] = [
+    {
+      key: "country",
+      options: [
+        { key: "IN", value: "India" },
+        { key: "USA", value: "United States of America" },
+        { key: "UK", value: "United Kingdom" }
+      ],
+      order: 8,
+      controlType: "selectionList",
+      initialValue: []
+    }
+  ];
+  @Input() data: any = {};
+  form!: FormGroup;
+  payLoad = "";
   constructor(private recordsService: RecordsService, private store: Store) {}
   public tableFilters$: Observable<IRecommendationsTableFilters> =
     this.store.select(
@@ -28,10 +46,11 @@ export class RecordListTableFiltersComponent implements OnInit {
     this.recordsService.clearTableFilters();
   }
 
-  onShow() {
+  onSubmit() {
     alert("Show button clicked!");
   }
   ngOnInit(): void {
+    this.form = this.recordsService.toFormGroup(this.meta, this.data);
     this.tableFilters$.subscribe((val) => {
       this.filters = val;
     });

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-record-list-table-filters',
+  templateUrl: './record-list-table-filters.component.html',
+  styleUrls: ['./record-list-table-filters.component.scss']
+})
+export class RecordListTableFiltersComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -122,6 +122,7 @@
                 <!-- remaining cells -->
                 <ng-template #notAdminCell>
                   <!-- cell value | format date -->
+
                   <ng-container
                     *ngIf="dateColumns.includes(i.name); else noPipe"
                   >
@@ -173,7 +174,7 @@
 
       <!--  no results found -->
       <ng-template #noResults>
-        <div class="d-grid justify-content-center">
+        <div class="d-grid justify-content-center no-records">
           We could not find any results. Please clear your search criteria in
           order to reset results.
         </div>

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -8,7 +8,13 @@
   <!-- spinner -->
   <div
     *ngIf="data.loading; else notLoading"
-    class="d-flex align-content-center justify-content-center align-items-center progress-spinner"
+    class="
+      d-flex
+      align-content-center
+      justify-content-center
+      align-items-center
+      progress-spinner
+    "
   >
     <mat-spinner></mat-spinner>
   </div>
@@ -80,7 +86,11 @@
               </th>
 
               <!-- mat cell -->
-              <td mat-cell *matCellDef="let element">
+              <td
+                mat-cell
+                [ngClass]="(fixedColumns$ | async) && 'fixed'"
+                *matCellDef="let element"
+              >
                 <!-- checkbox -->
                 <mat-checkbox
                   *ngIf="

--- a/src/app/records/record-list/record-list.component.spec.ts
+++ b/src/app/records/record-list/record-list.component.spec.ts
@@ -20,6 +20,7 @@ import { MaterialModule } from "../../shared/material/material.module";
 import { DEFAULT_SORT, generateColumnData } from "../constants";
 import { RecordsService } from "../services/records.service";
 import { RecordListComponent } from "./record-list.component";
+import { RecordListState } from "./state/record-list.state";
 
 describe("RecordListComponent", () => {
   let store: Store;
@@ -37,7 +38,7 @@ describe("RecordListComponent", () => {
         HttpClientTestingModule,
         RouterTestingModule,
         AdminsModule,
-        NgxsModule.forRoot([RecommendationsState, AdminsState])
+        NgxsModule.forRoot([RecommendationsState, AdminsState, RecordListState])
       ]
     }).compileComponents();
     store = TestBed.inject(Store);
@@ -50,11 +51,61 @@ describe("RecordListComponent", () => {
     component = fixture.componentInstance;
     recordsService.stateName = "recommendations";
     recordsService.setRecommendationsActions();
+    store.reset({
+      recommendations: {
+        items: mockRecommendationsResponse.recommendationInfo,
+        totalResults: 2,
+        sort: { active: "submissionDate", direction: "asc" },
+        enableAllocateAdmin: false,
+        enableUpdateConnections: false,
+        disableSearchAndSort: false,
+        allChecked: false,
+        someChecked: false
+      },
+      recordList: { fixedColumns: true }
+    });
+    component.columnData = generateColumnData(COLUMN_DATA);
+    component.dateColumns = [
+      "curriculumEndDate,submissionDate,dateAdded,lastUpdatedDate"
+    ];
+
     fixture.detectChanges();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("Should display a table containing doctors summary data", () => {
+    expect(
+      fixture.debugElement.nativeElement.querySelector(".mat-table")
+    ).toBeTruthy();
+  });
+
+  it("Should display message when no records returned", () => {
+    store.reset({
+      recommendations: { totalResults: 0 }
+    });
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.nativeElement.querySelector(".no-records")
+    ).toBeTruthy();
+  });
+
+  it("Should apply fixed class to table columns when display in fixed width mode", () => {
+    expect(
+      fixture.debugElement.nativeElement.querySelector(".mat-cell.fixed")
+    ).toBeTruthy();
+  });
+
+  it("Should not apply fixed class to table columns when display in fluid width mode", () => {
+    store.reset({
+      recordList: { fixedColumns: false }
+    });
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.nativeElement.querySelector(".mat-cell.fixed")
+    ).toBeFalsy();
   });
 
   it("should select 'items$' from state", () => {

--- a/src/app/records/record-list/record-list.component.ts
+++ b/src/app/records/record-list/record-list.component.ts
@@ -55,6 +55,10 @@ export class RecordListComponent implements OnDestroy {
     (state) => state[this.recordsService.stateName].disableSearchAndSort
   );
 
+  public fixedColumns$: Observable<boolean> = this.store.select(
+    (state) => state.recordList.fixedColumns
+  );
+
   constructor(
     protected activatedRoute: ActivatedRoute,
     protected recordsService: RecordsService,
@@ -79,10 +83,10 @@ export class RecordListComponent implements OnDestroy {
     row: any,
     enableAllocateAdmin: boolean,
     enableUpdateConnections: boolean
-  ): Promise<boolean> {
+  ) {
     event.stopPropagation();
     if (!enableAllocateAdmin && !enableUpdateConnections) {
-      return this.router.navigate([this.detailsRoute, row.gmcReferenceNumber]);
+      this.router.navigate([this.detailsRoute, row.gmcReferenceNumber]);
     }
   }
 

--- a/src/app/records/record-list/state/record-list.actions.ts
+++ b/src/app/records/record-list/state/record-list.actions.ts
@@ -1,0 +1,4 @@
+export class ToggleFixedColumns {
+  static readonly type = "[RECORDS LIST] Toggle Column Widths";
+  constructor(public payload: boolean) {}
+}

--- a/src/app/records/record-list/state/record-list.state.ts
+++ b/src/app/records/record-list/state/record-list.state.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@angular/core";
+import { Action, Selector, State, StateContext } from "@ngxs/store";
+import { ToggleFixedColumns } from "./record-list.actions";
+export class RecordListStateModel {
+  fixedColumns: boolean;
+}
+
+@State<RecordListStateModel>({
+  name: "recordList",
+  defaults: {
+    fixedColumns: true
+  }
+})
+@Injectable()
+export class RecordListState {
+  constructor() {}
+
+  @Selector()
+  static isFixedColumns(state: RecordListStateModel) {
+    return state.fixedColumns;
+  }
+
+  @Action(ToggleFixedColumns)
+  toggleFixedColumns(
+    { getState, patchState }: StateContext<RecordListStateModel>,
+    { payload }: ToggleFixedColumns
+  ) {
+    patchState({
+      fixedColumns: payload
+    });
+  }
+}

--- a/src/app/records/record-list/state/record-list.state.ts
+++ b/src/app/records/record-list/state/record-list.state.ts
@@ -13,8 +13,6 @@ export class RecordListStateModel {
 })
 @Injectable()
 export class RecordListState {
-  constructor() {}
-
   @Selector()
   static isFixedColumns(state: RecordListStateModel) {
     return state.fixedColumns;

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -1,6 +1,7 @@
 <div class="d-grid record-search">
   <div class="d-flex pl-25 pr-20 align-items-center">
     <button
+      data-cy="toggleFixedColumnsButton"
       color="primary"
       matTooltipPosition="below"
       matTooltipShowDelay="500"
@@ -28,6 +29,7 @@
     </button>
 
     <button
+      data-cy="toggleTableFiltersButton"
       *ngIf="showTableFilters"
       color="primary"
       [matTooltip]="

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -2,13 +2,17 @@
   <div class="d-flex pl-25 pr-20 align-items-center">
     <button
       color="primary"
-      matTooltip="Open filter panel"
+      [matTooltip]="
+        filterPanelOpen ? 'Close filter panel' : 'Open filter panel'
+      "
       matTooltipPosition="below"
       matTooltipShowDelay="500"
       mat-icon-button
-      aria-label="Enable allocate admin"
+      aria-label="Toggle table filter panel"
+      (click)="toggleTableFilterPanel()"
     >
-      <mat-icon>filter_alt</mat-icon>
+      <mat-icon *ngIf="!filterPanelOpen">filter_alt</mat-icon>
+      <mat-icon *ngIf="filterPanelOpen">filter_alt_off</mat-icon>
     </button>
     <app-reset-record-list></app-reset-record-list>
     <app-allocate-admin-btn

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -28,7 +28,7 @@
     </button>
 
     <button
-      *ngIf="!isConnectionsSummary"
+      *ngIf="showTableFilters"
       color="primary"
       [matTooltip]="
         filterPanelOpen ? 'Close filter panel' : 'Open filter panel'

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -1,6 +1,32 @@
 <div class="d-grid record-search">
   <div class="d-flex pl-25 pr-20 align-items-center">
     <button
+      color="primary"
+      matTooltipPosition="below"
+      matTooltipShowDelay="500"
+      mat-icon-button
+      [matTooltip]="fixedColumns ? 'Unlock column width' : 'Lock column width'"
+      aria-label="Toggle table column width setting"
+      (click)="toggleFixedColumns()"
+    >
+      <ng-container *ngIf="fixedColumns">
+        <mat-icon class="material-icons-outlined layered-icon base-icon"
+          >table_chart</mat-icon
+        >
+        <mat-icon class="layered-icon overlay-bg-icon">circle</mat-icon>
+        <mat-icon class="layered-icon overlay-icon">lock_open</mat-icon>
+      </ng-container>
+
+      <ng-container *ngIf="!fixedColumns">
+        <mat-icon class="material-icons-outlined layered-icon base-icon"
+          >table_chart</mat-icon
+        >
+        <mat-icon class="layered-icon overlay-bg-icon">circle</mat-icon>
+        <mat-icon class="layered-icon overlay-icon">lock</mat-icon>
+      </ng-container>
+    </button>
+
+    <button
       *ngIf="!isConnectionsSummary"
       color="primary"
       [matTooltip]="

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -1,6 +1,7 @@
 <div class="d-grid record-search">
   <div class="d-flex pl-25 pr-20 align-items-center">
     <button
+      *ngIf="!isConnectionsSummary"
       color="primary"
       [matTooltip]="
         filterPanelOpen ? 'Close filter panel' : 'Open filter panel'

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -1,21 +1,22 @@
 <div class="d-grid record-search">
-  <div class="d-grid align-items-center">
+  <div class="d-flex pl-25 pr-20 align-items-center">
     <button
+      color="primary"
+      matTooltip="Open filter panel"
+      matTooltipPosition="below"
+      matTooltipShowDelay="500"
       mat-icon-button
-      [matMenuTriggerFor]="menu"
-      aria-label="Menu for clear all and allocate admin "
+      aria-label="Enable allocate admin"
     >
-      <mat-icon>more_vert</mat-icon>
+      <mat-icon>filter_alt</mat-icon>
     </button>
-    <mat-menu #menu="matMenu">
-      <app-reset-record-list></app-reset-record-list>
-      <app-allocate-admin-btn
-        *ngIf="isRevalAdmin && !isConnectionsSummary"
-      ></app-allocate-admin-btn>
-      <app-update-connetions-btn
-        *ngIf="isRevalAdmin && isConnectionsSummary"
-      ></app-update-connetions-btn>
-    </mat-menu>
+    <app-reset-record-list></app-reset-record-list>
+    <app-allocate-admin-btn
+      *ngIf="isRevalAdmin && !isConnectionsSummary"
+    ></app-allocate-admin-btn>
+    <app-update-connetions-btn
+      *ngIf="isRevalAdmin && isConnectionsSummary"
+    ></app-update-connetions-btn>
   </div>
 
   <form

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -28,7 +28,7 @@
     </button>
 
     <button
-      *ngIf="isConnectionsSummary"
+      *ngIf="!isConnectionsSummary"
       color="primary"
       [matTooltip]="
         filterPanelOpen ? 'Close filter panel' : 'Open filter panel'
@@ -42,49 +42,54 @@
       <mat-icon *ngIf="!filterPanelOpen">filter_alt</mat-icon>
       <mat-icon *ngIf="filterPanelOpen">filter_alt_off</mat-icon>
     </button>
-    <app-reset-record-list></app-reset-record-list>
+
     <app-allocate-admin-btn
       *ngIf="isRevalAdmin && !isConnectionsSummary"
     ></app-allocate-admin-btn>
     <app-update-connetions-btn
       *ngIf="isRevalAdmin && isConnectionsSummary"
     ></app-update-connetions-btn>
-  </div>
 
-  <form
-    (ngSubmit)="checkForm()"
-    [formGroup]="form"
-    #ngForm="ngForm"
-    autocomplete="off"
-    *ngIf="{
-      enableAllocateAdmin: enableAllocateAdmin$ | async,
-      enableUpdateConnections: enableUpdateConnections$ | async,
-      disableSearchAndSort: disableSearchAndSort$ | async
-    } as data"
-  >
-    <mat-form-field style="width: 360px">
-      <mat-label>{{ searchLabel }}</mat-label>
-      <input
-        matInput
-        type="text"
-        [formControlName]="'searchQuery'"
-        [value]="searchQuery$ | async"
-      />
-      <button
-        mat-button
-        matSuffix
-        color="primary"
-        aria-label="Recommendations search"
-        type="submit"
-        [disabled]="
-          data.enableAllocateAdmin ||
-          data.enableUpdateConnections ||
-          data.disableSearchAndSort
-        "
-      >
-        <mat-icon aria-label="search icon">search</mat-icon>
-      </button>
-      <mat-error *ngIf="form.invalid">No search terms entered</mat-error>
-    </mat-form-field>
-  </form>
+    <form
+      (ngSubmit)="checkForm()"
+      [formGroup]="form"
+      #ngForm="ngForm"
+      autocomplete="off"
+      *ngIf="{
+        enableAllocateAdmin: enableAllocateAdmin$ | async,
+        enableUpdateConnections: enableUpdateConnections$ | async,
+        disableSearchAndSort: disableSearchAndSort$ | async
+      } as data"
+    >
+      <mat-form-field appearance="outline" class="ml-20" style="width: 360px">
+        <mat-label>{{ searchLabel }}</mat-label>
+        <input
+          matInput
+          type="text"
+          [formControlName]="'searchQuery'"
+          [value]="searchQuery$ | async"
+        />
+        <app-reset-record-list
+          *ngIf="showClearSearchForm"
+          matSuffix
+        ></app-reset-record-list>
+        <button
+          mat-icon-button
+          matSuffix
+          color="primary"
+          aria-label="Recommendations search"
+          type="submit"
+          [disabled]="
+            data.enableAllocateAdmin ||
+            data.enableUpdateConnections ||
+            data.disableSearchAndSort
+          "
+        >
+          <mat-icon aria-label="search icon">search</mat-icon>
+        </button>
+
+        <mat-error *ngIf="form.invalid">No search terms entered</mat-error>
+      </mat-form-field>
+    </form>
+  </div>
 </div>

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -5,29 +5,30 @@
       matTooltipPosition="below"
       matTooltipShowDelay="500"
       mat-icon-button
-      [matTooltip]="fixedColumns ? 'Unlock column width' : 'Lock column width'"
+      [matTooltip]="fixedColumns ? 'Fit columns to screen' : 'Expand columns'"
       aria-label="Toggle table column width setting"
       (click)="toggleFixedColumns()"
     >
       <ng-container *ngIf="fixedColumns">
         <mat-icon class="material-icons-outlined layered-icon base-icon"
-          >table_chart</mat-icon
+          >width_normal</mat-icon
         >
+
         <mat-icon class="layered-icon overlay-bg-icon">circle</mat-icon>
-        <mat-icon class="layered-icon overlay-icon">lock_open</mat-icon>
+        <mat-icon class="layered-icon overlay-icon">close_fullscreen </mat-icon>
       </ng-container>
 
       <ng-container *ngIf="!fixedColumns">
         <mat-icon class="material-icons-outlined layered-icon base-icon"
-          >table_chart</mat-icon
+          >width_wide</mat-icon
         >
         <mat-icon class="layered-icon overlay-bg-icon">circle</mat-icon>
-        <mat-icon class="layered-icon overlay-icon">lock</mat-icon>
+        <mat-icon class="layered-icon overlay-icon">open_in_full</mat-icon>
       </ng-container>
     </button>
 
     <button
-      *ngIf="!isConnectionsSummary"
+      *ngIf="isConnectionsSummary"
       color="primary"
       [matTooltip]="
         filterPanelOpen ? 'Close filter panel' : 'Open filter panel'

--- a/src/app/records/record-search/record-search.component.scss
+++ b/src/app/records/record-search/record-search.component.scss
@@ -13,16 +13,16 @@
     transform: translate(-50%, -50%);
   }
   &.overlay-bg-icon {
-    bottom: 0;
+    bottom: 2px;
     right: 0;
     transform: none;
     font-size: 20px;
     color: #005eb8;
   }
   &.overlay-icon {
-    bottom: 0;
+    bottom: 2px;
     right: 0;
-    transform: none;
+    transform: rotate(45deg);
     font-size: 11px;
     color: #fff;
   }

--- a/src/app/records/record-search/record-search.component.scss
+++ b/src/app/records/record-search/record-search.component.scss
@@ -3,6 +3,12 @@
   ::ng-deep .mat-form-field-infix {
     width: auto;
   }
+  ::ng-deep .mat-form-field-wrapper {
+    padding: 10px 0 !important;
+  }
+  ::ng-deep .mat-form-field {
+    font-size: 14px;
+  }
 }
 
 .layered-icon {

--- a/src/app/records/record-search/record-search.component.scss
+++ b/src/app/records/record-search/record-search.component.scss
@@ -4,3 +4,26 @@
     width: auto;
   }
 }
+
+.layered-icon {
+  position: absolute;
+  &.base-icon {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+  &.overlay-bg-icon {
+    bottom: 0;
+    right: 0;
+    transform: none;
+    font-size: 20px;
+    color: #005eb8;
+  }
+  &.overlay-icon {
+    bottom: 0;
+    right: 0;
+    transform: none;
+    font-size: 11px;
+    color: #fff;
+  }
+}

--- a/src/app/records/record-search/record-search.component.spec.ts
+++ b/src/app/records/record-search/record-search.component.spec.ts
@@ -88,10 +88,10 @@ describe("RecordSearchComponent", () => {
     expect(component.form.value.searchQuery).toBeNull();
   });
 
-  it("form should be invalid if no characters entered", () => {
-    component.setupForm();
-    expect(component.form.invalid).toBeTruthy();
-  });
+  // it("form should be invalid if no characters entered", () => {
+  //   component.setupForm();
+  //   expect(component.form.invalid).toBeTruthy();
+  // });
 
   it("should invoke resetForm() upon receiving `resetSearchForm$` event", () => {
     spyOn(component.ngForm, "resetForm");

--- a/src/app/records/record-search/record-search.component.spec.ts
+++ b/src/app/records/record-search/record-search.component.spec.ts
@@ -88,11 +88,6 @@ describe("RecordSearchComponent", () => {
     expect(component.form.value.searchQuery).toBeNull();
   });
 
-  // it("form should be invalid if no characters entered", () => {
-  //   component.setupForm();
-  //   expect(component.form.invalid).toBeTruthy();
-  // });
-
   it("should invoke resetForm() upon receiving `resetSearchForm$` event", () => {
     spyOn(component.ngForm, "resetForm");
 

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -82,6 +82,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.searchQuery$.subscribe((searchQuery) => {
         this.searchQuery = searchQuery;
+        searchQuery && this.form.get("searchQuery").setValue(searchQuery);
         this.toggleResetFormButton();
       })
     );
@@ -89,17 +90,20 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public toggleFixedColumns() {
     this.store.dispatch(new ToggleFixedColumns(!this.fixedColumns));
   }
+
   public setupForm(): void {
     this.form = this.formBuilder.group(
       {
-        searchQuery: [null]
+        searchQuery: this.searchQuery || null
       },
       { updateOn: "change" }
     );
 
-    this.form.get("searchQuery").valueChanges.subscribe((val) => {
-      this.toggleResetFormButton(val);
-    });
+    this.subscriptions.add(
+      this.form.get("searchQuery").valueChanges.subscribe((val) => {
+        this.toggleResetFormButton(val);
+      })
+    );
   }
 
   toggleResetFormButton(inputValue: string = "") {

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -41,6 +41,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public isConnectionsSummary: boolean;
   public form: FormGroup;
   public subscriptions: Subscription = new Subscription();
+  showTableFilters: boolean;
   filterPanelOpen: boolean = false;
   showClearSearchForm: boolean = false;
   fixedColumns: boolean;
@@ -62,7 +63,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
     this.setupForm();
     this.listenToClearAllEvent();
     this.listenToAllocateAdminsEvent();
-
+    this.showTableFilters = this.recordsService.showTableFilters;
     this.subscriptions.add(
       this.recordsService.toggleTableFilterPanel$.subscribe(
         (isOpen: boolean) => {

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -36,11 +36,13 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   );
 
   public searchLabel: string;
+  public searchQuery: string;
   public isRevalAdmin: boolean;
   public isConnectionsSummary: boolean;
   public form: FormGroup;
   public subscriptions: Subscription = new Subscription();
   filterPanelOpen: boolean = false;
+  showClearSearchForm: boolean = false;
   fixedColumns: boolean;
   @ViewChild("ngForm") public ngForm;
 
@@ -74,6 +76,13 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
         this.fixedColumns = isFixedColumns;
       })
     );
+
+    this.subscriptions.add(
+      this.searchQuery$.subscribe((searchQuery) => {
+        this.searchQuery = searchQuery;
+        this.toggleResetFormButton();
+      })
+    );
   }
   public toggleFixedColumns() {
     this.store.dispatch(new ToggleFixedColumns(!this.fixedColumns));
@@ -81,10 +90,22 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public setupForm(): void {
     this.form = this.formBuilder.group(
       {
-        searchQuery: [null, [Validators.required]]
+        searchQuery: [null]
       },
-      { updateOn: "submit" }
+      { updateOn: "change" }
     );
+
+    this.form.get("searchQuery").valueChanges.subscribe((val) => {
+      this.toggleResetFormButton(val);
+    });
+  }
+
+  toggleResetFormButton(inputValue: string = "") {
+    if (inputValue || this.searchQuery) {
+      this.showClearSearchForm = true;
+    } else {
+      this.showClearSearchForm = false;
+    }
   }
 
   /**
@@ -99,7 +120,9 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
     this.subscriptions.add(
       this.recordsService.resetSearchForm$
         .pipe(filter(Boolean))
-        .subscribe(() => this.ngForm.resetForm())
+        .subscribe(() => {
+          this.ngForm?.resetForm();
+        })
     );
   }
 

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -36,6 +36,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public isConnectionsSummary: boolean;
   public form: FormGroup;
   public subscriptions: Subscription = new Subscription();
+  filterPanelOpen: boolean = false;
   @ViewChild("ngForm") public ngForm;
 
   constructor(
@@ -54,6 +55,13 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
     this.setupForm();
     this.listenToClearAllEvent();
     this.listenToAllocateAdminsEvent();
+    this.subscriptions.add(
+      this.recordsService.toggleTableFilterPanel$.subscribe(
+        (isOpen: boolean) => {
+          this.filterPanelOpen = isOpen;
+        }
+      )
+    );
   }
 
   public setupForm(): void {
@@ -138,6 +146,10 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
       .resetPaginator()
       .pipe(take(1))
       .subscribe(() => this.recordsService.updateRoute());
+  }
+
+  toggleTableFilterPanel() {
+    this.recordsService.toggleTableFilterPanel$.next(!this.filterPanelOpen);
   }
 
   ngOnDestroy() {

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -57,7 +57,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
     this.isConnectionsSummary =
       this.recordsService.stateName === stateName.CONNECTIONS;
     this.isRevalAdmin = this.authService.isRevalAdmin;
-    this.searchLabel = "Search name, programme or GMC no";
+    this.searchLabel = "Search name or GMC no";
   }
 
   ngOnInit() {

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -3,10 +3,10 @@ import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { Store } from "@ngxs/store";
 import { Observable, Subscription } from "rxjs";
 import { filter, take } from "rxjs/operators";
-import { ConnectionsFilterType } from "src/app/connections/connections.interfaces";
 import { AuthService } from "src/app/core/auth/auth.service";
 import { UpdateConnectionsService } from "src/app/update-connections/services/update-connections.service";
 import { ToggleFixedColumns } from "../record-list/state/record-list.actions";
+import { stateName } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
 
 @Component({
@@ -54,7 +54,8 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
     private updateConnectionsService: UpdateConnectionsService,
     private authService: AuthService
   ) {
-    this.isConnectionsSummary = this.recordsService.stateName === "connections";
+    this.isConnectionsSummary =
+      this.recordsService.stateName === stateName.CONNECTIONS;
     this.isRevalAdmin = this.authService.isRevalAdmin;
     this.searchLabel = "Search name, programme or GMC no";
   }

--- a/src/app/records/record-search/record-search.component.ts
+++ b/src/app/records/record-search/record-search.component.ts
@@ -6,6 +6,7 @@ import { filter, take } from "rxjs/operators";
 import { ConnectionsFilterType } from "src/app/connections/connections.interfaces";
 import { AuthService } from "src/app/core/auth/auth.service";
 import { UpdateConnectionsService } from "src/app/update-connections/services/update-connections.service";
+import { ToggleFixedColumns } from "../record-list/state/record-list.actions";
 import { RecordsService } from "../services/records.service";
 
 @Component({
@@ -30,6 +31,9 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public filter$: Observable<any> = this.store.select(
     (state) => state[this.recordsService.stateName].filter
   );
+  public fixedColumns$: Observable<boolean> = this.store.select(
+    (state) => state.recordList.fixedColumns
+  );
 
   public searchLabel: string;
   public isRevalAdmin: boolean;
@@ -37,6 +41,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
   public form: FormGroup;
   public subscriptions: Subscription = new Subscription();
   filterPanelOpen: boolean = false;
+  fixedColumns: boolean;
   @ViewChild("ngForm") public ngForm;
 
   constructor(
@@ -55,6 +60,7 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
     this.setupForm();
     this.listenToClearAllEvent();
     this.listenToAllocateAdminsEvent();
+
     this.subscriptions.add(
       this.recordsService.toggleTableFilterPanel$.subscribe(
         (isOpen: boolean) => {
@@ -62,8 +68,16 @@ export class RecordSearchComponent implements OnInit, OnDestroy {
         }
       )
     );
-  }
 
+    this.subscriptions.add(
+      this.fixedColumns$.subscribe((isFixedColumns: boolean) => {
+        this.fixedColumns = isFixedColumns;
+      })
+    );
+  }
+  public toggleFixedColumns() {
+    this.store.dispatch(new ToggleFixedColumns(!this.fixedColumns));
+  }
   public setupForm(): void {
     this.form = this.formBuilder.group(
       {

--- a/src/app/records/records.component.html
+++ b/src/app/records/records.component.html
@@ -2,7 +2,13 @@
 
 <div
   *ngIf="loading; else notLoading"
-  class="d-flex align-content-center justify-content-center align-items-center progress-spinner"
+  class="
+    d-flex
+    align-content-center
+    justify-content-center
+    align-items-center
+    progress-spinner
+  "
 >
   <mat-spinner></mat-spinner>
 </div>
@@ -22,5 +28,13 @@
   <app-allocate-admin-actions
     *ngIf="enableAllocateAdmin$ | async"
   ></app-allocate-admin-actions>
-  <app-record-list></app-record-list>
+
+  <mat-drawer-container class="filters-drawer-container">
+    <mat-drawer #filtersDrawer mode="side" [opened]="filterPanelOpen">
+      <app-record-list-table-filters></app-record-list-table-filters>
+    </mat-drawer>
+    <mat-drawer-content>
+      <app-record-list></app-record-list>
+    </mat-drawer-content>
+  </mat-drawer-container>
 </ng-template>

--- a/src/app/records/records.component.html
+++ b/src/app/records/records.component.html
@@ -2,13 +2,7 @@
 
 <div
   *ngIf="loading; else notLoading"
-  class="
-    d-flex
-    align-content-center
-    justify-content-center
-    align-items-center
-    progress-spinner
-  "
+  class="d-flex align-content-center justify-content-center align-items-center progress-spinner"
 >
   <mat-spinner></mat-spinner>
 </div>
@@ -29,7 +23,10 @@
     *ngIf="enableAllocateAdmin$ | async"
   ></app-allocate-admin-actions>
 
-  <mat-drawer-container class="filters-drawer-container">
+  <mat-drawer-container
+    *ngIf="showTableFilters; else noTableFilters"
+    class="filters-drawer-container"
+  >
     <mat-drawer #filtersDrawer mode="side" [opened]="filterPanelOpen">
       <app-record-list-table-filters></app-record-list-table-filters>
     </mat-drawer>
@@ -37,4 +34,8 @@
       <app-record-list></app-record-list>
     </mat-drawer-content>
   </mat-drawer-container>
+
+  <ng-template #noTableFilters>
+    <app-record-list></app-record-list>
+  </ng-template>
 </ng-template>

--- a/src/app/records/records.component.scss
+++ b/src/app/records/records.component.scss
@@ -22,6 +22,11 @@ $toolbar-height: 64px;
     100vh - #{$main-navbar-height} - #{$child-navbar-height} - #{$toolbar-height}
   );
   background-color: #fafafa;
+  .mat-drawer-content {
+    min-height: calc(
+      100vh - #{$main-navbar-height} - #{$child-navbar-height} - #{$toolbar-height}
+    );
+  }
 }
 .mat-drawer {
   background-color: #fafafa;

--- a/src/app/records/records.component.scss
+++ b/src/app/records/records.component.scss
@@ -4,6 +4,7 @@
 .records-top-section {
   grid-template-columns: minmax(0, 1fr) auto auto;
   background: $color_nhsuk-white;
+  border-bottom: 1px solid #ddd;
 
   @media screen and (max-width: $xsmall) {
     :first-child {

--- a/src/app/records/records.component.scss
+++ b/src/app/records/records.component.scss
@@ -12,3 +12,18 @@
     }
   }
 }
+
+$main-navbar-height: 64px;
+$child-navbar-height: 48px;
+$toolbar-height: 64px;
+
+.filters-drawer-container {
+  min-height: calc(
+    100vh - #{$main-navbar-height} - #{$child-navbar-height} - #{$toolbar-height}
+  );
+  background-color: #fafafa;
+}
+.mat-drawer {
+  background-color: #fafafa;
+  width: 360px;
+}

--- a/src/app/records/records.component.spec.ts
+++ b/src/app/records/records.component.spec.ts
@@ -5,7 +5,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { RecordsComponent } from "./records.component";
 import { MaterialModule } from "../shared/material/material.module";
-
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 describe("RecordsComponent", () => {
   let component: RecordsComponent;
   let fixture: ComponentFixture<RecordsComponent>;
@@ -16,7 +16,8 @@ describe("RecordsComponent", () => {
         NgxsModule.forRoot(),
         HttpClientTestingModule,
         RouterTestingModule,
-        MaterialModule
+        MaterialModule,
+        BrowserAnimationsModule
       ],
       declarations: [RecordsComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/app/records/records.component.ts
+++ b/src/app/records/records.component.ts
@@ -1,6 +1,13 @@
-import { Component, EventEmitter, Input, Output } from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  OnDestroy
+} from "@angular/core";
 import { Store } from "@ngxs/store";
-import { Observable } from "rxjs";
+import { Observable, Subscription } from "rxjs";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { RecordsService } from "./services/records.service";
 
@@ -9,10 +16,11 @@ import { RecordsService } from "./services/records.service";
   templateUrl: "./records.component.html",
   styleUrls: ["./records.component.scss"]
 })
-export class RecordsComponent {
+export class RecordsComponent implements OnInit {
   @Output() updateConnections = new EventEmitter<any>();
   @Input() public loading: boolean;
-
+  filterPanelOpen: boolean;
+  public subscriptions: Subscription = new Subscription();
   public enableUpdateConnections$: Observable<boolean> = this.store.select(
     (state) =>
       state[this.updateConnectionsService.stateName].enableUpdateConnections
@@ -27,8 +35,21 @@ export class RecordsComponent {
     private recordsService: RecordsService,
     private updateConnectionsService: UpdateConnectionsService
   ) {}
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.recordsService.toggleTableFilterPanel$.subscribe(
+        (isOpen: boolean) => {
+          this.filterPanelOpen = isOpen;
+        }
+      )
+    );
+  }
 
   onSubmitConnections(formValues: any) {
     this.updateConnections.emit(formValues);
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/records/records.component.ts
+++ b/src/app/records/records.component.ts
@@ -16,7 +16,7 @@ import { RecordsService } from "./services/records.service";
   templateUrl: "./records.component.html",
   styleUrls: ["./records.component.scss"]
 })
-export class RecordsComponent implements OnInit {
+export class RecordsComponent implements OnInit, OnDestroy {
   @Output() updateConnections = new EventEmitter<any>();
   @Input() public loading: boolean;
   showTableFilters: boolean;

--- a/src/app/records/records.component.ts
+++ b/src/app/records/records.component.ts
@@ -19,6 +19,7 @@ import { RecordsService } from "./services/records.service";
 export class RecordsComponent implements OnInit {
   @Output() updateConnections = new EventEmitter<any>();
   @Input() public loading: boolean;
+  showTableFilters: boolean;
   filterPanelOpen: boolean;
   public subscriptions: Subscription = new Subscription();
   public enableUpdateConnections$: Observable<boolean> = this.store.select(
@@ -36,6 +37,7 @@ export class RecordsComponent implements OnInit {
     private updateConnectionsService: UpdateConnectionsService
   ) {}
   ngOnInit(): void {
+    this.showTableFilters = this.recordsService.showTableFilters;
     this.subscriptions.add(
       this.recordsService.toggleTableFilterPanel$.subscribe(
         (isOpen: boolean) => {

--- a/src/app/records/records.interfaces.ts
+++ b/src/app/records/records.interfaces.ts
@@ -18,3 +18,8 @@ export interface IFilter {
   label: string;
   name: string;
 }
+
+export enum stateName {
+  RECOMMENDATIONS = "recommendations",
+  CONNECTIONS = "connections"
+}

--- a/src/app/records/records.interfaces.ts
+++ b/src/app/records/records.interfaces.ts
@@ -20,7 +20,7 @@ export interface IFilter {
 }
 
 export interface ITableFilters {
-  [key: string]: string;
+  [key: string]: string | string[];
 }
 
 export enum stateName {

--- a/src/app/records/records.interfaces.ts
+++ b/src/app/records/records.interfaces.ts
@@ -19,6 +19,10 @@ export interface IFilter {
   name: string;
 }
 
+export interface ITableFilters {
+  [key: string]: string;
+}
+
 export enum stateName {
   RECOMMENDATIONS = "recommendations",
   CONNECTIONS = "connections"

--- a/src/app/records/records.module.ts
+++ b/src/app/records/records.module.ts
@@ -14,7 +14,8 @@ import { RefreshDataBtnComponent } from "./refresh-data-btn/refresh-data-btn.com
 import { ResetRecordListComponent } from "./reset-record-list/reset-record-list.component";
 import { RecordsService } from "./services/records.service";
 import { RecordListTableFiltersComponent } from "./record-list-table-filters/record-list-table-filters.component";
-
+import { RecordListState } from "./record-list/state/record-list.state";
+import { NgxsModule } from "@ngxs/store";
 const components: any[] = [
   RecordListComponent,
   RecordListFiltersComponent,
@@ -35,7 +36,8 @@ const components: any[] = [
     AdminsModule,
     SharedModule,
     ReactiveFormsModule,
-    UpdateConnectionsModule
+    UpdateConnectionsModule,
+    NgxsModule.forFeature([RecordListState])
   ],
   exports: components
 })

--- a/src/app/records/records.module.ts
+++ b/src/app/records/records.module.ts
@@ -13,6 +13,7 @@ import { RecordsComponent } from "./records.component";
 import { RefreshDataBtnComponent } from "./refresh-data-btn/refresh-data-btn.component";
 import { ResetRecordListComponent } from "./reset-record-list/reset-record-list.component";
 import { RecordsService } from "./services/records.service";
+import { RecordListTableFiltersComponent } from "./record-list-table-filters/record-list-table-filters.component";
 
 const components: any[] = [
   RecordListComponent,
@@ -21,7 +22,8 @@ const components: any[] = [
   RecordsComponent,
   RecordSearchComponent,
   RefreshDataBtnComponent,
-  ResetRecordListComponent
+  ResetRecordListComponent,
+  RecordListTableFiltersComponent
 ];
 
 @NgModule({

--- a/src/app/records/reset-record-list/reset-record-list.component.html
+++ b/src/app/records/reset-record-list/reset-record-list.component.html
@@ -1,12 +1,16 @@
 <button
+  color="primary"
+  matTooltip="Clear all"
+  matTooltipPosition="below"
+  matTooltipShowDelay="500"
+  mat-icon-button
   *ngIf="{
     enableAllocateAdmin: enableAllocateAdmin$ | async,
     enableUpdateConnections: enableUpdateConnections$ | async
   } as data"
-  mat-menu-item
   (click)="resetRecordList()"
   aria-label="Clear all"
   [disabled]="data.nableAllocateAdmin || data.enableUpdateConnections"
 >
-  Clear all
+  <mat-icon>restart_alt</mat-icon>
 </button>

--- a/src/app/records/reset-record-list/reset-record-list.component.html
+++ b/src/app/records/reset-record-list/reset-record-list.component.html
@@ -1,6 +1,7 @@
 <button
+  type="button"
   color="primary"
-  matTooltip="Clear all"
+  matTooltip="Clear search and results"
   matTooltipPosition="below"
   matTooltipShowDelay="500"
   mat-icon-button
@@ -9,8 +10,10 @@
     enableUpdateConnections: enableUpdateConnections$ | async
   } as data"
   (click)="resetRecordList()"
-  aria-label="Clear all"
+  aria-label="Clear search and results"
   [disabled]="data.nableAllocateAdmin || data.enableUpdateConnections"
 >
-  <mat-icon>restart_alt</mat-icon>
+  <mat-icon class="material-icons-outlined layered-icon base-icon"
+    >close</mat-icon
+  >
 </button>

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -296,11 +296,13 @@ export class RecordsService {
     return this.store.dispatch(new this.toggleAllCheckboxesAction());
   }
 
-  public toFormGroup(controls: FormControlBase[], data: any = {}) {
+  public toFormGroup(controls: FormControlBase[], formData: any = {}) {
     const group: any = {};
 
     controls.forEach((control) => {
-      group[control.key] = new FormControl(data[control.key] || "");
+      group[control.key] = new FormControl(
+        formData[control.key] || control.initialValue || ""
+      );
     });
     return new FormGroup(group);
   }

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -44,7 +44,9 @@ import {
   ResetRecommendationsSort,
   SortRecommendations,
   ToggleAllRecommendationsCheckboxes,
-  ToggleRecommendationsCheckbox
+  ToggleRecommendationsCheckbox,
+  SetRecommendationsTableFilters,
+  ClearRecommendationsTableFilters
 } from "../../recommendations/state/recommendations.actions";
 import { IFilter, IRecordDataCell } from "../records.interfaces";
 
@@ -75,6 +77,8 @@ export class RecordsService {
   public enableAllocateAdminAction: any;
   public toggleCheckboxAction: any;
   public toggleAllCheckboxesAction: any;
+  public setRecommendationsTableFilters: any;
+  public clearRecommendationsTableFilters: any;
 
   constructor(
     private http: HttpClient,
@@ -95,6 +99,8 @@ export class RecordsService {
     this.enableAllocateAdminAction = EnableRecommendationsAllocateAdmin;
     this.toggleCheckboxAction = ToggleRecommendationsCheckbox;
     this.toggleAllCheckboxesAction = ToggleAllRecommendationsCheckboxes;
+    this.setRecommendationsTableFilters = SetRecommendationsTableFilters;
+    this.clearRecommendationsTableFilters = ClearRecommendationsTableFilters;
   }
 
   public setConcernsActions(): void {
@@ -200,6 +206,18 @@ export class RecordsService {
   public clearSearch(): Observable<any> {
     this.handleUndefinedAction("clearSearchAction");
     return this.store.dispatch(new this.clearSearchAction());
+  }
+
+  public setTableFilters(filters: any): Observable<any> {
+    this.handleUndefinedAction("setTableFilters");
+    return this.store.dispatch(
+      new this.setRecommendationsTableFilters(filters)
+    );
+  }
+
+  public clearTableFilters(): Observable<any> {
+    this.handleUndefinedAction("clearTableFilters");
+    return this.store.dispatch(new this.clearRecommendationsTableFilters());
   }
 
   public filter(filter: string): Observable<any> {

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -5,7 +5,10 @@ import { Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { BehaviorSubject, forkJoin, Observable } from "rxjs";
 import { switchMap, take } from "rxjs/operators";
-import { ControlBase } from "src/app/shared/form-controls/contol-base.model";
+import {
+  ControlBase,
+  MaterialAutocompleteControl
+} from "src/app/shared/form-controls/contol-base.model";
 import {
   ClearConcernsSearch,
   ConcernsSearch,
@@ -65,7 +68,8 @@ export class RecordsService {
   public columnData: IRecordDataCell[];
   public detailsRoute: string;
   public filters: IFilter[];
-  public tableFiltersForm: ControlBase[];
+  public showTableFilters: boolean = false;
+  public tableFiltersFormData: (ControlBase | MaterialAutocompleteControl)[];
 
   // TODO type these
   public clearSearchAction: any;
@@ -80,8 +84,8 @@ export class RecordsService {
   public enableAllocateAdminAction: any;
   public toggleCheckboxAction: any;
   public toggleAllCheckboxesAction: any;
-  public setRecommendationsTableFilters: any;
-  public clearRecommendationsTableFilters: any;
+  public setTableFiltersAction: any;
+  public clearTableFiltersAction: any;
 
   constructor(
     private http: HttpClient,
@@ -102,8 +106,8 @@ export class RecordsService {
     this.enableAllocateAdminAction = EnableRecommendationsAllocateAdmin;
     this.toggleCheckboxAction = ToggleRecommendationsCheckbox;
     this.toggleAllCheckboxesAction = ToggleAllRecommendationsCheckboxes;
-    this.setRecommendationsTableFilters = SetRecommendationsTableFilters;
-    this.clearRecommendationsTableFilters = ClearRecommendationsTableFilters;
+    this.setTableFiltersAction = SetRecommendationsTableFilters;
+    this.clearTableFiltersAction = ClearRecommendationsTableFilters;
   }
 
   public setConcernsActions(): void {
@@ -162,15 +166,6 @@ export class RecordsService {
    * which effectively means the components do not get reinstantiated
    * which is great for performance.
    */
-
-  private convertToQueryString(obj: {}): string {
-    if (obj) {
-      return Object.keys(obj)
-        .map((key) => key + "=" + obj[key])
-        .join("&");
-    }
-    return "";
-  }
 
   private buildQueryParams() {
     const snapshot: any = this.store.snapshot()[this.stateName];
@@ -240,14 +235,12 @@ export class RecordsService {
 
   public setTableFilters(filters: any): Observable<any> {
     this.handleUndefinedAction("setTableFilters");
-    return this.store.dispatch(
-      new this.setRecommendationsTableFilters(filters)
-    );
+    return this.store.dispatch(new this.setTableFiltersAction(filters));
   }
 
   public clearTableFilters(): Observable<any> {
     this.handleUndefinedAction("clearTableFilters");
-    return this.store.dispatch(new this.clearRecommendationsTableFilters());
+    return this.store.dispatch(new this.clearTableFiltersAction());
   }
 
   public filter(filter: string): Observable<any> {

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -53,6 +53,9 @@ import { IFilter, IRecordDataCell } from "../records.interfaces";
 })
 export class RecordsService {
   public resetSearchForm$: BehaviorSubject<boolean> = new BehaviorSubject(null);
+  public toggleTableFilterPanel$: BehaviorSubject<boolean> =
+    new BehaviorSubject(false);
+
   public stateName: string;
   public dateColumns: string[];
   public columnData: IRecordDataCell[];

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -1,9 +1,11 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
+import { FormControl, FormGroup } from "@angular/forms";
 import { Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { BehaviorSubject, forkJoin, Observable } from "rxjs";
 import { switchMap, take } from "rxjs/operators";
+import { ControlBase } from "src/app/shared/form-controls/contol-base.model";
 import {
   ClearConcernsSearch,
   ConcernsSearch,
@@ -271,5 +273,16 @@ export class RecordsService {
     this.handleUndefinedAction("toggleAllCheckboxesAction");
 
     return this.store.dispatch(new this.toggleAllCheckboxesAction());
+  }
+
+  public toFormGroup(controls: ControlBase[], data: any) {
+    const group: any = {};
+
+    controls.forEach((control) => {
+      if (control.controlType !== "label") {
+        group[control.key] = new FormControl(data[control.key] || "");
+      }
+    });
+    return new FormGroup(group);
   }
 }

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -5,6 +5,7 @@ import { Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { BehaviorSubject, forkJoin, Observable } from "rxjs";
 import { switchMap, take } from "rxjs/operators";
+import { IRecommendationsTableFilters } from "src/app/recommendations/recommendations.interfaces";
 import {
   FormControlBase,
   AutocompleteControl
@@ -53,7 +54,7 @@ import {
   SetRecommendationsTableFilters,
   ClearRecommendationsTableFilters
 } from "../../recommendations/state/recommendations.actions";
-import { IFilter, IRecordDataCell } from "../records.interfaces";
+import { IFilter, IRecordDataCell, ITableFilters } from "../records.interfaces";
 
 @Injectable({
   providedIn: "root"
@@ -167,7 +168,7 @@ export class RecordsService {
    * which is great for performance.
    */
 
-  private buildQueryParams() {
+  private buildQueryParamsForRoute() {
     const snapshot: any = this.store.snapshot()[this.stateName];
     const params = {
       active: snapshot.sort.active,
@@ -190,11 +191,10 @@ export class RecordsService {
   }
 
   public updateRoute(): Promise<boolean> {
-    const snapshot: any = this.store.snapshot()[this.stateName];
     const current = this.router.url.split("?")[0];
 
     return this.router.navigate([current], {
-      queryParams: this.buildQueryParams()
+      queryParams: this.buildQueryParamsForRoute()
     });
   }
 
@@ -233,7 +233,7 @@ export class RecordsService {
     return this.store.dispatch(new this.clearSearchAction());
   }
 
-  public setTableFilters(filters: any): Observable<any> {
+  public setTableFilters(filters: ITableFilters): Observable<any> {
     this.handleUndefinedAction("setTableFilters");
     return this.store.dispatch(new this.setTableFiltersAction(filters));
   }

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -5,7 +5,7 @@ import { Router } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { BehaviorSubject, forkJoin, Observable } from "rxjs";
 import { switchMap, take } from "rxjs/operators";
-import { IRecommendationsTableFilters } from "src/app/recommendations/recommendations.interfaces";
+
 import {
   FormControlBase,
   AutocompleteControl
@@ -69,7 +69,7 @@ export class RecordsService {
   public columnData: IRecordDataCell[];
   public detailsRoute: string;
   public filters: IFilter[];
-  public showTableFilters: boolean = false;
+  public showTableFilters: boolean;
   public tableFiltersFormData: (FormControlBase | AutocompleteControl)[];
 
   // TODO type these

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -182,14 +182,15 @@ export class RecordsService {
       ...(snapshot.searchQuery && { searchQuery: snapshot.searchQuery })
     };
     const tableFilters = snapshot.tableFilters;
-
-    Object.keys(tableFilters).forEach((key) => {
-      if (Array.isArray(tableFilters[key])) {
-        params[key] = tableFilters[key].join(",");
-      } else {
-        params[key] = tableFilters[key];
-      }
-    });
+    if (tableFilters) {
+      Object.keys(tableFilters).forEach((key) => {
+        if (Array.isArray(tableFilters[key])) {
+          params[key] = tableFilters[key].join(",");
+        } else {
+          params[key] = tableFilters[key];
+        }
+      });
+    }
     return params;
   }
 

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -6,9 +6,9 @@ import { Store } from "@ngxs/store";
 import { BehaviorSubject, forkJoin, Observable } from "rxjs";
 import { switchMap, take } from "rxjs/operators";
 import {
-  ControlBase,
-  MaterialAutocompleteControl
-} from "src/app/shared/form-controls/contol-base.model";
+  FormControlBase,
+  AutocompleteControl
+} from "src/app/shared/form-controls/form-contol-base.model";
 import {
   ClearConcernsSearch,
   ConcernsSearch,
@@ -69,7 +69,7 @@ export class RecordsService {
   public detailsRoute: string;
   public filters: IFilter[];
   public showTableFilters: boolean = false;
-  public tableFiltersFormData: (ControlBase | MaterialAutocompleteControl)[];
+  public tableFiltersFormData: (FormControlBase | AutocompleteControl)[];
 
   // TODO type these
   public clearSearchAction: any;
@@ -296,13 +296,11 @@ export class RecordsService {
     return this.store.dispatch(new this.toggleAllCheckboxesAction());
   }
 
-  public toFormGroup(controls: ControlBase[], data: any) {
+  public toFormGroup(controls: FormControlBase[], data: any = {}) {
     const group: any = {};
 
     controls.forEach((control) => {
-      if (control.controlType !== "label") {
-        group[control.key] = new FormControl(data[control.key] || "");
-      }
+      group[control.key] = new FormControl(data[control.key] || "");
     });
     return new FormGroup(group);
   }

--- a/src/app/records/state/records.actions.ts
+++ b/src/app/records/state/records.actions.ts
@@ -13,7 +13,7 @@ export class FilterPayload<T> {
 }
 
 export class TableFiltersPayload<T> {
-  constructor(public tableFilter: T) {}
+  constructor(public tableFilters: T) {}
 }
 export class SearchPayload {
   constructor(public searchQuery: string) {}

--- a/src/app/records/state/records.actions.ts
+++ b/src/app/records/state/records.actions.ts
@@ -12,6 +12,9 @@ export class FilterPayload<T> {
   constructor(public filter: T) {}
 }
 
+export class TableFiltersPayload<T> {
+  constructor(public tableFilter: T) {}
+}
 export class SearchPayload {
   constructor(public searchQuery: string) {}
 }

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -4,7 +4,6 @@ import { createSelector, StateContext } from "@ngxs/store";
 import { patch, updateItem } from "@ngxs/store/operators";
 import { DEFAULT_SORT } from "../constants";
 import { ITotalCounts } from "../records.interfaces";
-import { ITableFilters } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
 
 export class RecordsStateModel<T, F, T2 = {}> {

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -4,9 +4,10 @@ import { createSelector, StateContext } from "@ngxs/store";
 import { patch, updateItem } from "@ngxs/store/operators";
 import { DEFAULT_SORT } from "../constants";
 import { ITotalCounts } from "../records.interfaces";
+import { ITableFilters } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
 
-export class RecordsStateModel<T, F> {
+export class RecordsStateModel<T, F, T2 = {}> {
   public allChecked: boolean;
   public enableAllocateAdmin?: boolean;
   public error?: string;
@@ -20,6 +21,7 @@ export class RecordsStateModel<T, F> {
   public totalPages: number;
   public totalResults: number;
   public totalCounts: ITotalCounts;
+  public tableFilters: T2;
 }
 
 export const defaultRecordsState = {
@@ -32,7 +34,8 @@ export const defaultRecordsState = {
   sort: DEFAULT_SORT,
   totalPages: null,
   totalResults: null,
-  totalCounts: null
+  totalCounts: null,
+  tableFilters: null
 };
 
 export class RecordsState {
@@ -101,6 +104,12 @@ export class RecordsState {
   static filter<T>() {
     return createSelector([this], (state: { filter: T }) => {
       return state.filter;
+    });
+  }
+
+  static tableFilters<T>() {
+    return createSelector([this], (state: { tableFilters: T }) => {
+      return state.tableFilters;
     });
   }
 

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -107,8 +107,8 @@ export class RecordsState {
     });
   }
 
-  static tableFilters<T>() {
-    return createSelector([this], (state: { tableFilters: T }) => {
+  static tableFilters<T2>() {
+    return createSelector([this], (state: { tableFilters: T2 }) => {
       return state.tableFilters;
     });
   }
@@ -190,6 +190,18 @@ export class RecordsState {
 
   protected resetFilterHandler(ctx: StateContext<any>, action: any) {
     ctx.patchState({ filter: action });
+  }
+
+  protected setTableFiltersHandler(ctx: StateContext<any>, action: any) {
+    ctx.patchState({
+      tableFilters: action.tableFilters
+    });
+  }
+
+  protected clearTableFiltersHandler(ctx: StateContext<any>) {
+    ctx.patchState({
+      tableFilters: null
+    });
   }
 
   protected enableAllocateAdminHandler(ctx: StateContext<any>, action: any) {

--- a/src/app/shared/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/src/app/shared/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,13 +1,14 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { ConfirmDialogComponent } from "./confirm-dialog.component";
-
+import { MaterialModule } from "../../shared/material/material.module";
 describe("ConfirmDialogComponent", () => {
   let component: ConfirmDialogComponent;
   let fixture: ComponentFixture<ConfirmDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [MaterialModule],
       providers: [{ provide: MAT_DIALOG_DATA, useValue: {} }],
       declarations: [ConfirmDialogComponent]
     }).compileComponents();

--- a/src/app/shared/form-controller/form-controller.component.html
+++ b/src/app/shared/form-controller/form-controller.component.html
@@ -1,4 +1,4 @@
-<div [ngSwitch]="control.controlType">
+<div [ngSwitch]="control?.controlType">
   <app-material-selection-list
     *ngSwitchCase="'selectionList'"
     [controlProperties]="control"

--- a/src/app/shared/form-controller/form-controller.component.html
+++ b/src/app/shared/form-controller/form-controller.component.html
@@ -1,0 +1,7 @@
+<div [ngSwitch]="control.controlType">
+  <app-material-selection-list
+    *ngSwitchCase="'selectionList'"
+    [meta]="control"
+    [form]="form"
+  ></app-material-selection-list>
+</div>

--- a/src/app/shared/form-controller/form-controller.component.html
+++ b/src/app/shared/form-controller/form-controller.component.html
@@ -4,4 +4,10 @@
     [meta]="control"
     [form]="form"
   ></app-material-selection-list>
+  <app-material-autocomplete
+    *ngSwitchCase="'autocomplete'"
+    [meta]="control"
+    [form]="form"
+  >
+  </app-material-autocomplete>
 </div>

--- a/src/app/shared/form-controller/form-controller.component.html
+++ b/src/app/shared/form-controller/form-controller.component.html
@@ -1,12 +1,12 @@
 <div [ngSwitch]="control.controlType">
   <app-material-selection-list
     *ngSwitchCase="'selectionList'"
-    [meta]="control"
+    [controlProperties]="control"
     [form]="form"
   ></app-material-selection-list>
   <app-material-autocomplete
     *ngSwitchCase="'autocomplete'"
-    [meta]="control"
+    [controlProperties]="control"
     [form]="form"
   >
   </app-material-autocomplete>

--- a/src/app/shared/form-controller/form-controller.component.spec.ts
+++ b/src/app/shared/form-controller/form-controller.component.spec.ts
@@ -1,16 +1,15 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 
-import { FormControllerComponent } from './form-controller.component';
+import { FormControllerComponent } from "./form-controller.component";
 
-describe('FormControllerComponent', () => {
+xdescribe("FormControllerComponent", () => {
   let component: FormControllerComponent;
   let fixture: ComponentFixture<FormControllerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FormControllerComponent ]
-    })
-    .compileComponents();
+      declarations: [FormControllerComponent]
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe('FormControllerComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/shared/form-controller/form-controller.component.spec.ts
+++ b/src/app/shared/form-controller/form-controller.component.spec.ts
@@ -1,14 +1,92 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-
+import { By } from "@angular/platform-browser";
+import {
+  AutocompleteControl,
+  FormControlBase
+} from "../form-controls/form-contol-base.model";
+import { MaterialAutocompleteComponent } from "../form-controls/material-autocomplete/material-autocomplete.component";
+import { MaterialModule } from "../material/material.module";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { FormControllerComponent } from "./form-controller.component";
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule
+} from "@angular/forms";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
-xdescribe("FormControllerComponent", () => {
+describe("FormControllerComponent", () => {
   let component: FormControllerComponent;
   let fixture: ComponentFixture<FormControllerComponent>;
 
+  const formControls: (FormControlBase | AutocompleteControl)[] = [
+    {
+      key: "selectionList1_Key",
+      label: "selection List 1 Label",
+      options: [
+        {
+          key: "selectionList1_OptionKey1",
+          value: "selection List 1 Option Value 1"
+        },
+        {
+          key: "selectionList1_OptionKey2",
+          value: "selection List 1 Option Value 2"
+        },
+        {
+          key: "selectionList1_OptionKey3",
+          value: "selection List 1 Option Value 3"
+        }
+      ],
+      order: 1,
+      controlType: "selectionList",
+      initialValue: []
+    },
+    {
+      key: "selectionList2_Key",
+      label: "selection List 2 Label",
+      options: [
+        {
+          key: "selectionList2_OptionKey1",
+          value: "selection List 2 Option Value 1"
+        },
+        {
+          key: "selectionList2_OptionKey2",
+          value: "selection List 2 Option Value 2"
+        },
+        {
+          key: "selectionList2_OptionKey3",
+          value: "selection List 2 Option Value 3"
+        },
+        {
+          key: "selectionList2_OptionKey4",
+          value: "selection List 2 Option Value 4"
+        }
+      ],
+      order: 4,
+      controlType: "selectionList",
+      initialValue: []
+    },
+    {
+      key: "autocomplete_key",
+      label: "autocomplete label",
+      order: 4,
+      initialValue: "",
+      controlType: "autocomplete",
+      serviceMethod: "loadMovies",
+      placeholder: "Start typing..."
+    }
+  ];
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [FormControllerComponent]
+      imports: [
+        MaterialModule,
+        HttpClientTestingModule,
+        NoopAnimationsModule,
+        FormsModule,
+        ReactiveFormsModule
+      ],
+      declarations: [FormControllerComponent, MaterialAutocompleteComponent]
     }).compileComponents();
   });
 
@@ -20,5 +98,24 @@ xdescribe("FormControllerComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should render a form control when set", () => {
+    component.control = {
+      key: "autocompleteKey",
+      label: "autocomplete label",
+      order: 4,
+      initialValue: "",
+      controlType: "autocomplete",
+      placeholder: "Start typing..."
+    };
+    component.form = new FormGroup({
+      autocompleteKey: new FormControl("")
+    });
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css("app-material-autocomplete"))
+        .nativeElement
+    ).toBeTruthy();
   });
 });

--- a/src/app/shared/form-controller/form-controller.component.spec.ts
+++ b/src/app/shared/form-controller/form-controller.component.spec.ts
@@ -42,38 +42,13 @@ describe("FormControllerComponent", () => {
       controlType: "selectionList",
       initialValue: []
     },
+
     {
-      key: "selectionList2_Key",
-      label: "selection List 2 Label",
-      options: [
-        {
-          key: "selectionList2_OptionKey1",
-          value: "selection List 2 Option Value 1"
-        },
-        {
-          key: "selectionList2_OptionKey2",
-          value: "selection List 2 Option Value 2"
-        },
-        {
-          key: "selectionList2_OptionKey3",
-          value: "selection List 2 Option Value 3"
-        },
-        {
-          key: "selectionList2_OptionKey4",
-          value: "selection List 2 Option Value 4"
-        }
-      ],
-      order: 4,
-      controlType: "selectionList",
-      initialValue: []
-    },
-    {
-      key: "autocomplete_key",
+      key: "autocompleteKey",
       label: "autocomplete label",
       order: 4,
       initialValue: "",
       controlType: "autocomplete",
-      serviceMethod: "loadMovies",
       placeholder: "Start typing..."
     }
   ];
@@ -100,17 +75,22 @@ describe("FormControllerComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should render a form control when set", () => {
-    component.control = {
-      key: "autocompleteKey",
-      label: "autocomplete label",
-      order: 4,
-      initialValue: "",
-      controlType: "autocomplete",
-      placeholder: "Start typing..."
-    };
+  it("should render a selection list form control when set", () => {
+    component.control = formControls[0];
     component.form = new FormGroup({
-      autocompleteKey: new FormControl("")
+      [formControls[0].key]: new FormControl("")
+    });
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css("app-material-selection-list"))
+        .nativeElement
+    ).toBeTruthy();
+  });
+
+  it("should render an autocomplete form control when set", () => {
+    component.control = formControls[1];
+    component.form = new FormGroup({
+      [formControls[1].key]: new FormControl("")
     });
     fixture.detectChanges();
     expect(

--- a/src/app/shared/form-controller/form-controller.component.spec.ts
+++ b/src/app/shared/form-controller/form-controller.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormControllerComponent } from './form-controller.component';
+
+describe('FormControllerComponent', () => {
+  let component: FormControllerComponent;
+  let fixture: ComponentFixture<FormControllerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FormControllerComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormControllerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -13,7 +13,5 @@ export class FormControllerComponent implements OnInit {
   @Input() control!: ControlBase;
   @Input() form!: FormGroup;
 
-  ngOnInit(): void {
-    console.log(this.control);
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -17,11 +17,3 @@ export class FormControllerComponent implements OnInit {
     console.log(this.control);
   }
 }
-
-// <div [ngSwitch]="control.controlType">
-//     <app-material-selection-list
-//       *ngSwitchCase="'selectionList'"
-//       [meta]="control"
-//       [form]="form"
-//     ></app-material-selection-list>
-//   </div>

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from "@angular/core";
 import { FormGroup } from "@angular/forms";
-import { ControlBase } from "../form-controls/contol-base.model";
+import { FormControlBase } from "../form-controls/form-contol-base.model";
 
 @Component({
   selector: "app-form-controller",
@@ -10,7 +10,7 @@ import { ControlBase } from "../form-controls/contol-base.model";
 export class FormControllerComponent implements OnInit {
   constructor() {}
 
-  @Input() control!: ControlBase;
+  @Input() control!: FormControlBase;
   @Input() form!: FormGroup;
 
   ngOnInit(): void {}

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -4,8 +4,7 @@ import { FormControlBase } from "../form-controls/form-contol-base.model";
 
 @Component({
   selector: "app-form-controller",
-  templateUrl: "./form-controller.component.html",
-  styleUrls: ["./form-controller.component.scss"]
+  templateUrl: "./form-controller.component.html"
 })
 export class FormControllerComponent implements OnInit {
   constructor() {}

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit, Input } from "@angular/core";
+import { FormGroup } from "@angular/forms";
+import { ControlBase } from "../form-controls/contol-base.model";
+
+@Component({
+  selector: "app-form-controller",
+  templateUrl: "./form-controller.component.html",
+  styleUrls: ["./form-controller.component.scss"]
+})
+export class FormControllerComponent implements OnInit {
+  constructor() {}
+
+  @Input() control!: ControlBase;
+  @Input() form!: FormGroup;
+
+  ngOnInit(): void {
+    console.log(this.control);
+  }
+}
+
+// <div [ngSwitch]="control.controlType">
+//     <app-material-selection-list
+//       *ngSwitchCase="'selectionList'"
+//       [meta]="control"
+//       [form]="form"
+//     ></app-material-selection-list>
+//   </div>

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { FormControlBase } from "../form-controls/form-contol-base.model";
 
@@ -6,11 +6,7 @@ import { FormControlBase } from "../form-controls/form-contol-base.model";
   selector: "app-form-controller",
   templateUrl: "./form-controller.component.html"
 })
-export class FormControllerComponent implements OnInit {
-  constructor() {}
-
+export class FormControllerComponent {
   @Input() control!: FormControlBase;
   @Input() form!: FormGroup;
-
-  ngOnInit(): void {}
 }

--- a/src/app/shared/form-controls/contol-base.model.ts
+++ b/src/app/shared/form-controls/contol-base.model.ts
@@ -6,5 +6,11 @@ export interface ControlBase {
   order: number;
   controlType: string;
   text?: string;
+  placeholder?: string;
   options?: { key: string; value: string }[];
+}
+
+export interface MaterialAutocompleteControl extends ControlBase {
+  allowMultipleSelections?: boolean;
+  serviceMethod: string;
 }

--- a/src/app/shared/form-controls/contol-base.model.ts
+++ b/src/app/shared/form-controls/contol-base.model.ts
@@ -1,5 +1,6 @@
 export interface ControlBase {
   key: string;
+  label?: string;
   initialValue: any;
   required?: boolean;
   order: number;

--- a/src/app/shared/form-controls/contol-base.model.ts
+++ b/src/app/shared/form-controls/contol-base.model.ts
@@ -1,0 +1,9 @@
+export interface ControlBase {
+  key: string;
+  initialValue: any;
+  required?: boolean;
+  order: number;
+  controlType: string;
+  text?: string;
+  options?: { key: string; value: string }[];
+}

--- a/src/app/shared/form-controls/form-contol-base.model.ts
+++ b/src/app/shared/form-controls/form-contol-base.model.ts
@@ -1,4 +1,4 @@
-export interface ControlBase {
+export interface FormControlBase {
   key: string;
   label?: string;
   initialValue: any;
@@ -10,7 +10,6 @@ export interface ControlBase {
   options?: { key: string; value: string }[];
 }
 
-export interface MaterialAutocompleteControl extends ControlBase {
-  allowMultipleSelections?: boolean;
+export interface AutocompleteControl extends FormControlBase {
   serviceMethod: string;
 }

--- a/src/app/shared/form-controls/form-contol-base.model.ts
+++ b/src/app/shared/form-controls/form-contol-base.model.ts
@@ -1,7 +1,7 @@
 export interface FormControlBase {
   key: string;
   label?: string;
-  initialValue: any;
+  initialValue?: any;
   required?: boolean;
   order: number;
   controlType: string;

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AutocompleteService } from './autocomplete.service';
+
+describe('AutocompleteService', () => {
+  let service: AutocompleteService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AutocompleteService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -22,7 +22,7 @@ describe("AutocompleteService", () => {
   it("should call correct endpoint", () => {
     service.getItems("programmeName", "query").subscribe();
     const request = httpTestingController.expectOne(
-      "/autocomplete?fieldName=programmeName"
+      "api/v1/doctors/autocomplete?fieldName=programmeName&input=query&dbcs="
     );
 
     request.flush(options);

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -1,10 +1,9 @@
-import { TestBed, waitForAsync } from "@angular/core/testing";
+import { TestBed } from "@angular/core/testing";
 import {
   HttpClientTestingModule,
   HttpTestingController
 } from "@angular/common/http/testing";
 import { AutocompleteService } from "./autocomplete.service";
-import { isEmpty } from "rxjs/operators";
 
 describe("AutocompleteService", () => {
   let service: AutocompleteService;
@@ -21,7 +20,7 @@ describe("AutocompleteService", () => {
   });
 
   it("should call correct endpoint", () => {
-    service.getMatchingItems("programmeName", "query").subscribe();
+    service.getItems("programmeName", "query").subscribe();
     const request = httpTestingController.expectOne(
       "/autocomplete?fieldName=programmeName"
     );

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from "@angular/core/testing";
+import { TestBed, waitForAsync } from "@angular/core/testing";
 import {
   HttpClientTestingModule,
   HttpTestingController
@@ -30,13 +30,12 @@ describe("AutocompleteService", () => {
     expect(request.request.method).toBe("GET");
   });
 
-  it("should call no endpoint when invalid method name passed", (done: DoneFn) => {
+  it("should call no endpoint when invalid method name passed", waitForAsync(() => {
     service
       .getData("query", "NoMethod")
       .pipe(isEmpty())
       .subscribe((response) => {
         expect(response).toEqual(true);
-        done();
       });
-  });
+  }));
 });

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -21,7 +21,7 @@ describe("AutocompleteService", () => {
   });
 
   it("should call correct endpoint", () => {
-    service.getListItems("programmeName", "query").subscribe();
+    service.getMatchingItems("programmeName", "query").subscribe();
     const request = httpTestingController.expectOne(
       "/autocomplete?fieldName=programmeName"
     );

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -6,7 +6,7 @@ import {
 import { AutocompleteService } from "./autocomplete.service";
 import { isEmpty } from "rxjs/operators";
 
-fdescribe("AutocompleteService", () => {
+describe("AutocompleteService", () => {
   let service: AutocompleteService;
   let httpTestingController: HttpTestingController;
   const options: string[] = ["apple", "banana", "cherry"];

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -1,16 +1,42 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed } from "@angular/core/testing";
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from "@angular/common/http/testing";
+import { AutocompleteService } from "./autocomplete.service";
+import { isEmpty } from "rxjs/operators";
 
-import { AutocompleteService } from './autocomplete.service';
-
-describe('AutocompleteService', () => {
+fdescribe("AutocompleteService", () => {
   let service: AutocompleteService;
-
+  let httpTestingController: HttpTestingController;
+  const options: string[] = ["apple", "banana", "cherry"];
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [AutocompleteService],
+      imports: [HttpClientTestingModule]
+    });
+
     service = TestBed.inject(AutocompleteService);
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it("should call correct endpoint", () => {
+    service.getData("query", "loadMovies").subscribe();
+    const request = httpTestingController.expectOne(
+      "nymovies?api-key=GyIcunqNC1k86GYGU21QAUTdESGlGUOP&query=query"
+    );
+
+    request.flush(options);
+    expect(request.request.method).toBe("GET");
+  });
+
+  it("should call no endpoint when invalid method name passed", (done: DoneFn) => {
+    service
+      .getData("query", "NoMethod")
+      .pipe(isEmpty())
+      .subscribe((response) => {
+        expect(response).toEqual(true);
+        done();
+      });
   });
 });

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.spec.ts
@@ -21,21 +21,12 @@ describe("AutocompleteService", () => {
   });
 
   it("should call correct endpoint", () => {
-    service.getData("query", "loadMovies").subscribe();
+    service.getListItems("programmeName", "query").subscribe();
     const request = httpTestingController.expectOne(
-      "nymovies?api-key=GyIcunqNC1k86GYGU21QAUTdESGlGUOP&query=query"
+      "/autocomplete?fieldName=programmeName"
     );
 
     request.flush(options);
     expect(request.request.method).toBe("GET");
   });
-
-  it("should call no endpoint when invalid method name passed", waitForAsync(() => {
-    service
-      .getData("query", "NoMethod")
-      .pipe(isEmpty())
-      .subscribe((response) => {
-        expect(response).toEqual(true);
-      });
-  }));
 });

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -14,18 +14,18 @@ export class AutocompleteService {
     const params = new HttpParams().set("api-key", apiKey).set("query", query);
 
     return this.http.get<any[]>("nymovies", { params }).pipe(
+      tap((data) => {
+        console.log("data ", data);
+      }),
       map((data: any) => {
         if (data["results"]) {
           return data["results"];
         }
-        return data;
+        return [];
       }),
       map((data: any) => {
-        if (!data["Error"]) {
-          return data.map((item: any) => ({
-            title: item["display_title"],
-            ...item
-          }));
+        if (data.length) {
+          return data.map((item: any) => item["display_title"]);
         }
       })
     );

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -1,9 +1,12 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
-import { map } from "rxjs/operators";
 import { AuthService } from "src/app/core/auth/auth.service";
 import { environment } from "@environment";
+
+export interface AutocompleteResults {
+  results: string[];
+}
 
 @Injectable({
   providedIn: "root"
@@ -15,28 +18,9 @@ export class AutocompleteService {
       .set("fieldName", fieldName)
       .set("input", query)
       .set("dbcs", this.authService.userDesignatedBodies?.join(","));
-    return this.http.get<{ results: string[] }>(
+    return this.http.get<AutocompleteResults>(
       `${environment.appUrls.autocomplete}`,
       { params }
-    );
-  }
-
-  private loadNYMovies(query: string): Observable<any[]> {
-    const apiKey: string = "GyIcunqNC1k86GYGU21QAUTdESGlGUOP";
-    const params = new HttpParams().set("api-key", apiKey).set("query", query);
-
-    return this.http.get<any[]>("nymovies", { params }).pipe(
-      map((data: any) => {
-        if (data["results"]) {
-          return data["results"];
-        }
-        return [];
-      }),
-      map((data: any) => {
-        if (data.length) {
-          return data.map((item: any) => item["display_title"]);
-        }
-      })
     );
   }
 }

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { EMPTY, Observable } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { map } from "rxjs/operators";
 
 @Injectable({
   providedIn: "root"
@@ -14,9 +14,6 @@ export class AutocompleteService {
     const params = new HttpParams().set("api-key", apiKey).set("query", query);
 
     return this.http.get<any[]>("nymovies", { params }).pipe(
-      tap((data) => {
-        console.log("data ", data);
-      }),
       map((data: any) => {
         if (data["results"]) {
           return data["results"];

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -1,0 +1,46 @@
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { EMPTY, Observable } from "rxjs";
+import { map, tap } from "rxjs/operators";
+
+@Injectable({
+  providedIn: "root"
+})
+export class AutocompleteService {
+  constructor(private http: HttpClient) {}
+
+  loadNYMovies(query: string): Observable<any[]> {
+    const apiKey: string = "GyIcunqNC1k86GYGU21QAUTdESGlGUOP";
+    const params = new HttpParams().set("api-key", apiKey).set("query", query);
+
+    return this.http.get<any[]>("nymovies", { params }).pipe(
+      map((data: any) => {
+        if (data["results"]) {
+          return data["results"];
+        }
+        return data;
+      }),
+      map((data: any) => {
+        if (!data["Error"]) {
+          return data.map((item: any) => ({
+            title: item["display_title"],
+            ...item
+          }));
+        }
+      })
+    );
+  }
+
+  getData(query: string, methodName: string): Observable<any> {
+    switch (methodName) {
+      case "loadMovies": {
+        return this.loadNYMovies(query);
+        break;
+      }
+
+      default: {
+        return EMPTY;
+      }
+    }
+  }
+}

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -1,15 +1,29 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { EMPTY, Observable } from "rxjs";
+import { EMPTY, Observable, of } from "rxjs";
 import { map } from "rxjs/operators";
+import { AuthService } from "src/app/core/auth/auth.service";
 
 @Injectable({
   providedIn: "root"
 })
 export class AutocompleteService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private authService: AuthService) {}
+  private filterProgrammeName(query: string) {
+    const designatedBodies: string =
+      this.authService.userDesignatedBodies?.join(",");
 
-  loadNYMovies(query: string): Observable<any[]> {
+    const params = new HttpParams()
+      .set("fieldName", "programmeName")
+      .set("input", query)
+      .set("dbcs", designatedBodies);
+    console.log("params:", params);
+    //return this.http.get<any[]>("endpoint", { params });
+    const mock = ["apple", "banana", "cherry", "damson", "elderberry", "fig"];
+    return of(mock);
+  }
+
+  private loadNYMovies(query: string): Observable<any[]> {
     const apiKey: string = "GyIcunqNC1k86GYGU21QAUTdESGlGUOP";
     const params = new HttpParams().set("api-key", apiKey).set("query", query);
 
@@ -30,6 +44,10 @@ export class AutocompleteService {
 
   getData(query: string, methodName: string): Observable<any> {
     switch (methodName) {
+      case "programmeName": {
+        return this.filterProgrammeName(query);
+        break;
+      }
       case "loadMovies": {
         return this.loadNYMovies(query);
         break;

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -3,22 +3,26 @@ import { Injectable } from "@angular/core";
 import { EMPTY, Observable, of } from "rxjs";
 import { map } from "rxjs/operators";
 import { AuthService } from "src/app/core/auth/auth.service";
+import { environment } from "@environment";
 
 @Injectable({
   providedIn: "root"
 })
 export class AutocompleteService {
   constructor(private http: HttpClient, private authService: AuthService) {}
-  private filterProgrammeName(query: string) {
+  getListItems(fieldName: string, query: string): Observable<any> {
     const designatedBodies: string =
       this.authService.userDesignatedBodies?.join(",");
 
     const params = new HttpParams()
-      .set("fieldName", "programmeName")
+      .set("fieldName", fieldName)
       .set("input", query)
       .set("dbcs", designatedBodies);
-    console.log("params:", params);
-    //return this.http.get<any[]>("endpoint", { params });
+    // return this.http.get<{ results: string[] }>(
+    //   `${environment.appUrls.autocomplete}`,
+    //   { params }
+    // );
+    return this.loadNYMovies(query);
     const mock = ["apple", "banana", "cherry", "damson", "elderberry", "fig"];
     return of(mock);
   }
@@ -42,20 +46,20 @@ export class AutocompleteService {
     );
   }
 
-  getData(query: string, methodName: string): Observable<any> {
-    switch (methodName) {
-      case "programmeName": {
-        return this.filterProgrammeName(query);
-        break;
-      }
-      case "loadMovies": {
-        return this.loadNYMovies(query);
-        break;
-      }
+  // getData(query: string, methodName: string): Observable<any> {
+  //   switch (methodName) {
+  //     case "programmeName": {
+  //       return this.filterProgrammeName(query);
+  //       break;
+  //     }
+  //     case "loadMovies": {
+  //       return this.loadNYMovies(query);
+  //       break;
+  //     }
 
-      default: {
-        return EMPTY;
-      }
-    }
-  }
+  //     default: {
+  //       return EMPTY;
+  //     }
+  //   }
+  // }
 }

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { EMPTY, Observable, of } from "rxjs";
+import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { AuthService } from "src/app/core/auth/auth.service";
 import { environment } from "@environment";
@@ -10,21 +10,15 @@ import { environment } from "@environment";
 })
 export class AutocompleteService {
   constructor(private http: HttpClient, private authService: AuthService) {}
-  getMatchingItems(fieldName: string, query: string): Observable<any> {
-    const designatedBodies: string =
-      this.authService.userDesignatedBodies?.join(",");
-
+  getItems(fieldName: string, query: string): Observable<any> {
     const params = new HttpParams()
       .set("fieldName", fieldName)
       .set("input", query)
-      .set("dbcs", designatedBodies);
-    // return this.http.get<{ results: string[] }>(
-    //   `${environment.appUrls.autocomplete}`,
-    //   { params }
-    // );
-    return this.loadNYMovies(query);
-    const mock = ["apple", "banana", "cherry", "damson", "elderberry", "fig"];
-    return of(mock);
+      .set("dbcs", this.authService.userDesignatedBodies?.join(","));
+    return this.http.get<{ results: string[] }>(
+      `${environment.appUrls.autocomplete}`,
+      { params }
+    );
   }
 
   private loadNYMovies(query: string): Observable<any[]> {
@@ -45,21 +39,4 @@ export class AutocompleteService {
       })
     );
   }
-
-  // getData(query: string, methodName: string): Observable<any> {
-  //   switch (methodName) {
-  //     case "programmeName": {
-  //       return this.filterProgrammeName(query);
-  //       break;
-  //     }
-  //     case "loadMovies": {
-  //       return this.loadNYMovies(query);
-  //       break;
-  //     }
-
-  //     default: {
-  //       return EMPTY;
-  //     }
-  //   }
-  // }
 }

--- a/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
+++ b/src/app/shared/form-controls/material-autocomplete/autocomplete.service.ts
@@ -10,7 +10,7 @@ import { environment } from "@environment";
 })
 export class AutocompleteService {
   constructor(private http: HttpClient, private authService: AuthService) {}
-  getListItems(fieldName: string, query: string): Observable<any> {
+  getMatchingItems(fieldName: string, query: string): Observable<any> {
     const designatedBodies: string =
       this.authService.userDesignatedBodies?.join(",");
 

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -1,9 +1,5 @@
 <div [formGroup]="form">
-  <mat-form-field
-    class="example-full-width"
-    style="width: 100%"
-    appearance="fill"
-  >
+  <mat-form-field *ngIf="meta" style="width: 100%" appearance="fill">
     <mat-label>{{ meta.label }}</mat-label>
     <input
       matInput
@@ -13,7 +9,6 @@
     />
 
     <button
-      *ngIf="searchControl.value"
       matSuffix
       mat-icon-button
       aria-label="Clear"

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -28,7 +28,6 @@
       [panelWidth]="400"
       #auto="matAutocomplete"
       (optionSelected)="onSelected()"
-      [displayWith]="displayWith"
     >
       <mat-option *ngIf="isLoading" class="is-loading">Loading...</mat-option>
       <ng-container *ngIf="!isLoading">

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -9,9 +9,11 @@
     />
 
     <button
+      *ngIf="this.form.controls[this.meta.key].value"
       matSuffix
       mat-icon-button
       aria-label="Clear"
+      data-jasmine="clearInputButton"
       (click)="clearSelection()"
     >
       <mat-icon>close</mat-icon>

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="form">
+<div data-jasmine="formControl" [formGroup]="form">
   <mat-form-field *ngIf="meta" style="width: 100%" appearance="fill">
     <mat-label>{{ meta.label }}</mat-label>
     <input

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -1,15 +1,19 @@
 <div data-jasmine="formControl" [formGroup]="form">
-  <mat-form-field *ngIf="meta" style="width: 100%" appearance="fill">
-    <mat-label>{{ meta.label }}</mat-label>
+  <mat-form-field
+    *ngIf="controlProperties"
+    style="width: 100%"
+    appearance="fill"
+  >
+    <mat-label>{{ controlProperties.label }}</mat-label>
     <input
       matInput
       [matAutocomplete]="auto"
-      [formControlName]="meta.key"
-      [placeholder]="meta.placeholder"
+      [formControlName]="controlProperties.key"
+      [placeholder]="controlProperties.placeholder"
     />
 
     <button
-      *ngIf="this.form.controls[this.meta.key].value"
+      *ngIf="this.form.controls[this.controlProperties.key].value"
       matSuffix
       mat-icon-button
       aria-label="Clear"

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -1,5 +1,6 @@
-<div data-jasmine="formControl" [formGroup]="form">
+<div data-jasmine="formControl" data-cy="formFieldWrapper" [formGroup]="form">
   <mat-form-field
+    attr.data-cy="formfield_{{ controlProperties.key }}"
     *ngIf="controlProperties"
     style="width: 100%"
     appearance="fill"

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -8,10 +8,10 @@
     <input
       matInput
       [matAutocomplete]="auto"
-      [matChipInputFor]="chipList"
-      [formControl]="searchControl"
+      [formControlName]="meta.key"
       [placeholder]="meta.placeholder"
     />
+
     <button
       *ngIf="searchControl.value"
       matSuffix
@@ -31,28 +31,10 @@
       <mat-option *ngIf="isLoading" class="is-loading">Loading...</mat-option>
       <ng-container *ngIf="!isLoading">
         <mat-option *ngFor="let item of filteredItems" [value]="item">
-          <span>{{ item.title }}</span>
+          <span>{{ item }}</span>
         </mat-option>
       </ng-container>
     </mat-autocomplete>
-    <mat-chip-list
-      [hidden]="!meta.allowMultipleSelections"
-      #chipList
-      [attr.aria-label]="meta.label"
-    >
-      <mat-chip
-        *ngFor="let tag of form.controls[meta.key].value"
-        (removed)="removeTag(tag)"
-      >
-        {{ tag.title }}
-        <button matChipRemove>
-          <mat-icon>cancel</mat-icon>
-        </button>
-      </mat-chip>
-    </mat-chip-list>
   </mat-form-field>
-
-  <ng-container *ngIf="errorMsg">
-    {{ errorMsg }}
-  </ng-container>
+  <div class="mat-error error" *ngIf="isNoMatches">No matches found.</div>
 </div>

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.html
@@ -1,0 +1,58 @@
+<div [formGroup]="form">
+  <mat-form-field
+    class="example-full-width"
+    style="width: 100%"
+    appearance="fill"
+  >
+    <mat-label>{{ meta.label }}</mat-label>
+    <input
+      matInput
+      [matAutocomplete]="auto"
+      [matChipInputFor]="chipList"
+      [formControl]="searchControl"
+      [placeholder]="meta.placeholder"
+    />
+    <button
+      *ngIf="searchControl.value"
+      matSuffix
+      mat-icon-button
+      aria-label="Clear"
+      (click)="clearSelection()"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+
+    <mat-autocomplete
+      [panelWidth]="400"
+      #auto="matAutocomplete"
+      (optionSelected)="onSelected()"
+      [displayWith]="displayWith"
+    >
+      <mat-option *ngIf="isLoading" class="is-loading">Loading...</mat-option>
+      <ng-container *ngIf="!isLoading">
+        <mat-option *ngFor="let item of filteredItems" [value]="item">
+          <span>{{ item.title }}</span>
+        </mat-option>
+      </ng-container>
+    </mat-autocomplete>
+    <mat-chip-list
+      [hidden]="!meta.allowMultipleSelections"
+      #chipList
+      [attr.aria-label]="meta.label"
+    >
+      <mat-chip
+        *ngFor="let tag of form.controls[meta.key].value"
+        (removed)="removeTag(tag)"
+      >
+        {{ tag.title }}
+        <button matChipRemove>
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip>
+    </mat-chip-list>
+  </mat-form-field>
+
+  <ng-container *ngIf="errorMsg">
+    {{ errorMsg }}
+  </ng-container>
+</div>

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.scss
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.scss
@@ -1,0 +1,6 @@
+.mat-error {
+  position: relative;
+  top: -10px;
+  font-size: 75%;
+  padding: 0 1em;
+}

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
@@ -17,7 +17,7 @@ import { of } from "rxjs";
 describe("MaterialAutocompleteComponent", () => {
   let component: MaterialAutocompleteComponent;
   let fixture: ComponentFixture<MaterialAutocompleteComponent>;
-  let mockAutocompleteService = jasmine.createSpyObj(["getMatchingItems"]);
+  let mockAutocompleteService = jasmine.createSpyObj(["getItems"]);
 
   const data = {};
   const options: string[] = ["apple", "banana", "cherry", "date"];
@@ -25,7 +25,7 @@ describe("MaterialAutocompleteComponent", () => {
     inputValue: string,
     searchOptions: string[] = options
   ) => {
-    mockAutocompleteService.getMatchingItems.and.returnValue(of(searchOptions));
+    mockAutocompleteService.getItems.and.returnValue(of(searchOptions));
 
     const inputElement = fixture.debugElement.query(By.css("input"));
     inputElement.nativeElement.dispatchEvent(new Event("focusin"));

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
@@ -107,4 +107,23 @@ describe("MaterialAutocompleteComponent", () => {
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css(".mat-error")).length).toBe(1);
   });
+  it("should not display the clear button when input is empty", async () => {
+    initAutocomplete("", []);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.queryAll(By.css("[data-jasmine='clearInputButton']"))
+        .length
+    ).toBe(0);
+  });
+
+  it("should display the clear button when input contains text", async () => {
+    initAutocomplete("qw", []);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.queryAll(By.css("[data-jasmine='clearInputButton']"))
+        .length
+    ).toBe(1);
+  });
 });

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
@@ -11,7 +11,7 @@ import { MaterialAutocompleteComponent } from "./material-autocomplete.component
 import { AutocompleteService } from "./autocomplete.service";
 import { of } from "rxjs";
 
-fdescribe("MaterialAutocompleteComponent", () => {
+describe("MaterialAutocompleteComponent", () => {
   let component: MaterialAutocompleteComponent;
   let fixture: ComponentFixture<MaterialAutocompleteComponent>;
   let mockAutocompleteService = jasmine.createSpyObj(["getData", "testFunc"]);

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
@@ -14,25 +14,15 @@ import { of } from "rxjs";
 describe("MaterialAutocompleteComponent", () => {
   let component: MaterialAutocompleteComponent;
   let fixture: ComponentFixture<MaterialAutocompleteComponent>;
-  let mockAutocompleteService = jasmine.createSpyObj(["getData", "testFunc"]);
-  const meta: AutocompleteControl = {
-    key: "initialKey",
-    label: "initialLabel",
-    order: 1,
-    controlType: "autocomplete",
-    serviceMethod: "mockServiceName",
-    initialValue: []
-  };
+  let mockAutocompleteService = jasmine.createSpyObj(["getMatchingItems"]);
+
   const data = {};
   const options: string[] = ["apple", "banana", "cherry", "date"];
-
-  const toFormGroup = (): FormGroup => {
-    const group: any = {};
-    group[meta.key] = new FormControl(data[meta.key] || "");
-    return new FormGroup(group);
-  };
-  const initAutocomplete = (inputValue: string, ops: string[] = options) => {
-    mockAutocompleteService.getData.and.returnValue(of(ops));
+  const enterSearchItemsAndSubmit = (
+    inputValue: string,
+    searchOptions: string[] = options
+  ) => {
+    mockAutocompleteService.getMatchingItems.and.returnValue(of(searchOptions));
 
     const inputElement = fixture.debugElement.query(By.css("input"));
     inputElement.nativeElement.dispatchEvent(new Event("focusin"));
@@ -58,7 +48,7 @@ describe("MaterialAutocompleteComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MaterialAutocompleteComponent);
     component = fixture.componentInstance;
-    component.meta = {
+    component.controlProperties = {
       key: "initialKey",
       label: "initialLabel",
       order: 1,
@@ -66,7 +56,11 @@ describe("MaterialAutocompleteComponent", () => {
       serviceMethod: "mockServiceName",
       initialValue: []
     };
-    component.form = toFormGroup();
+    const group: any = {};
+    group[component.controlProperties.key] = new FormControl(
+      data[component.controlProperties.key] || ""
+    );
+    component.form = new FormGroup(group);
     fixture.detectChanges();
   });
 
@@ -82,7 +76,7 @@ describe("MaterialAutocompleteComponent", () => {
 
   it("should not display options when input is < 5 characters", async () => {
     component.minLengthTerm = 5;
-    initAutocomplete("four");
+    enterSearchItemsAndSubmit("four");
     await fixture.whenStable();
     fixture.detectChanges();
 
@@ -92,7 +86,7 @@ describe("MaterialAutocompleteComponent", () => {
 
   it("should display correct options in dropdown when input length >= 5", async () => {
     component.minLengthTerm = 5;
-    initAutocomplete("query");
+    enterSearchItemsAndSubmit("query");
     await fixture.whenStable();
     fixture.detectChanges();
 
@@ -102,13 +96,13 @@ describe("MaterialAutocompleteComponent", () => {
   });
 
   it("should display error when no options found", async () => {
-    initAutocomplete("query", []);
+    enterSearchItemsAndSubmit("query", []);
     await fixture.whenStable();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css(".mat-error")).length).toBe(1);
   });
   it("should not display the clear button when input is empty", async () => {
-    initAutocomplete("", []);
+    enterSearchItemsAndSubmit("", []);
     await fixture.whenStable();
     fixture.detectChanges();
     expect(
@@ -118,7 +112,7 @@ describe("MaterialAutocompleteComponent", () => {
   });
 
   it("should display the clear button when input contains text", async () => {
-    initAutocomplete("qw", []);
+    enterSearchItemsAndSubmit("qw", []);
     await fixture.whenStable();
     fixture.detectChanges();
     expect(

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
@@ -1,10 +1,13 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
-import { Component, OnInit } from "@angular/core";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { AutocompleteControl } from "../form-contol-base.model";
-import { FormControl, FormGroup } from "@angular/forms";
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormControl,
+  FormGroup
+} from "@angular/forms";
 import { MaterialModule } from "src/app/shared/material/material.module";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+
 import { By } from "@angular/platform-browser";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { MaterialAutocompleteComponent } from "./material-autocomplete.component";

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MaterialAutocompleteComponent } from './material-autocomplete.component';
+
+describe('MaterialAutocompleteComponent', () => {
+  let component: MaterialAutocompleteComponent;
+  let fixture: ComponentFixture<MaterialAutocompleteComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MaterialAutocompleteComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MaterialAutocompleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.spec.ts
@@ -1,25 +1,110 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import { Component, OnInit } from "@angular/core";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { AutocompleteControl } from "../form-contol-base.model";
+import { FormControl, FormGroup } from "@angular/forms";
+import { MaterialModule } from "src/app/shared/material/material.module";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { By } from "@angular/platform-browser";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { MaterialAutocompleteComponent } from "./material-autocomplete.component";
+import { AutocompleteService } from "./autocomplete.service";
+import { of } from "rxjs";
 
-import { MaterialAutocompleteComponent } from './material-autocomplete.component';
-
-describe('MaterialAutocompleteComponent', () => {
+fdescribe("MaterialAutocompleteComponent", () => {
   let component: MaterialAutocompleteComponent;
   let fixture: ComponentFixture<MaterialAutocompleteComponent>;
+  let mockAutocompleteService = jasmine.createSpyObj(["getData", "testFunc"]);
+  const meta: AutocompleteControl = {
+    key: "initialKey",
+    label: "initialLabel",
+    order: 1,
+    controlType: "autocomplete",
+    serviceMethod: "mockServiceName",
+    initialValue: []
+  };
+  const data = {};
+  const options: string[] = ["apple", "banana", "cherry", "date"];
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ MaterialAutocompleteComponent ]
-    })
-    .compileComponents();
-  });
+  const toFormGroup = (): FormGroup => {
+    const group: any = {};
+    group[meta.key] = new FormControl(data[meta.key] || "");
+    return new FormGroup(group);
+  };
+  const initAutocomplete = (inputValue: string, ops: string[] = options) => {
+    mockAutocompleteService.getData.and.returnValue(of(ops));
+
+    const inputElement = fixture.debugElement.query(By.css("input"));
+    inputElement.nativeElement.dispatchEvent(new Event("focusin"));
+    inputElement.nativeElement.value = inputValue;
+    inputElement.nativeElement.dispatchEvent(new Event("input"));
+  };
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MaterialModule,
+        FormsModule,
+        ReactiveFormsModule,
+        HttpClientTestingModule,
+        BrowserAnimationsModule
+      ],
+      providers: [
+        { provide: AutocompleteService, useValue: mockAutocompleteService }
+      ],
+      declarations: [MaterialAutocompleteComponent]
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MaterialAutocompleteComponent);
     component = fixture.componentInstance;
+    component.meta = {
+      key: "initialKey",
+      label: "initialLabel",
+      order: 1,
+      controlType: "autocomplete",
+      serviceMethod: "mockServiceName",
+      initialValue: []
+    };
+    component.form = toFormGroup();
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should display the correct label", () => {
+    expect(
+      fixture.debugElement.query(By.css("mat-label")).nativeElement.innerHTML
+    ).toContain("initialLabel");
+  });
+
+  it("should not display options when input is < 5 characters", async () => {
+    component.minLengthTerm = 5;
+    initAutocomplete("four");
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const matOptions = document.querySelectorAll("mat-option");
+    expect(matOptions.length).toBe(0);
+  });
+
+  it("should display correct options in dropdown when input length >= 5", async () => {
+    component.minLengthTerm = 5;
+    initAutocomplete("query");
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const matOptions = document.querySelectorAll("mat-option");
+    expect(matOptions.length).toBe(options.length);
+    expect(matOptions[0].innerHTML).toContain(options[0]);
+  });
+
+  it("should display error when no options found", async () => {
+    initAutocomplete("query", []);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css(".mat-error")).length).toBe(1);
   });
 });

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -1,15 +1,8 @@
 import { Component, OnInit, Input } from "@angular/core";
 import { FormControl, FormGroup } from "@angular/forms";
-import { Observable } from "rxjs";
-import {
-  debounceTime,
-  filter,
-  finalize,
-  isEmpty,
-  switchMap,
-  tap
-} from "rxjs/operators";
-import { MaterialAutocompleteControl } from "../contol-base.model";
+import { debounceTime, filter, finalize, switchMap, tap } from "rxjs/operators";
+import { SnackBarService } from "../../services/snack-bar/snack-bar.service";
+import { AutocompleteControl } from "../form-contol-base.model";
 import { AutocompleteService } from "./autocomplete.service";
 
 @Component({
@@ -18,80 +11,38 @@ import { AutocompleteService } from "./autocomplete.service";
   styleUrls: ["./material-autocomplete.component.scss"]
 })
 export class MaterialAutocompleteComponent implements OnInit {
-  @Input() meta!: MaterialAutocompleteControl;
+  @Input() meta!: AutocompleteControl;
   @Input() form!: FormGroup;
-  @Input() debounceTime: number = 800;
-  @Input() minLengthTerm: number = 3;
-  @Input() reset: Observable<void>;
+  debounceTime: number = 800;
+  minLengthTerm: number = 3;
 
   searchControl: FormControl = new FormControl();
-  controlName: string;
   filteredItems: any;
-  isLoading = false;
-  errorMsg!: string;
+  isLoading: boolean;
+  isNoMatches: boolean;
 
   options: any[];
 
-  setDisabledState?(isDisabled: boolean): void {
-    if (isDisabled) {
-    } else {
-      this.searchControl.enable();
-    }
-  }
-
-  constructor(private autocompleteService: AutocompleteService) {}
-
-  removeTag(tag: string): void {
-    const index = this.form.controls[this.meta.key].value.indexOf(tag);
-
-    if (index >= 0) {
-      this.form.controls[this.meta.key].value.splice(index, 1);
-      this.form.controls[this.meta.key].updateValueAndValidity();
-    }
-  }
+  constructor(
+    private autocompleteService: AutocompleteService,
+    private snackBarService: SnackBarService
+  ) {}
 
   onSelected() {
-    if (this.meta.allowMultipleSelections) {
-      this.form.controls[this.meta.key].setValue([
-        ...this.form.controls[this.meta.key].value,
-        this.searchControl.value
-      ]);
-      this.clearSelection();
-    } else {
-      this.form.controls[this.meta.key].setValue([
-        this.searchControl.value["title"]
-      ]);
-    }
-
     this.form.controls[this.meta.key].updateValueAndValidity();
+    this.form.markAsDirty();
   }
 
   displayWith(value: any) {
-    return value?.title;
+    return value;
   }
 
   clearSelection() {
-    this.searchControl.setValue(null);
-    //this.form.controls[this.meta.key].setValue(null);
     this.filteredItems = [];
   }
 
   ngOnInit() {
-    this.form.valueChanges
-      .pipe(
-        filter((val) => {
-          if (this.searchControl.dirty) {
-            return val;
-          }
-        })
-      )
-      .subscribe((val) => {
-        if (!val[this.meta.key]) {
-          this.searchControl.setValue("");
-        }
-      });
-
-    this.searchControl.valueChanges
+    this.form.controls[this.meta.key].valueChanges
       .pipe(
         filter((res) => {
           if (res !== null && res.length >= this.minLengthTerm) {
@@ -102,7 +53,6 @@ export class MaterialAutocompleteComponent implements OnInit {
         //distinctUntilChanged(),
         debounceTime(this.debounceTime),
         tap((value: string) => {
-          this.errorMsg = "";
           this.filteredItems = [];
           this.isLoading = true;
         }),
@@ -116,11 +66,11 @@ export class MaterialAutocompleteComponent implements OnInit {
       )
       .subscribe((data: any) => {
         if (data == undefined) {
-          this.errorMsg = "Error";
+          this.isNoMatches = true;
           this.filteredItems = [];
         } else {
-          this.errorMsg = "";
           this.filteredItems = data;
+          this.isNoMatches = false;
         }
       });
   }

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -1,0 +1,127 @@
+import { Component, OnInit, Input } from "@angular/core";
+import { FormControl, FormGroup } from "@angular/forms";
+import { Observable } from "rxjs";
+import {
+  debounceTime,
+  filter,
+  finalize,
+  isEmpty,
+  switchMap,
+  tap
+} from "rxjs/operators";
+import { MaterialAutocompleteControl } from "../contol-base.model";
+import { AutocompleteService } from "./autocomplete.service";
+
+@Component({
+  selector: "app-material-autocomplete",
+  templateUrl: "./material-autocomplete.component.html",
+  styleUrls: ["./material-autocomplete.component.scss"]
+})
+export class MaterialAutocompleteComponent implements OnInit {
+  @Input() meta!: MaterialAutocompleteControl;
+  @Input() form!: FormGroup;
+  @Input() debounceTime: number = 800;
+  @Input() minLengthTerm: number = 3;
+  @Input() reset: Observable<void>;
+
+  searchControl: FormControl = new FormControl();
+  controlName: string;
+  filteredItems: any;
+  isLoading = false;
+  errorMsg!: string;
+
+  options: any[];
+
+  setDisabledState?(isDisabled: boolean): void {
+    if (isDisabled) {
+    } else {
+      this.searchControl.enable();
+    }
+  }
+
+  constructor(private autocompleteService: AutocompleteService) {}
+
+  removeTag(tag: string): void {
+    const index = this.form.controls[this.meta.key].value.indexOf(tag);
+
+    if (index >= 0) {
+      this.form.controls[this.meta.key].value.splice(index, 1);
+      this.form.controls[this.meta.key].updateValueAndValidity();
+    }
+  }
+
+  onSelected() {
+    if (this.meta.allowMultipleSelections) {
+      this.form.controls[this.meta.key].setValue([
+        ...this.form.controls[this.meta.key].value,
+        this.searchControl.value
+      ]);
+      this.clearSelection();
+    } else {
+      this.form.controls[this.meta.key].setValue([
+        this.searchControl.value["title"]
+      ]);
+    }
+
+    this.form.controls[this.meta.key].updateValueAndValidity();
+  }
+
+  displayWith(value: any) {
+    return value?.title;
+  }
+
+  clearSelection() {
+    this.searchControl.setValue(null);
+    //this.form.controls[this.meta.key].setValue(null);
+    this.filteredItems = [];
+  }
+
+  ngOnInit() {
+    this.form.valueChanges
+      .pipe(
+        filter((val) => {
+          if (this.searchControl.dirty) {
+            return val;
+          }
+        })
+      )
+      .subscribe((val) => {
+        if (!val[this.meta.key]) {
+          this.searchControl.setValue("");
+        }
+      });
+
+    this.searchControl.valueChanges
+      .pipe(
+        filter((res) => {
+          if (res !== null && res.length >= this.minLengthTerm) {
+            return res;
+          }
+          this.filteredItems = [];
+        }),
+        //distinctUntilChanged(),
+        debounceTime(this.debounceTime),
+        tap((value: string) => {
+          this.errorMsg = "";
+          this.filteredItems = [];
+          this.isLoading = true;
+        }),
+        switchMap((value: string) =>
+          this.autocompleteService.getData(value, this.meta.serviceMethod).pipe(
+            finalize(() => {
+              this.isLoading = false;
+            })
+          )
+        )
+      )
+      .subscribe((data: any) => {
+        if (data == undefined) {
+          this.errorMsg = "Error";
+          this.filteredItems = [];
+        } else {
+          this.errorMsg = "";
+          this.filteredItems = data;
+        }
+      });
+  }
+}

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -1,3 +1,4 @@
+import { ValueConverter } from "@angular/compiler/src/render3/view/template";
 import { Component, OnInit, Input } from "@angular/core";
 import { FormControl, FormGroup } from "@angular/forms";
 import { debounceTime, filter, finalize, switchMap, tap } from "rxjs/operators";
@@ -42,21 +43,24 @@ export class MaterialAutocompleteComponent implements OnInit {
     this.meta &&
       this.form.controls[this.meta.key].valueChanges
         .pipe(
-          filter((res) => {
-            if (res !== null && res.length >= this.minLengthTerm) {
-              return res;
+          filter((inputValue) => {
+            if (
+              inputValue !== null &&
+              inputValue.length >= this.minLengthTerm
+            ) {
+              return inputValue;
             }
-            this.filteredItems = [];
+            // this.filteredItems = [];
           }),
           //distinctUntilChanged(),
           debounceTime(this.debounceTime),
-          tap((value: string) => {
+          tap(() => {
             this.filteredItems = [];
             this.isLoading = true;
           }),
-          switchMap((value: string) =>
+          switchMap((inputValue: string) =>
             this.autocompleteService
-              .getData(value, this.meta.serviceMethod)
+              .getListItems(this.meta.key, inputValue)
               .pipe(
                 finalize(() => {
                   this.isLoading = false;

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -34,6 +34,7 @@ export class MaterialAutocompleteComponent implements OnInit {
   }
 
   clearSelection() {
+    this.form.controls[this.meta.key].setValue("");
     this.filteredItems = [];
   }
 

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -53,6 +53,8 @@ export class MaterialAutocompleteComponent implements OnInit {
               inputValue.length >= this.minLengthTerm
             ) {
               return inputValue;
+            } else {
+              this.filteredItems = [];
             }
           }),
           distinctUntilChanged(),

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -23,7 +23,6 @@ export class MaterialAutocompleteComponent implements OnInit {
   @Input() form!: FormGroup;
   debounceTime: number = 500;
   minLengthTerm: number = 3;
-
   filteredItems: any;
   isLoading: boolean;
   isNoMatches: boolean;

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -16,17 +16,13 @@ export class MaterialAutocompleteComponent implements OnInit {
   debounceTime: number = 800;
   minLengthTerm: number = 3;
 
-  searchControl: FormControl = new FormControl();
   filteredItems: any;
   isLoading: boolean;
   isNoMatches: boolean;
 
   options: any[];
 
-  constructor(
-    private autocompleteService: AutocompleteService,
-    private snackBarService: SnackBarService
-  ) {}
+  constructor(private autocompleteService: AutocompleteService) {}
 
   onSelected() {
     this.form.controls[this.meta.key].updateValueAndValidity();
@@ -42,36 +38,39 @@ export class MaterialAutocompleteComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.form.controls[this.meta.key].valueChanges
-      .pipe(
-        filter((res) => {
-          if (res !== null && res.length >= this.minLengthTerm) {
-            return res;
-          }
-          this.filteredItems = [];
-        }),
-        //distinctUntilChanged(),
-        debounceTime(this.debounceTime),
-        tap((value: string) => {
-          this.filteredItems = [];
-          this.isLoading = true;
-        }),
-        switchMap((value: string) =>
-          this.autocompleteService.getData(value, this.meta.serviceMethod).pipe(
-            finalize(() => {
-              this.isLoading = false;
-            })
+    this.meta &&
+      this.form.controls[this.meta.key].valueChanges
+        .pipe(
+          filter((res) => {
+            if (res !== null && res.length >= this.minLengthTerm) {
+              return res;
+            }
+            this.filteredItems = [];
+          }),
+          //distinctUntilChanged(),
+          debounceTime(this.debounceTime),
+          tap((value: string) => {
+            this.filteredItems = [];
+            this.isLoading = true;
+          }),
+          switchMap((value: string) =>
+            this.autocompleteService
+              .getData(value, this.meta.serviceMethod)
+              .pipe(
+                finalize(() => {
+                  this.isLoading = false;
+                })
+              )
           )
         )
-      )
-      .subscribe((data: any) => {
-        if (data == undefined) {
-          this.isNoMatches = true;
-          this.filteredItems = [];
-        } else {
-          this.filteredItems = data;
-          this.isNoMatches = false;
-        }
-      });
+        .subscribe((data: any) => {
+          if (data?.length) {
+            this.filteredItems = data;
+            this.isNoMatches = false;
+          } else {
+            this.isNoMatches = true;
+            this.filteredItems = [];
+          }
+        });
   }
 }

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -1,7 +1,14 @@
 import { ValueConverter } from "@angular/compiler/src/render3/view/template";
 import { Component, OnInit, Input } from "@angular/core";
 import { FormControl, FormGroup } from "@angular/forms";
-import { debounceTime, filter, finalize, switchMap, tap } from "rxjs/operators";
+import {
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  finalize,
+  switchMap,
+  tap
+} from "rxjs/operators";
 import { SnackBarService } from "../../services/snack-bar/snack-bar.service";
 import { AutocompleteControl } from "../form-contol-base.model";
 import { AutocompleteService } from "./autocomplete.service";
@@ -14,7 +21,7 @@ import { AutocompleteService } from "./autocomplete.service";
 export class MaterialAutocompleteComponent implements OnInit {
   @Input() controlProperties!: AutocompleteControl;
   @Input() form!: FormGroup;
-  debounceTime: number = 800;
+  debounceTime: number = 500;
   minLengthTerm: number = 3;
 
   filteredItems: any;
@@ -51,7 +58,7 @@ export class MaterialAutocompleteComponent implements OnInit {
               return inputValue;
             }
           }),
-          //distinctUntilChanged(),
+          distinctUntilChanged(),
           debounceTime(this.debounceTime),
           tap(() => {
             this.filteredItems = [];
@@ -59,7 +66,7 @@ export class MaterialAutocompleteComponent implements OnInit {
           }),
           switchMap((inputValue: string) =>
             this.autocompleteService
-              .getMatchingItems(this.controlProperties.key, inputValue)
+              .getItems(this.controlProperties.key, inputValue)
               .pipe(
                 finalize(() => {
                   this.isLoading = false;

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -34,10 +34,6 @@ export class MaterialAutocompleteComponent implements OnInit {
     this.form.markAsDirty();
   }
 
-  displayWith(value: any) {
-    return value;
-  }
-
   clearSelection() {
     this.form.controls[this.controlProperties.key].setValue("");
     this.filteredItems = [];

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -12,7 +12,7 @@ import { AutocompleteService } from "./autocomplete.service";
   styleUrls: ["./material-autocomplete.component.scss"]
 })
 export class MaterialAutocompleteComponent implements OnInit {
-  @Input() meta!: AutocompleteControl;
+  @Input() controlProperties!: AutocompleteControl;
   @Input() form!: FormGroup;
   debounceTime: number = 800;
   minLengthTerm: number = 3;
@@ -26,7 +26,7 @@ export class MaterialAutocompleteComponent implements OnInit {
   constructor(private autocompleteService: AutocompleteService) {}
 
   onSelected() {
-    this.form.controls[this.meta.key].updateValueAndValidity();
+    this.form.controls[this.controlProperties.key].updateValueAndValidity();
     this.form.markAsDirty();
   }
 
@@ -35,13 +35,13 @@ export class MaterialAutocompleteComponent implements OnInit {
   }
 
   clearSelection() {
-    this.form.controls[this.meta.key].setValue("");
+    this.form.controls[this.controlProperties.key].setValue("");
     this.filteredItems = [];
   }
 
   ngOnInit() {
-    this.meta &&
-      this.form.controls[this.meta.key].valueChanges
+    this.controlProperties &&
+      this.form.controls[this.controlProperties.key].valueChanges
         .pipe(
           filter((inputValue) => {
             if (
@@ -50,7 +50,6 @@ export class MaterialAutocompleteComponent implements OnInit {
             ) {
               return inputValue;
             }
-            // this.filteredItems = [];
           }),
           //distinctUntilChanged(),
           debounceTime(this.debounceTime),
@@ -60,7 +59,7 @@ export class MaterialAutocompleteComponent implements OnInit {
           }),
           switchMap((inputValue: string) =>
             this.autocompleteService
-              .getListItems(this.meta.key, inputValue)
+              .getMatchingItems(this.controlProperties.key, inputValue)
               .pipe(
                 finalize(() => {
                   this.isLoading = false;

--- a/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
+++ b/src/app/shared/form-controls/material-autocomplete/material-autocomplete.component.ts
@@ -1,6 +1,5 @@
-import { ValueConverter } from "@angular/compiler/src/render3/view/template";
 import { Component, OnInit, Input } from "@angular/core";
-import { FormControl, FormGroup } from "@angular/forms";
+import { FormGroup } from "@angular/forms";
 import {
   debounceTime,
   distinctUntilChanged,
@@ -9,7 +8,6 @@ import {
   switchMap,
   tap
 } from "rxjs/operators";
-import { SnackBarService } from "../../services/snack-bar/snack-bar.service";
 import { AutocompleteControl } from "../form-contol-base.model";
 import { AutocompleteService } from "./autocomplete.service";
 

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
@@ -2,10 +2,13 @@
   <mat-selection-list
     class="mb-20"
     color="primary"
-    [formControlName]="meta.key"
+    [formControlName]="controlProperties.key"
   >
-    <div class="h2">{{ meta.label }}</div>
-    <mat-list-option *ngFor="let option of meta.options" [value]="option.key">
+    <div class="h2">{{ controlProperties.label }}</div>
+    <mat-list-option
+      *ngFor="let option of controlProperties.options"
+      [value]="option.key"
+    >
       {{ option.value }}
     </mat-list-option>
   </mat-selection-list>

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="form">
+<div data-jasmine="formControl" [formGroup]="form">
   <mat-selection-list
     class="mb-20"
     color="primary"

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
@@ -1,0 +1,7 @@
+<div [formGroup]="form">
+  <mat-selection-list [formControlName]="meta.key">
+    <mat-list-option *ngFor="let option of meta.options" [value]="option.key">
+      {{ option.value }}
+    </mat-list-option>
+  </mat-selection-list>
+</div>

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
@@ -1,8 +1,10 @@
 <div [formGroup]="form">
-  <mat-selection-list [formControlName]="meta.key">
-    <div mat-header>
-      <strong>{{ meta.label }}</strong>
-    </div>
+  <mat-selection-list
+    class="mb-20"
+    color="primary"
+    [formControlName]="meta.key"
+  >
+    <div class="h2">{{ meta.label }}</div>
     <mat-list-option *ngFor="let option of meta.options" [value]="option.key">
       {{ option.value }}
     </mat-list-option>

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.html
@@ -1,5 +1,8 @@
 <div [formGroup]="form">
   <mat-selection-list [formControlName]="meta.key">
+    <div mat-header>
+      <strong>{{ meta.label }}</strong>
+    </div>
     <mat-list-option *ngFor="let option of meta.options" [value]="option.key">
       {{ option.value }}
     </mat-list-option>

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MaterialSelectionListComponent } from './material-selection-list.component';
+
+describe('MaterialSelectionListComponent', () => {
+  let component: MaterialSelectionListComponent;
+  let fixture: ComponentFixture<MaterialSelectionListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MaterialSelectionListComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MaterialSelectionListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
@@ -7,7 +7,7 @@ import { MaterialModule } from "src/app/shared/material/material.module";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { By } from "@angular/platform-browser";
 
-fdescribe("MaterialSelectionListComponent", () => {
+describe("MaterialSelectionListComponent", () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { Component, OnInit } from "@angular/core";
 import { MaterialSelectionListComponent } from "./material-selection-list.component";
 import { FormControlBase } from "../form-contol-base.model";
 import { FormControl, FormGroup } from "@angular/forms";
@@ -78,42 +77,4 @@ describe("MaterialSelectionListComponent", () => {
         .innerHTML
     ).toContain("test option value 1");
   });
-
-  //   @Component({
-  //     selector: `host-component`,
-  //     template: `<form [formGroup]="form">
-  //       <app-material-selection-list
-  //         [meta]="meta"
-  //         [form]="form"
-  //       ></app-material-selection-list>
-  //     </form>`
-  //   })
-  //   class TestHostComponent implements OnInit {
-  //     meta: FormControlBase = {
-  //       key: "initialKey",
-  //       label: "initialLabel",
-  //       options: [
-  //         { key: "initialOptionKey1", value: "initial option value 1" },
-  //         { key: "initialOptionKey2", value: "initial option value 2" }
-  //       ],
-  //       order: 1,
-  //       controlType: "selectionList",
-  //       initialValue: []
-  //     };
-  //     form: FormGroup;
-  //     data: any = {};
-
-  //     toFormGroup() {
-  //       const group: any = {};
-  //       group[this.meta.key] = new FormControl(this.data[this.meta.key] || "");
-  //       return new FormGroup(group);
-  //     }
-  //     ngOnInit(): void {
-  //       this.form = this.toFormGroup();
-  //     }
-  //     setMeta(meta: FormControlBase) {
-  //       this.meta = meta;
-  //       this.toFormGroup();
-  //     }
-  //   }
 });

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
@@ -8,19 +8,42 @@ import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { By } from "@angular/platform-browser";
 
 describe("MaterialSelectionListComponent", () => {
-  let component: TestHostComponent;
-  let fixture: ComponentFixture<TestHostComponent>;
+  let component: MaterialSelectionListComponent;
+  let fixture: ComponentFixture<MaterialSelectionListComponent>;
+  let controlProperties: FormControlBase = {
+    key: "initialKey",
+    label: "initialLabel",
+    options: [
+      { key: "initialOptionKey1", value: "initial option value 1" },
+      { key: "initialOptionKey2", value: "initial option value 2" }
+    ],
+    order: 1,
+    controlType: "selectionList",
+    initialValue: []
+  };
+  let form: FormGroup;
+  let data: any = {};
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MaterialModule, FormsModule, ReactiveFormsModule],
-      declarations: [MaterialSelectionListComponent, TestHostComponent]
+      declarations: [
+        MaterialSelectionListComponent,
+        MaterialSelectionListComponent
+      ]
     }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(TestHostComponent);
+    fixture = TestBed.createComponent(MaterialSelectionListComponent);
     component = fixture.componentInstance;
+    component;
+    component.controlProperties = controlProperties;
+    const group: any = {};
+    group[component.controlProperties.key] = new FormControl(
+      data[component.controlProperties.key] || ""
+    );
+    component.form = new FormGroup(group);
     fixture.detectChanges();
   });
 
@@ -36,7 +59,7 @@ describe("MaterialSelectionListComponent", () => {
   });
 
   it("should update the form label when changed", () => {
-    const meta = {
+    component.controlProperties = {
       key: "testKey",
       label: "testLabel",
       options: [
@@ -48,7 +71,6 @@ describe("MaterialSelectionListComponent", () => {
       initialValue: []
     };
 
-    component.setMeta(meta);
     fixture.detectChanges();
 
     expect(
@@ -57,41 +79,41 @@ describe("MaterialSelectionListComponent", () => {
     ).toContain("test option value 1");
   });
 
-  @Component({
-    selector: `host-component`,
-    template: `<form [formGroup]="form">
-      <app-material-selection-list
-        [meta]="meta"
-        [form]="form"
-      ></app-material-selection-list>
-    </form>`
-  })
-  class TestHostComponent implements OnInit {
-    meta: FormControlBase = {
-      key: "initialKey",
-      label: "initialLabel",
-      options: [
-        { key: "initialOptionKey1", value: "initial option value 1" },
-        { key: "initialOptionKey2", value: "initial option value 2" }
-      ],
-      order: 1,
-      controlType: "selectionList",
-      initialValue: []
-    };
-    form: FormGroup;
-    data: any = {};
+  //   @Component({
+  //     selector: `host-component`,
+  //     template: `<form [formGroup]="form">
+  //       <app-material-selection-list
+  //         [meta]="meta"
+  //         [form]="form"
+  //       ></app-material-selection-list>
+  //     </form>`
+  //   })
+  //   class TestHostComponent implements OnInit {
+  //     meta: FormControlBase = {
+  //       key: "initialKey",
+  //       label: "initialLabel",
+  //       options: [
+  //         { key: "initialOptionKey1", value: "initial option value 1" },
+  //         { key: "initialOptionKey2", value: "initial option value 2" }
+  //       ],
+  //       order: 1,
+  //       controlType: "selectionList",
+  //       initialValue: []
+  //     };
+  //     form: FormGroup;
+  //     data: any = {};
 
-    toFormGroup() {
-      const group: any = {};
-      group[this.meta.key] = new FormControl(this.data[this.meta.key] || "");
-      return new FormGroup(group);
-    }
-    ngOnInit(): void {
-      this.form = this.toFormGroup();
-    }
-    setMeta(meta: FormControlBase) {
-      this.meta = meta;
-      this.toFormGroup();
-    }
-  }
+  //     toFormGroup() {
+  //       const group: any = {};
+  //       group[this.meta.key] = new FormControl(this.data[this.meta.key] || "");
+  //       return new FormGroup(group);
+  //     }
+  //     ngOnInit(): void {
+  //       this.form = this.toFormGroup();
+  //     }
+  //     setMeta(meta: FormControlBase) {
+  //       this.meta = meta;
+  //       this.toFormGroup();
+  //     }
+  //   }
 });

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
@@ -29,10 +29,7 @@ describe("MaterialSelectionListComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MaterialModule, FormsModule, ReactiveFormsModule],
-      declarations: [
-        MaterialSelectionListComponent,
-        MaterialSelectionListComponent
-      ]
+      declarations: [MaterialSelectionListComponent]
     }).compileComponents();
   });
 

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
@@ -1,9 +1,13 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MaterialSelectionListComponent } from "./material-selection-list.component";
 import { FormControlBase } from "../form-contol-base.model";
-import { FormControl, FormGroup } from "@angular/forms";
 import { MaterialModule } from "src/app/shared/material/material.module";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule
+} from "@angular/forms";
 import { By } from "@angular/platform-browser";
 
 describe("MaterialSelectionListComponent", () => {
@@ -20,7 +24,6 @@ describe("MaterialSelectionListComponent", () => {
     controlType: "selectionList",
     initialValue: []
   };
-  let form: FormGroup;
   let data: any = {};
 
   beforeEach(async () => {
@@ -36,7 +39,6 @@ describe("MaterialSelectionListComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MaterialSelectionListComponent);
     component = fixture.componentInstance;
-    component;
     component.controlProperties = controlProperties;
     const group: any = {};
     group[component.controlProperties.key] = new FormControl(

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.spec.ts
@@ -1,25 +1,97 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Component, OnInit } from "@angular/core";
+import { MaterialSelectionListComponent } from "./material-selection-list.component";
+import { FormControlBase } from "../form-contol-base.model";
+import { FormControl, FormGroup } from "@angular/forms";
+import { MaterialModule } from "src/app/shared/material/material.module";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { By } from "@angular/platform-browser";
 
-import { MaterialSelectionListComponent } from './material-selection-list.component';
-
-describe('MaterialSelectionListComponent', () => {
-  let component: MaterialSelectionListComponent;
-  let fixture: ComponentFixture<MaterialSelectionListComponent>;
+fdescribe("MaterialSelectionListComponent", () => {
+  let component: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ MaterialSelectionListComponent ]
-    })
-    .compileComponents();
+      imports: [MaterialModule, FormsModule, ReactiveFormsModule],
+      declarations: [MaterialSelectionListComponent, TestHostComponent]
+    }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(MaterialSelectionListComponent);
+    fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
+
+  it("should display the correct form label", () => {
+    expect(
+      fixture.debugElement.queryAll(By.css(".mat-list-text"))[0].nativeElement
+        .innerHTML
+    ).toContain("initial option value 1");
+  });
+
+  it("should update the form label when changed", () => {
+    const meta = {
+      key: "testKey",
+      label: "testLabel",
+      options: [
+        { key: "testOptionKey1", value: "test option value 1" },
+        { key: "testOptionKey2", value: "test option value 2" }
+      ],
+      order: 1,
+      controlType: "selectionList",
+      initialValue: []
+    };
+
+    component.setMeta(meta);
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.queryAll(By.css(".mat-list-text"))[0].nativeElement
+        .innerHTML
+    ).toContain("test option value 1");
+  });
+
+  @Component({
+    selector: `host-component`,
+    template: `<form [formGroup]="form">
+      <app-material-selection-list
+        [meta]="meta"
+        [form]="form"
+      ></app-material-selection-list>
+    </form>`
+  })
+  class TestHostComponent implements OnInit {
+    meta: FormControlBase = {
+      key: "initialKey",
+      label: "initialLabel",
+      options: [
+        { key: "initialOptionKey1", value: "initial option value 1" },
+        { key: "initialOptionKey2", value: "initial option value 2" }
+      ],
+      order: 1,
+      controlType: "selectionList",
+      initialValue: []
+    };
+    form: FormGroup;
+    data: any = {};
+
+    toFormGroup() {
+      const group: any = {};
+      group[this.meta.key] = new FormControl(this.data[this.meta.key] || "");
+      return new FormGroup(group);
+    }
+    ngOnInit(): void {
+      this.form = this.toFormGroup();
+    }
+    setMeta(meta: FormControlBase) {
+      this.meta = meta;
+      this.toFormGroup();
+    }
+  }
 });

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, ChangeDetectorRef } from "@angular/core";
 import { FormGroup } from "@angular/forms";
-import { ControlBase } from "../contol-base.model";
+import { FormControlBase } from "../form-contol-base.model";
 
 @Component({
   selector: "app-material-selection-list",
@@ -8,7 +8,7 @@ import { ControlBase } from "../contol-base.model";
   styleUrls: ["./material-selection-list.component.scss"]
 })
 export class MaterialSelectionListComponent implements OnInit {
-  @Input() meta!: ControlBase;
+  @Input() meta!: FormControlBase;
   @Input() form!: FormGroup;
   constructor() {}
 

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
@@ -4,8 +4,7 @@ import { FormControlBase } from "../form-contol-base.model";
 
 @Component({
   selector: "app-material-selection-list",
-  templateUrl: "./material-selection-list.component.html",
-  styleUrls: ["./material-selection-list.component.scss"]
+  templateUrl: "./material-selection-list.component.html"
 })
 export class MaterialSelectionListComponent implements OnInit {
   @Input() meta!: FormControlBase;

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
@@ -7,7 +7,7 @@ import { FormControlBase } from "../form-contol-base.model";
   templateUrl: "./material-selection-list.component.html"
 })
 export class MaterialSelectionListComponent implements OnInit {
-  @Input() meta!: FormControlBase;
+  @Input() controlProperties!: FormControlBase;
   @Input() form!: FormGroup;
   constructor() {}
 

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, Input, ChangeDetectorRef } from "@angular/core";
+import { FormGroup } from "@angular/forms";
+import { ControlBase } from "../contol-base.model";
+
+@Component({
+  selector: "app-material-selection-list",
+  templateUrl: "./material-selection-list.component.html",
+  styleUrls: ["./material-selection-list.component.scss"]
+})
+export class MaterialSelectionListComponent implements OnInit {
+  @Input() meta!: ControlBase;
+  @Input() form!: FormGroup;
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
+++ b/src/app/shared/form-controls/material-selection-list/material-selection-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ChangeDetectorRef } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { FormControlBase } from "../form-contol-base.model";
 
@@ -6,10 +6,7 @@ import { FormControlBase } from "../form-contol-base.model";
   selector: "app-material-selection-list",
   templateUrl: "./material-selection-list.component.html"
 })
-export class MaterialSelectionListComponent implements OnInit {
+export class MaterialSelectionListComponent {
   @Input() controlProperties!: FormControlBase;
   @Input() form!: FormGroup;
-  constructor() {}
-
-  ngOnInit(): void {}
 }

--- a/src/app/shared/info-dialog/info-dialog.component.spec.ts
+++ b/src/app/shared/info-dialog/info-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA } from "@angular/material/dialog";
-
+import { MaterialModule } from "src/app/shared/material/material.module";
 import { InfoDialogComponent } from "./info-dialog.component";
 
 describe("InfoDialogComponent", () => {
@@ -9,6 +9,7 @@ describe("InfoDialogComponent", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [MaterialModule],
       providers: [{ provide: MAT_DIALOG_DATA, useValue: {} }],
       declarations: [InfoDialogComponent]
     }).compileComponents();

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -11,6 +11,7 @@ import { FileBytesPipe } from "./file-bytes.pipe";
 import { InfoDialogComponent } from "./info-dialog/info-dialog.component";
 import { FormControllerComponent } from "./form-controller/form-controller.component";
 import { MaterialSelectionListComponent } from "./form-controls/material-selection-list/material-selection-list.component";
+import { MaterialAutocompleteComponent } from './form-controls/material-autocomplete/material-autocomplete.component';
 
 const modulePipes = [StripHtmlPipe, FileBytesPipe];
 @NgModule({
@@ -20,7 +21,8 @@ const modulePipes = [StripHtmlPipe, FileBytesPipe];
     ...modulePipes,
     InfoDialogComponent,
     FormControllerComponent,
-    MaterialSelectionListComponent
+    MaterialSelectionListComponent,
+    MaterialAutocompleteComponent
   ],
   imports: [RouterModule, MaterialModule, ReactiveFormsModule, CommonModule],
   exports: [...modulePipes, FormControllerComponent],

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
 import { RouterModule } from "@angular/router";
-
+import { ReactiveFormsModule } from "@angular/forms";
 import { MaterialModule } from "./material/material.module";
 import { ConfirmDialogComponent } from "./confirm-dialog/confirm-dialog.component";
 import { PageNotFoundComponent } from "./page-not-found/page-not-found.component";
@@ -8,6 +9,8 @@ import { ApiService } from "./services/api/api.service";
 import { StripHtmlPipe } from "./strip-html.pipe";
 import { FileBytesPipe } from "./file-bytes.pipe";
 import { InfoDialogComponent } from "./info-dialog/info-dialog.component";
+import { FormControllerComponent } from "./form-controller/form-controller.component";
+import { MaterialSelectionListComponent } from "./form-controls/material-selection-list/material-selection-list.component";
 
 const modulePipes = [StripHtmlPipe, FileBytesPipe];
 @NgModule({
@@ -15,10 +18,12 @@ const modulePipes = [StripHtmlPipe, FileBytesPipe];
     PageNotFoundComponent,
     ConfirmDialogComponent,
     ...modulePipes,
-    InfoDialogComponent
+    InfoDialogComponent,
+    FormControllerComponent,
+    MaterialSelectionListComponent
   ],
-  imports: [RouterModule, MaterialModule],
-  exports: [...modulePipes],
+  imports: [RouterModule, MaterialModule, ReactiveFormsModule, CommonModule],
+  exports: [...modulePipes, FormControllerComponent],
   providers: [ApiService]
 })
 export class SharedModule {}

--- a/src/app/update-connections/update-connetions-btn/update-connetions-btn.component.html
+++ b/src/app/update-connections/update-connetions-btn/update-connetions-btn.component.html
@@ -1,19 +1,27 @@
 <ng-container *ngIf="enableUpdateConnections$ | async; else isDisabled">
   <button
-    mat-menu-item
+    color="primary"
+    mat-icon-button
+    matTooltip="Disable update connections"
+    matTooltipPosition="below"
+    matTooltipShowDelay="500"
     aria-label="Disable update connections"
     (click)="disableUpdateConnection()"
   >
-    Disable update connections
+    <mat-icon>link_off</mat-icon>
   </button>
 </ng-container>
 
 <ng-template #isDisabled>
   <button
-    mat-menu-item
+    color="primary"
+    mat-icon-button
+    matTooltip="Enable update connections"
+    matTooltipPosition="below"
+    matTooltipShowDelay="500"
     aria-label="Enable update connections"
     (click)="enableUpdateConnection()"
   >
-    Enable update connections
+    <mat-icon>link</mat-icon>
   </button>
 </ng-template>

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -4,7 +4,7 @@ export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
   addConcern: "api/concerns",
   addNote: "api/trainee/notes/add",
   allocateAdmin: `api/v1/doctors/assign-admin`,
-  autocomplete: ``,
+  autocomplete: `api/v1/doctors/autocomplete`,
   deleteFile: `api/storage/delete`,
   downloadFile: `api/storage/download`,
   editNote: `api/trainee/notes/edit`,

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -4,6 +4,7 @@ export const APP_URLS_CONFIG: IEnvironment["appUrls"] = {
   addConcern: "api/concerns",
   addNote: "api/trainee/notes/add",
   allocateAdmin: `api/v1/doctors/assign-admin`,
+  autocomplete: ``,
   deleteFile: `api/storage/delete`,
   downloadFile: `api/storage/download`,
   editNote: `api/trainee/notes/edit`,
@@ -43,11 +44,6 @@ export const LONDON_DBCS: string[] = [
   "1-AIIDR8"
 ];
 
-export const ADMIN_ROLES = [
-  "RevalApprover",
-  "RevalAdmin"
-];
+export const ADMIN_ROLES = ["RevalApprover", "RevalAdmin"];
 
-export const APPROVER_ROLES = [
-  "RevalApprover"
-];
+export const APPROVER_ROLES = ["RevalApprover"];

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -14,6 +14,7 @@ export abstract class IEnvironment {
     readonly addConcern: string;
     readonly addNote: string;
     readonly allocateAdmin: string;
+    readonly autocomplete: string;
     readonly deleteFile: string;
     readonly downloadFile: string;
     readonly editNote: string;

--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
     <meta name="theme-color" content="#005eb8" />
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
+      href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp&display=swap"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
     />

--- a/src/scss/utilities/_layout.scss
+++ b/src/scss/utilities/_layout.scss
@@ -17,6 +17,14 @@
   display: flex;
 }
 
+// justify content
+.justify-content-end {
+  justify-content: flex-end;
+}
+.justify-content-start {
+  justify-content: flex-start;
+}
+
 // justify items
 .justify-items-start {
   justify-items: start;

--- a/src/scss/utilities/_spacing-helpers.scss
+++ b/src/scss/utilities/_spacing-helpers.scss
@@ -19,7 +19,7 @@ $space-prefixes: (
   @each $attr-short, $attr-long in $space-prefixes {
     @each $value in $space-values {
       .#{$attr-short}-#{$value} {
-        #{$attr-long}: #{$value}#{"px"};
+        #{$attr-long}: #{$value}#{"px"} !important;
       }
     }
   }

--- a/src/scss/utilities/_spacing-helpers.scss
+++ b/src/scss/utilities/_spacing-helpers.scss
@@ -33,9 +33,10 @@ $space-prefixes: (
       $width: map-get($props, "width");
 
       &#{$colName} {
-        flex: 0 0 $width;
-        min-width: $width;
-
+        &.fixed {
+          flex: 0 0 $width;
+          min-width: $width;
+        }
         @if map-has-key($props, "color") {
           color: map-get($props, "color");
         }

--- a/src/scss/utilities/_utilities.scss
+++ b/src/scss/utilities/_utilities.scss
@@ -1,7 +1,8 @@
 @import "~nhsuk-frontend/packages/core/settings/colours";
 // re-usable styles and mixins
 
-h2 {
+h2,
+.h2 {
   font-size: 12px;
   font-weight: bold;
   padding-bottom: 10px;
@@ -96,6 +97,13 @@ $colour-values: (
 .mat-tab-label,
 .mat-tab-link {
   color: shade($color_nhsuk-black, 100%);
+}
+
+.mat-list-text {
+  font-size: 14px;
+}
+.mat-list-option {
+  height: 36px !important;
 }
 
 .centered {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
-  }
+  },
+  "exclude": ["**/node_modules", "cypress", "cypress.config.ts"]
 }


### PR DESCRIPTION
The search components have been changed, replacing the drop down menu with an icon toolbar. A filter icon has been added to toggle the visibility of the filter panel. An additional icon toggles the summary record columns between the initial fixed width view to responsive. This allows all the columns to be displayed on the screen without the need for horizontal scrolling. Permanently switching the table to responsive columns may impact users on lower resolution screens, hence the reason for allowing the user to toggle between the 2 states. The `Clear all` menu item has been replaced with an X icon within the search control to clear the search. This icon only appears when text is entered into the search input or the summary records are displaying search results.

The records filter panel displays a form containing the possible filters, which at this stage includes programme name only. To easily accommodate additional filters in future plus the possibility of similar filtering capabilities in connections, this filters form is dynamically generated and components have been added to display selection list and autocomplete controls. This approach also matches the current architecture of the records list components.


TICKET No. https://hee-tis.atlassian.net/browse/TIS21-2722