### PR TITLE
fix: blank filter form displayed after loading doctor's detail screen  

### DIFF
--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -123,12 +123,7 @@ describe("Record List Table FIlters", () => {
       }
     });
 
-    component.form = recordsService.toFormGroup(
-      formControls as FormControlBase[],
-      []
-    );
-    component.formControls = formControls;
-
+    recordsService.tableFiltersFormData.next(formControls);
     fixture.detectChanges();
   });
 

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -70,9 +70,9 @@ export class RecordsService {
   public detailsRoute: string;
   public filters: IFilter[];
   public showTableFilters: boolean;
-  public tableFiltersFormData: Subject<
+  public tableFiltersFormData: BehaviorSubject<
     (FormControlBase | AutocompleteControl)[]
-  > = new Subject();
+  > = new BehaviorSubject([]);
 
   // TODO type these
   public clearSearchAction: any;


### PR DESCRIPTION
A bug was spotted whereby when a user navigates from recommendation summary table to the trainee details screen and then clicks the back button to return to the summary, the filter panel is blank since the form data is empty. By swapping the Subject to a BehaviorSubject, the latest value for this form data property is retrieved on subscription. 