### PR TITLE
feat:add alpha env variables for callback

### DIFF
--- a/src/assets/environments/environment.json
+++ b/src/assets/environments/environment.json
@@ -45,5 +45,28 @@
       "redirectSignIn": "https://stage-revalidation.tis.nhs.uk",
       "redirectSignOut": "https://stage-revalidation.tis.nhs.uk"
     }
+  },
+  "alpha": {
+    "production": true,
+    "name": "stage",
+    "siteIds": ["UA-40570867-6"],
+    "hotJarId": 1980924,
+    "hotJarSv": 6,
+    "adminsUIHostUri": "https://stage-apps.tis.nhs.uk/",
+    "supportLink": "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
+    "dateFormat": "dd/MM/yyyy",
+    "awsConfig": {
+      "domain": "stage-auth.tis.nhs.uk",
+      "region": "eu-west-2",
+      "scope": ["openid", "aws.cognito.signin.user.admin"],
+      "authenticationFlowType": "USER_PASSWORD_AUTH",
+      "responseType": "token",
+      "userPoolId": "eu-west-2_o5Es6Bpl8",
+      "userPoolWebClientId": "r28c0u6jpc7scm9e2anhh274r",
+      "bucketName": "tis-revalidation-concerns-upload-preprod",
+      "mandatorySignIn": true,
+      "redirectSignIn": "https://alpha-revalidation.tis.nhs.uk",
+      "redirectSignOut": "https://alpha-revalidation.tis.nhs.uk"
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,9 @@ async function initializeApplication(envName: string = "") {
   const redirectKey = "reval_redirectLocation";
   const location = window.location;
 
+  if (location.origin.includes("alpha")) {
+    envName = "alpha";
+  }
   if (
     !location.origin.includes("localhost") &&
     envName.length > 0 &&


### PR DESCRIPTION
Need to set sign/out domain for alpha. Conditional test for alpha domain temporary so detection via `window.location` should suffice.  