### PR TITLE
fix: update environment name from stage to preprod

### DIFF
--- a/src/assets/environments/environment.json
+++ b/src/assets/environments/environment.json
@@ -23,7 +23,7 @@
       "redirectSignOut": "https://revalidation.tis.nhs.uk"
     }
   },
-  "stage": {
+  "preprod": {
     "production": true,
     "name": "stage",
     "siteIds": ["UA-40570867-6"],


### PR DESCRIPTION
The backend core service reuses the sentry environment name for the environment endpoint, the result of that endpoint is used by the frontend to select a set of variables per environment. The sentry environment env var was changed from `stage` to `preprod` in the backend, change the lookup value in the front end to match this change.

The `environment.name` value was left as `stage` as I'm not sure the full impact and this is a quick fix to get the stage app working again.

TIS21-3497
TIS32-3849