### PR TITLE
Test/dbc changes london

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -21,8 +21,6 @@ export class AuthService {
   public isRevalAdmin = false;
   public isRevalApprover = false;
 
-  constructor() {}
-
   currentSession(): Observable<CognitoUserSession> {
     return from(Auth.currentSession()).pipe(
       tap((cognitoUserSession: CognitoUserSession) => {

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -4,7 +4,8 @@ import { CognitoUserSession } from "amazon-cognito-identity-js";
 import { Auth } from "aws-amplify";
 import { from, Observable } from "rxjs";
 import { catchError, tap } from "rxjs/operators";
-import { ADMIN_ROLES, LONDON_DBCS, APPROVER_ROLES } from "src/environments/constants";
+import { ADMIN_ROLES, APPROVER_ROLES } from "src/environments/constants";
+import { environment } from "@environment";
 
 @Injectable({
   providedIn: "root"
@@ -40,10 +41,15 @@ export class AuthService {
         );
 
         let dbcs: string[] = cognitoIdToken.payload["cognito:groups"] || [];
-        this.inludesLondonDbcs = dbcs.some((dbc) => LONDON_DBCS.includes(dbc));
+        let londonDBCodes: string[] = environment.londonDBCs.map(
+          (dbc) => dbc.key
+        );
+        this.inludesLondonDbcs = dbcs.some((dbc) =>
+          londonDBCodes.includes(dbc)
+        );
 
         if (this.inludesLondonDbcs) {
-          dbcs = Array.from(new Set([...LONDON_DBCS, ...dbcs]));
+          dbcs = Array.from(new Set([...londonDBCodes, ...dbcs]));
         }
         this.userDesignatedBodies = dbcs;
       }),

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -1,4 +1,6 @@
 import { Sort } from "@angular/material/sort";
+import { environment } from "@environment";
+
 import {
   RecommendationGmcOutcome,
   RecommendationStatus
@@ -119,12 +121,7 @@ export const TABLE_FILTERS_FORM_BASE: Array<
 export const TABLE_FILTERS_FORM_DBC: FormControlBase = {
   key: "dbcs",
   label: "Designated Body",
-  options: [
-    { key: "1-AIIDR8", value: "Kent, Surrey and Sussex" },
-    { key: "1-AIIDVS", value: "North Central and East London" },
-    { key: "1-AIIDWA", value: "North West London" },
-    { key: "1-AIIDWI", value: "South London" }
-  ],
+  options: environment.londonDBCs,
   order: 4,
   controlType: FormControlType.SELECTION_LIST,
   initialValue: []

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -1,4 +1,4 @@
-import { IAWSConfig, IAppUrls } from "./environment.interface";
+import { IAWSConfig, IAppUrls, IKeyValue } from "./environment.interface";
 
 export const APP_URLS_CONFIG: IAppUrls = {
   addConcern: "api/concerns",
@@ -37,11 +37,17 @@ export const AWS_CONFIG: IAWSConfig = {
   userPoolWebClientId: ""
 };
 
-export const LONDON_DBCS: string[] = [
-  "1-AIIDWA",
-  "1-AIIDVS",
-  "1-AIIDWI",
-  "1-AIIDR8"
+export const LONDON_DBCS: IKeyValue[] = [
+  {
+    key: "1-AIIDR8",
+    value: "Kent, Surrey and Sussex"
+  },
+  {
+    key: "1-AIIDVS",
+    value: "North Central and East London"
+  },
+  { key: "1-AIIDWA", value: "North West London" },
+  { key: "1-AIIDWI", value: "South London" }
 ];
 
 export const ADMIN_ROLES = ["RevalApprover", "RevalAdmin"];

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -7,9 +7,8 @@ export interface IEnvironment {
   readonly production: boolean; // build mode
   readonly siteIds: string[]; // Google analytics site id's
   readonly supportLink: string; // link to tis-support
-
   readonly appUrls: IAppUrls;
-
+  readonly londonDBCs: IKeyValue[];
   readonly awsConfig: IAWSConfig;
 }
 
@@ -48,4 +47,9 @@ export interface IAppUrls {
   readonly saveRecommendation: string;
   readonly submitToGMC: string;
   readonly upload: string;
+}
+
+export interface IKeyValue {
+  key: string;
+  value: string;
 }

--- a/src/environments/environment.preprod.ts
+++ b/src/environments/environment.preprod.ts
@@ -14,7 +14,8 @@ export const environment: IEnvironment = {
   appUrls: APP_URLS_CONFIG,
   londonDBCs: [
     ...LONDON_DBCS,
-    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" }
+    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" },
+    { key: "1-1P9Y9QH", value: "Yorkshire & Humber (DBC TESTING)" }
   ],
 
   awsConfig: {

--- a/src/environments/environment.preprod.ts
+++ b/src/environments/environment.preprod.ts
@@ -1,4 +1,4 @@
-import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { APP_URLS_CONFIG, AWS_CONFIG, LONDON_DBCS } from "./constants";
 import { IEnvironment } from "./environment.interface";
 
 export const environment: IEnvironment = {
@@ -12,6 +12,10 @@ export const environment: IEnvironment = {
     "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
   dateFormat: "dd/MM/yyyy",
   appUrls: APP_URLS_CONFIG,
+  londonDBCs: [
+    ...LONDON_DBCS,
+    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" }
+  ],
 
   awsConfig: {
     ...AWS_CONFIG,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 import { IEnvironment } from "./environment.interface";
-import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { APP_URLS_CONFIG, AWS_CONFIG, LONDON_DBCS } from "./constants";
 
 export const environment: IEnvironment = {
   production: true,
@@ -12,6 +12,7 @@ export const environment: IEnvironment = {
     "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
   dateFormat: "dd/MM/yyyy",
   appUrls: APP_URLS_CONFIG,
+  londonDBCs: LONDON_DBCS,
   awsConfig: {
     ...AWS_CONFIG,
     bucketName: "tis-revalidation-concerns-upload-prod",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
-import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { APP_URLS_CONFIG, AWS_CONFIG, LONDON_DBCS } from "./constants";
 import { IEnvironment } from "./environment.interface";
 
 export const environment: IEnvironment = {
@@ -11,6 +11,10 @@ export const environment: IEnvironment = {
   supportLink: `https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab`,
   dateFormat: "dd/MM/yyyy",
   appUrls: APP_URLS_CONFIG,
+  londonDBCs: [
+    ...LONDON_DBCS,
+    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" }
+  ],
   awsConfig: {
     ...AWS_CONFIG,
     bucketName: "tis-revalidation-concerns-upload-preprod",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,7 +13,8 @@ export const environment: IEnvironment = {
   appUrls: APP_URLS_CONFIG,
   londonDBCs: [
     ...LONDON_DBCS,
-    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" }
+    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" },
+    { key: "1-1P9Y9QH", value: "Yorkshire & Humber (DBC TESTING)" }
   ],
   awsConfig: {
     ...AWS_CONFIG,


### PR DESCRIPTION
Setting YH and NW as London DBCs with new codes on stage environment to make sure the DBC column is shown and DBC filter works as expected. This is part of the testing of Reval prior to the release of new DBC codes by the GMC, 

TIS21-4290