### PR TITLE
feat:reset pagination on filtering

### DIFF
--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.spec.ts
@@ -198,7 +198,7 @@ describe("Record List Table FIlters", () => {
     expect(spySubmitForm).toHaveBeenCalled();
   });
 
-  it("should reset form when 'Clear filters' button is clicked", fakeAsync(() => {
+  fit("should reset form when 'Clear filters' button is clicked", fakeAsync(() => {
     spyOn(router, "navigate");
     const snapshot: RecommendationsStateModel =
       store.snapshot().recommendations;
@@ -212,7 +212,7 @@ describe("Record List Table FIlters", () => {
       queryParams: {
         active: snapshot.sort.active,
         direction: snapshot.sort.direction,
-        pageIndex: snapshot.pageIndex,
+        pageIndex: 0,
         filter: snapshot.filter,
         selectionList1_Key: "selectionList1_OptionKey1",
         selectionList2_Key: "",

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -35,6 +35,7 @@ export class RecordListTableFiltersComponent implements OnInit, OnDestroy {
   }
 
   onSubmit() {
+    this.recordsService.resetPaginator();
     this.subscriptions.add(
       this.recordsService.setTableFilters(this.form.value).subscribe(() => {
         this.recordsService.updateRoute();


### PR DESCRIPTION
An issue was found when a user had paginated through the doctors list and then applied a filter resulting in a blank page even though matching results were found. Now, when the filter is applied, pagination is reset to zero first.  