### PR TITLE
test:add table check after nav and prior to test

### DIFF
--- a/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
+++ b/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
@@ -33,9 +33,14 @@ describe("Recommendations", () => {
       cy.get("mat-option").should("exist");
     };
 
+    const showAllDoctors = () => {
+      cy.get("[data-cy='filter-records-button']").first().click();
+      cy.get("app-record-list .mat-table").should("exist");
+    };
     const initFilterPanel = () => {
       cy.visit("/recommendations");
-      cy.get("[data-cy='filter-records-button']").first().click();
+      cy.get("app-record-list .mat-table").should("exist");
+      showAllDoctors();
       cy.get("[data-cy='toggleTableFiltersButton']").click();
       cy.get(".filters-drawer-container .mat-drawer-opened").should("exist");
     };


### PR DESCRIPTION
Believe the test is failing due to the value displayed being updated before being read. To fix, the test waits for the doctors table to display before and after clicking the All Doctors tab.