### PR TITLE
feat: remove ECS pre-prod deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy-pre-prod-s3:
-    name: Build and deploy to pre-prod S3
+  deploy-pre-prod:
+    name: Build and deploy to pre-prod on S3
     runs-on: ubuntu-latest
     environment: pre-prod
     steps:
@@ -45,6 +45,28 @@ jobs:
 
       - name: Invalidate CDN Cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}} --paths /*.js /*.css /static/*
+
+      - name: Slack Notification - Deploy Success
+        if: success()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: TIS-REVALIDATION-V2
+          SLACK_TITLE: "Successfully deployed to preprod."
+          SLACK_CHANNEL: reval-pipeline
+          SLACK_ICON_EMOJI: ":deploy_yellow:"
+          SLACK_COLOR: FFCC00
+
+      - name: Slack Notification - Deploy Fail
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: TIS-REVALIDATION-V2
+          SLACK_TITLE: "Failed deployment to preprod."
+          SLACK_CHANNEL: reval-pipeline
+          SLACK_ICON_EMOJI: ":deploy_red:"
+          SLACK_COLOR: FF0000
 
   build:
     name: Build
@@ -138,58 +160,6 @@ jobs:
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
 
-  deploy-pre-prod:
-    name: Deploy to pre-prod environment
-    environment: pre-prod
-    needs: dockerize
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-
-      - name: Log in to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: .aws/task-definition.json
-          container-name: reval-fe
-          image: ${{ steps.login-ecr.outputs.registry }}/tis-revalidation-v2:${{ github.sha }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: reval-fe
-          cluster: revalidation-preprod
-          wait-for-service-stability: true
-
-      - name: Slack Notification
-        if: success()
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "TIS-REVALIDATION-V2 has been deployed through the pipeline"
-
-      - name: Slack Notification
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "TIS-REVALIDATION-V2 build has failed in the pipeline"
-          SLACK_COLOR: "#fc1303"
-
   cypress-e2e:
     needs: deploy-pre-prod
     name: Run Cypress E2E tests
@@ -213,6 +183,28 @@ jobs:
           browser: chrome
           record: true
           #TODO: Fix/finish reporting setup
+
+      - name: Slack Notification - E2E Tests Pass
+        if: success()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: TIS-REVALIDATION-V2
+          SLACK_TITLE: "E2E tests passed"
+          SLACK_CHANNEL: reval-pipeline
+          SLACK_ICON_EMOJI: ":test_tube:"
+          SLACK_COLOR: 00CC00
+
+      - name: Slack Notification - E2E Tests Fail
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: TIS-REVALIDATION-V2
+          SLACK_TITLE: "E2E tests failed"
+          SLACK_CHANNEL: reval-pipeline
+          SLACK_ICON_EMOJI: ":test_tube_red:"
+          SLACK_COLOR: FF0000
 
   deploy-prod:
     name: Deploy to production


### PR DESCRIPTION
build, backup-artifacts and dockerise jobs remain fir now as required for deployment to prod ECS.

Add Slack messages to pre prod s3 deploy

TIS21-4043: CI/CD pipeline modification to deploy to S3 in parallel with existing pipeline