### PR TITLE
Feat/restyle multiple programmes

### DIFF
--- a/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
+++ b/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
@@ -19,7 +19,7 @@ describe("Recommendations", () => {
         { value: "COMPLETE", label: "Complete" }
       ]
     };
-    const openProgrammeNameDropdown = (query: string = "General") => {
+    const openProgrammeNameDropdown = (query: string = "General Practice") => {
       cy.get("mat-option").should("not.exist");
       cy.get("[data-cy='formfield_programmeName'] input").type(query);
       cy.wait(2000);
@@ -35,6 +35,7 @@ describe("Recommendations", () => {
 
     const initFilterPanel = () => {
       cy.visit("/recommendations");
+      cy.get("[data-cy='filter-records-button']").first().click();
       cy.get("[data-cy='toggleTableFiltersButton']").click();
       cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
     };

--- a/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
+++ b/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
@@ -53,7 +53,7 @@ describe("Recommendations", () => {
       cy.get(
         "[data-cy='tableFiltersForm'] button[data-jasmine='submitFormButton']"
       ).click();
-      cy.wait(5000);
+      cy.wait(3000);
     };
 
     it("should open and close filter panel when toggle button is clicked", () => {
@@ -131,10 +131,10 @@ describe("Recommendations", () => {
 
             submitForm();
             cy.get("td.cdk-column-programmeName").each(($el) => {
-              expect($el.text()).to.equal(value);
+              expect($el.text().trim()).to.equal(value);
             });
             cy.get("td.cdk-column-designatedBody").each(($el) => {
-              expect($el.text()).to.equal("1-AIIDR8");
+              expect($el.text().trim()).to.equal("1-AIIDR8");
             });
           });
       });
@@ -167,7 +167,7 @@ describe("Recommendations", () => {
         );
         cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
         cy.get("td.cdk-column-designatedBody").each(($el) => {
-          expect($el.text() === "1-AIIDWT").to.be.false;
+          expect($el.text().trim() === "1-AIIDWT").to.be.false;
         });
       });
     });
@@ -201,7 +201,7 @@ describe("Recommendations", () => {
         submitForm();
 
         cy.get("td.cdk-column-gmcOutcome").each(($el) => {
-          expect($el.text()).to.equal("Approved");
+          expect($el.text().trim()).to.equal("Approved");
         });
       });
 
@@ -256,7 +256,7 @@ describe("Recommendations", () => {
         submitForm();
 
         cy.get("td.cdk-column-doctorStatus").each(($el) => {
-          expect($el.text()).to.equal("Draft");
+          expect($el.text().trim()).to.equal("Draft");
         });
       });
 
@@ -356,7 +356,7 @@ describe("Recommendations", () => {
             submitForm();
 
             cy.get("td.cdk-column-programmeName").each(($el) => {
-              expect($el.text()).to.equal(value);
+              expect($el.text().trim()).to.equal(value);
             });
           });
       });
@@ -424,7 +424,7 @@ describe("Recommendations", () => {
             submitForm();
 
             cy.get("td.cdk-column-admin").each(($el) => {
-              expect($el.text()).to.equal(value);
+              expect($el.text().trim()).to.equal(value);
             });
           });
       });

--- a/src/app/details/details-side-nav/details-side-nav.component.html
+++ b/src/app/details/details-side-nav/details-side-nav.component.html
@@ -14,12 +14,18 @@
       <div class="mat-caption" mat-line>GMC No:</div>
       <div mat-line>{{ traineeDetails.gmcNumber }}</div>
     </mat-list-item>
-    <mat-list-item *ngIf="traineeDetails.programmeMembershipType">
+    <mat-list-item>
       <div class="mat-caption" mat-line>Programme membership type:</div>
-      <div mat-line>{{ traineeDetails.programmeMembershipType }}</div>
+      <div mat-line>
+        {{
+          traineeDetails.programmeMembershipType === null
+            ? "N/A"
+            : traineeDetails.programmeMembershipType
+        }}
+      </div>
     </mat-list-item>
     <mat-list-item *ngIf="traineeDetails.programmeName">
-      <div class="mat-caption" mat-line>Programme name:</div>
+      <div class="mat-caption" mat-line>Current programme name:</div>
       <div
         mat-line
         class="programme-names"
@@ -37,10 +43,14 @@
         }}
       </div>
     </mat-list-item>
-    <mat-list-item *ngIf="traineeDetails.curriculumEndDate">
+    <mat-list-item>
       <div class="mat-caption" mat-line>Curriculum end date:</div>
       <div mat-line>
-        {{ traineeDetails.curriculumEndDate | date: dateFormat }}
+        {{
+          traineeDetails.curriculumEndDate === null
+            ? "N/A"
+            : (traineeDetails.curriculumEndDate | date: dateFormat)
+        }}
       </div>
     </mat-list-item>
   </mat-list>

--- a/src/app/details/details-side-nav/details-side-nav.component.html
+++ b/src/app/details/details-side-nav/details-side-nav.component.html
@@ -20,8 +20,13 @@
     </mat-list-item>
     <mat-list-item *ngIf="traineeDetails.programmeName">
       <div class="mat-caption" mat-line>Programme name:</div>
-      <div mat-line>{{ traineeDetails.programmeName }}</div>
+      <div
+        mat-line
+        class="programme-names"
+        [innerHTML]="traineeDetails.programmeName | splitStringToHTML"
+      ></div>
     </mat-list-item>
+
     <mat-list-item>
       <div class="mat-caption" mat-line>Current grade:</div>
       <div mat-line>

--- a/src/app/details/details-side-nav/details-side-nav.component.scss
+++ b/src/app/details/details-side-nav/details-side-nav.component.scss
@@ -26,4 +26,10 @@
       }
     }
   }
+  .programme-names {
+    .split-item {
+      display: block;
+      color: #da291c;
+    }
+  }
 }

--- a/src/app/details/details-side-nav/details-side-nav.component.scss
+++ b/src/app/details/details-side-nav/details-side-nav.component.scss
@@ -13,10 +13,17 @@
       height: 60px;
     }
 
-    .mat-list-text .mat-caption {
-      font-size: 14px;
-      color: tint($color_nhsuk-black, 46%);
-      color: rgba(0, 0, 0, 0.54);
+    .mat-list-text {
+      .mat-line {
+        overflow: auto;
+        white-space: normal;
+        text-overflow: unset;
+      }
+      .mat-caption {
+        font-size: 14px;
+        color: tint($color_nhsuk-black, 46%);
+        color: rgba(0, 0, 0, 0.54);
+      }
     }
   }
 }

--- a/src/app/details/details.module.ts
+++ b/src/app/details/details.module.ts
@@ -23,42 +23,44 @@ import { ReactiveFormsModule } from "@angular/forms";
 import { HttpErrorInterceptor } from "../core/http-error/http-error.interceptor";
 import { NoteCardComponent } from "./notes-drawer/note-card/note-card.component";
 import { ToolBarComponent } from "./tool-bar/tool-bar.component";
+import { SharedModule } from "../shared/shared.module";
 
 @NgModule({
-    // TODO double check if NavBarComponent, DetailsSideNavComponent
-    // are needed to be imported and/or exported as the RecordDetailsComponent
-    // already encapsulate both of them
-    declarations: [
-        NavBarComponent,
-        DetailsSideNavComponent,
-        RecordDetailsComponent,
-        NotesToolBarComponent,
-        NotesDrawerComponent,
-        DeleteCommentDialogueComponent,
-        CommentsComponent,
-        NoteCardComponent,
-        ToolBarComponent
-    ],
-    imports: [
-        CommonModule,
-        MaterialModule,
-        RouterModule,
-        HttpClientModule,
-        ReactiveFormsModule,
-        NgxsModule.forFeature([DetailsSideNavState, NotesDrawerState])
-    ],
-    providers: [
-        DetailsSideNavService,
-        CommentsService,
-        NotesService,
-        { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
-        { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true }
-    ],
-    exports: [
-        NavBarComponent,
-        DetailsSideNavComponent,
-        RecordDetailsComponent,
-        CommentsComponent
-    ]
+  // TODO double check if NavBarComponent, DetailsSideNavComponent
+  // are needed to be imported and/or exported as the RecordDetailsComponent
+  // already encapsulate both of them
+  declarations: [
+    NavBarComponent,
+    DetailsSideNavComponent,
+    RecordDetailsComponent,
+    NotesToolBarComponent,
+    NotesDrawerComponent,
+    DeleteCommentDialogueComponent,
+    CommentsComponent,
+    NoteCardComponent,
+    ToolBarComponent
+  ],
+  imports: [
+    CommonModule,
+    MaterialModule,
+    RouterModule,
+    HttpClientModule,
+    ReactiveFormsModule,
+    SharedModule,
+    NgxsModule.forFeature([DetailsSideNavState, NotesDrawerState])
+  ],
+  providers: [
+    DetailsSideNavService,
+    CommentsService,
+    NotesService,
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true }
+  ],
+  exports: [
+    NavBarComponent,
+    DetailsSideNavComponent,
+    RecordDetailsComponent,
+    CommentsComponent
+  ]
 })
 export class DetailsModule {}

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -21,7 +21,7 @@ export const COLUMN_DATA: [string, string, boolean][] = [
   ["GMC Submission due date", "submissionDate", true],
   ["GMC Status", "gmcOutcome", false],
   ["TIS Status", "doctorStatus", false],
-  ["Programme name", "programmeName", false],
+  ["Current programme name", "programmeName", false],
   ["Programme membership type", "programmeMembershipType", false],
   ["Curriculum end date", "curriculumEndDate", false],
   ["Admin", "admin", false],

--- a/src/app/recommendations/services/recommendations.service.ts
+++ b/src/app/recommendations/services/recommendations.service.ts
@@ -36,7 +36,7 @@ export class RecommendationsService {
     if (snapshot.tableFilters?.admin && admins.items) {
       adminEmail = admins.items?.find(
         (admin: IAdmin) => admin.fullName === snapshot.tableFilters.admin
-      ).email;
+      )?.email;
     }
 
     params = params

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -8,13 +8,7 @@
   <!-- spinner -->
   <div
     *ngIf="data.loading; else notLoading"
-    class="
-      d-flex
-      align-content-center
-      justify-content-center
-      align-items-center
-      progress-spinner
-    "
+    class="d-flex align-content-center justify-content-center align-items-center progress-spinner"
   >
     <mat-spinner></mat-spinner>
   </div>
@@ -129,7 +123,11 @@
                     {{ element[i.name] | date: dateFormat }}
                   </ng-container>
                   <!-- cell value | no formatting needed -->
-                  <ng-template #noPipe>{{ element[i.name] }}</ng-template>
+                  <ng-template #noPipe>
+                    <div
+                      [innerHTML]="element[i.name] | splitStringToHTML"
+                    ></div>
+                  </ng-template>
                 </ng-template>
               </td>
             </ng-container>

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -125,8 +125,12 @@
                   <!-- cell value | no formatting needed -->
                   <ng-template #noPipe>
                     <div
+                      *ngIf="i.name === 'programmeName'; else NotProgramme"
                       [innerHTML]="element[i.name] | splitStringToHTML"
                     ></div>
+                    <ng-template #NotProgramme>
+                      {{ element[i.name] }}
+                    </ng-template>
                   </ng-template>
                 </ng-template>
               </td>

--- a/src/app/records/record-list/record-list.component.scss
+++ b/src/app/records/record-list/record-list.component.scss
@@ -6,6 +6,20 @@
   border-left: solid 4px $color_nhsuk-red;
 }
 
+::ng-deep {
+  .mat-column-programmeName {
+    .split-item {
+      display: block;
+      padding-top: 4px;
+      color: #da291c;
+      font-size: smaller;
+    }
+    &:last-child() {
+      padding-bottom: 4px;
+    }
+  }
+}
+
 // common columns
 @include mat-table-columns(
   (

--- a/src/app/records/record-list/record-list.component.scss
+++ b/src/app/records/record-list/record-list.component.scss
@@ -12,7 +12,6 @@
       display: block;
       padding-top: 4px;
       color: #da291c;
-      font-size: smaller;
     }
     &:last-child() {
       padding-bottom: 4px;

--- a/src/app/records/records.resolver.ts
+++ b/src/app/records/records.resolver.ts
@@ -39,7 +39,7 @@ export class RecordsResolver {
 
   private checkSorting(queryParams: Params, state: any): void {
     if (
-      queryParams.active !== state.sort.active &&
+      queryParams.active !== state.sort.active ||
       queryParams.direction !== state.sort.direction
     ) {
       this.recordsService.sort(queryParams.active, queryParams.direction);

--- a/src/app/shared/pipes/split-string-to-html.pipe.spec.ts
+++ b/src/app/shared/pipes/split-string-to-html.pipe.spec.ts
@@ -1,0 +1,29 @@
+import { SplitStringToHTMLPipe } from "./split-string-to-html.pipe";
+import {
+  BrowserModule,
+  DomSanitizer,
+  SafeHtml
+} from "@angular/platform-browser";
+import { TestBed } from "@angular/core/testing";
+describe("SplitStringToHTMLPipe", () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserModule]
+    });
+  });
+
+  it("create an instance", () => {
+    const domSanitizer = TestBed.inject(DomSanitizer);
+    const pipe = new SplitStringToHTMLPipe(domSanitizer);
+    expect(pipe).toBeTruthy();
+  });
+
+  it("should split string containing '|' into separate <span> elements ", () => {
+    const domSanitizer = TestBed.inject(DomSanitizer);
+    const pipe = new SplitStringToHTMLPipe(domSanitizer);
+    const safeHtml: SafeHtml = pipe.transform("Hello|World", "|");
+    const text = safeHtml["changingThisBreaksApplicationSecurity"];
+    expect(text).toContain("<span class='split-item'>Hello</span>");
+    expect(text).toContain("<span class='split-item'>World</span>");
+  });
+});

--- a/src/app/shared/pipes/split-string-to-html.pipe.ts
+++ b/src/app/shared/pipes/split-string-to-html.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
+@Pipe({
+  name: "splitStringToHTML"
+})
+export class SplitStringToHTMLPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+  transform(value: string, delimiter: string = "|"): SafeHtml {
+    if (value && value.includes(delimiter)) {
+      return this.sanitizer.bypassSecurityTrustHtml(
+        value
+          .split(delimiter)
+          .map((item: string) => `<span class='split-item'>${item}</span>`)
+          .join(" ")
+      );
+    }
+    return value;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -11,10 +11,11 @@ import { FileBytesPipe } from "./file-bytes.pipe";
 import { InfoDialogComponent } from "./info-dialog/info-dialog.component";
 import { FormControllerComponent } from "./form-controller/form-controller.component";
 import { MaterialSelectionListComponent } from "./form-controls/material-selection-list/material-selection-list.component";
-import { MaterialAutocompleteComponent } from './form-controls/material-autocomplete/material-autocomplete.component';
-import { RemoveWhitespacePipe } from './pipes/remove-whitespace.pipe';
+import { MaterialAutocompleteComponent } from "./form-controls/material-autocomplete/material-autocomplete.component";
+import { RemoveWhitespacePipe } from "./pipes/remove-whitespace.pipe";
+import { SplitStringToHTMLPipe } from "./pipes/split-string-to-html.pipe";
 
-const modulePipes = [StripHtmlPipe, FileBytesPipe];
+const modulePipes = [StripHtmlPipe, FileBytesPipe, SplitStringToHTMLPipe];
 @NgModule({
   declarations: [
     PageNotFoundComponent,
@@ -24,7 +25,8 @@ const modulePipes = [StripHtmlPipe, FileBytesPipe];
     FormControllerComponent,
     MaterialSelectionListComponent,
     MaterialAutocompleteComponent,
-    RemoveWhitespacePipe
+    RemoveWhitespacePipe,
+    SplitStringToHTMLPipe
   ],
   imports: [RouterModule, MaterialModule, ReactiveFormsModule, CommonModule],
   exports: [...modulePipes, FormControllerComponent],


### PR DESCRIPTION
A few tweaks to FE in this PR.

- When a doctor has multiple programmes, the data returned includes each programme name separated by a `|`. This is processed in the recommendations summary table and doctors detail side nav via a new pipe that outputs each programme name enclosed in a `<span>` tag to allow displaying on separate lines and custom styling.
- The mat list used in the details side nav restricts content to a single line, which was truncating longer values such as programme name. This is fixed via css changes.
- The Programme name label is updated to Current programme name.
- Bug fix whereby the data in recommendations summary table was sorted by GMC number when page is reset and query string params are present with sort column param set to submission due date. 
- Fix E2E tests
    