### PR TITLE
feat: update gmc dbc values

### DIFF
--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -67,7 +67,7 @@ describe("AuthService", () => {
 
     service.currentSession().subscribe((curresntSession) => {
       expect(service.inludesLondonDbcs).toBeTruthy();
-      expect(service.userDesignatedBodies.length).toBe(8);
+      expect(service.userDesignatedBodies.length).toBe(6);
     });
   });
 

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -37,19 +37,6 @@ export const AWS_CONFIG: IAWSConfig = {
   userPoolWebClientId: ""
 };
 
-export const LONDON_DBCS: IKeyValue[] = [
-  {
-    key: "1-AIIDR8",
-    value: "Kent, Surrey and Sussex"
-  },
-  {
-    key: "1-AIIDVS",
-    value: "North Central and East London"
-  },
-  { key: "1-AIIDWA", value: "North West London" },
-  { key: "1-AIIDWI", value: "South London" }
-];
-
 export const ADMIN_ROLES = ["RevalApprover", "RevalAdmin"];
 
 export const APPROVER_ROLES = ["RevalApprover"];

--- a/src/environments/environment.preprod.ts
+++ b/src/environments/environment.preprod.ts
@@ -1,4 +1,4 @@
-import { APP_URLS_CONFIG, AWS_CONFIG, LONDON_DBCS } from "./constants";
+import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
 import { IEnvironment } from "./environment.interface";
 
 export const environment: IEnvironment = {
@@ -13,9 +13,16 @@ export const environment: IEnvironment = {
   dateFormat: "dd/MM/yyyy",
   appUrls: APP_URLS_CONFIG,
   londonDBCs: [
-    ...LONDON_DBCS,
-    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" },
-    { key: "1-1P9Y9QH", value: "Yorkshire & Humber (DBC TESTING)" }
+    {
+      key: "1-AIIDR8",
+      value: "Kent, Surrey and Sussex"
+    },
+    {
+      key: "1-AIIDVS",
+      value: "North Central and East London"
+    },
+    { key: "1-AIIDWA", value: "North West London" },
+    { key: "1-AIIDWI", value: "South London" }
   ],
 
   awsConfig: {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -14,15 +14,15 @@ export const environment: IEnvironment = {
   appUrls: APP_URLS_CONFIG,
   londonDBCs: [
     {
-      key: "ADD_NEW_DBC_CODE_HERE",
+      key: "1-1RUZV1D",
       value: "Kent, Surrey and Sussex"
     },
     {
-      key: "ADD_NEW_DBC_CODE_HERE",
+      key: "1-1RUZV4H",
       value: "North Central and East London"
     },
-    { key: "ADD_NEW_DBC_CODE_HERE", value: "North West London" },
-    { key: "ADD_NEW_DBC_CODE_HERE", value: "South London" }
+    { key: "1-1RUZV6H", value: "North West London" },
+    { key: "1-1RSSQ5L", value: "South London" }
   ],
   awsConfig: {
     ...AWS_CONFIG,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 import { IEnvironment } from "./environment.interface";
-import { APP_URLS_CONFIG, AWS_CONFIG, LONDON_DBCS } from "./constants";
+import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
 
 export const environment: IEnvironment = {
   production: true,
@@ -12,7 +12,18 @@ export const environment: IEnvironment = {
     "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
   dateFormat: "dd/MM/yyyy",
   appUrls: APP_URLS_CONFIG,
-  londonDBCs: LONDON_DBCS,
+  londonDBCs: [
+    {
+      key: "ADD_NEW_DBC_CODE_HERE",
+      value: "Kent, Surrey and Sussex"
+    },
+    {
+      key: "ADD_NEW_DBC_CODE_HERE",
+      value: "North Central and East London"
+    },
+    { key: "ADD_NEW_DBC_CODE_HERE", value: "North West London" },
+    { key: "ADD_NEW_DBC_CODE_HERE", value: "South London" }
+  ],
   awsConfig: {
     ...AWS_CONFIG,
     bucketName: "tis-revalidation-concerns-upload-prod",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
-import { APP_URLS_CONFIG, AWS_CONFIG, LONDON_DBCS } from "./constants";
+import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
 import { IEnvironment } from "./environment.interface";
 
 export const environment: IEnvironment = {
@@ -12,9 +12,16 @@ export const environment: IEnvironment = {
   dateFormat: "dd/MM/yyyy",
   appUrls: APP_URLS_CONFIG,
   londonDBCs: [
-    ...LONDON_DBCS,
-    { key: "1-1P9Y9R1", value: "North West (DBC TESTING)" },
-    { key: "1-1P9Y9QH", value: "Yorkshire & Humber (DBC TESTING)" }
+    {
+      key: "1-AIIDR8",
+      value: "Kent, Surrey and Sussex"
+    },
+    {
+      key: "1-AIIDVS",
+      value: "North Central and East London"
+    },
+    { key: "1-AIIDWA", value: "North West London" },
+    { key: "1-AIIDWI", value: "South London" }
   ],
   awsConfig: {
     ...AWS_CONFIG,


### PR DESCRIPTION
This change impacts PROD DBCs only following
the announcement that GMC do not intend to update
the code on their test environment.

When the new codes have been published, the only change required is to update the values in `environment.prod.ts`

TIS21-4239: Add new DBCs to reval front end (Auth service, E2E tests)