### PR TITLE
feat:add configs for alpha environment

### DIFF
--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm install
 
       - name: Build Angular App
-        run: npm run build:misc && npm run build -- --configuration=staging
+        run: npm run build:misc && npm run build -- --configuration=alpha
 
       - name: Deploy app build to S3 bucket
         run: aws s3 sync ./dist/revalidation/ s3://${{ vars.AWS_S3_BUCKET }} --delete

--- a/angular.json
+++ b/angular.json
@@ -180,6 +180,36 @@
                 }
               ]
             },
+            "alpha": {
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ],
+              "serviceWorker": true,
+              "ngswConfigPath": "ngsw-config.json",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.alpha.ts"
+                }
+              ]
+            },
+
             "mocky": {
               "outputHashing": "all"
             }

--- a/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
@@ -94,7 +94,7 @@ export const menuItems: IMenuItem[] = JSON.parse(
             },
             {
                 "type": 0,
-                "env": ["dev","stage"],
+                "env": ["dev","alpha","stage"],
                 "route": "/connections",
                 "name": "Connections",
                 "description": ""

--- a/src/environments/environment.alpha.ts
+++ b/src/environments/environment.alpha.ts
@@ -1,0 +1,39 @@
+import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { IEnvironment } from "./environment.interface";
+
+export const environment: IEnvironment = {
+  production: true,
+  name: "alpha",
+  siteIds: ["UA-40570867-6"],
+  hotJarId: 1980924,
+  hotJarSv: 6,
+  adminsUIHostUri: "https://stage-apps.tis.nhs.uk/",
+  supportLink:
+    "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
+  dateFormat: "dd/MM/yyyy",
+  appUrls: APP_URLS_CONFIG,
+  londonDBCs: [
+    {
+      key: "1-AIIDR8",
+      value: "Kent, Surrey and Sussex"
+    },
+    {
+      key: "1-AIIDVS",
+      value: "North Central and East London"
+    },
+    { key: "1-AIIDWA", value: "North West London" },
+    { key: "1-AIIDWI", value: "South London" }
+  ],
+
+  awsConfig: {
+    ...AWS_CONFIG,
+
+    domain: "stage-auth.tis.nhs.uk",
+    bucketName: "tis-revalidation-concerns-upload-preprod",
+    mandatorySignIn: true,
+    redirectSignIn: "https://alpha-revalidation.tis.nhs.uk",
+    redirectSignOut: "https://alpha-revalidation.tis.nhs.uk",
+    userPoolId: "eu-west-2_o5Es6Bpl8",
+    userPoolWebClientId: "r28c0u6jpc7scm9e2anhh274r"
+  }
+};

--- a/src/environments/environment.alpha.ts
+++ b/src/environments/environment.alpha.ts
@@ -1,39 +1,14 @@
-import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { commonEnv } from "./environment.common";
 import { IEnvironment } from "./environment.interface";
 
-export const environment: IEnvironment = {
-  production: true,
+const env: Partial<IEnvironment> = {
   name: "alpha",
-  siteIds: ["UA-40570867-6"],
+  production: true,
   hotJarId: 1980924,
-  hotJarSv: 6,
-  adminsUIHostUri: "https://stage-apps.tis.nhs.uk/",
-  supportLink:
-    "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
-  dateFormat: "dd/MM/yyyy",
-  appUrls: APP_URLS_CONFIG,
-  londonDBCs: [
-    {
-      key: "1-AIIDR8",
-      value: "Kent, Surrey and Sussex"
-    },
-    {
-      key: "1-AIIDVS",
-      value: "North Central and East London"
-    },
-    { key: "1-AIIDWA", value: "North West London" },
-    { key: "1-AIIDWI", value: "South London" }
-  ],
-
   awsConfig: {
-    ...AWS_CONFIG,
-
-    domain: "stage-auth.tis.nhs.uk",
-    bucketName: "tis-revalidation-concerns-upload-preprod",
-    mandatorySignIn: true,
     redirectSignIn: "https://alpha-revalidation.tis.nhs.uk",
-    redirectSignOut: "https://alpha-revalidation.tis.nhs.uk",
-    userPoolId: "eu-west-2_o5Es6Bpl8",
-    userPoolWebClientId: "r28c0u6jpc7scm9e2anhh274r"
+    redirectSignOut: "https://alpha-revalidation.tis.nhs.uk"
   }
 };
+
+export const environment = { ...commonEnv, ...env };

--- a/src/environments/environment.common.ts
+++ b/src/environments/environment.common.ts
@@ -1,0 +1,36 @@
+import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { IEnvironment } from "./environment.interface";
+
+export const commonEnv: IEnvironment = {
+  production: false,
+  name: "dev",
+  siteIds: ["UA-40570867-6"],
+  hotJarId: 1662399,
+  hotJarSv: 6,
+  adminsUIHostUri: `https://stage-apps.tis.nhs.uk/`,
+  supportLink: `https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab`,
+  dateFormat: "dd/MM/yyyy",
+  appUrls: APP_URLS_CONFIG,
+  londonDBCs: [
+    {
+      key: "1-AIIDR8",
+      value: "Kent, Surrey and Sussex"
+    },
+    {
+      key: "1-AIIDVS",
+      value: "North Central and East London"
+    },
+    { key: "1-AIIDWA", value: "North West London" },
+    { key: "1-AIIDWI", value: "South London" }
+  ],
+  awsConfig: {
+    ...AWS_CONFIG,
+    bucketName: "tis-revalidation-concerns-upload-preprod",
+    domain: "stage-auth.tis.nhs.uk",
+    mandatorySignIn: true,
+    redirectSignIn: "http://localhost:4200",
+    redirectSignOut: "http://localhost:4200",
+    userPoolId: "eu-west-2_o5Es6Bpl8",
+    userPoolWebClientId: "r28c0u6jpc7scm9e2anhh274r"
+  }
+};

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -9,7 +9,7 @@ export interface IEnvironment {
   readonly supportLink: string; // link to tis-support
   readonly appUrls: IAppUrls;
   readonly londonDBCs: IKeyValue[];
-  readonly awsConfig: IAWSConfig;
+  readonly awsConfig: Partial<IAWSConfig>;
 }
 
 export interface IAWSConfig {

--- a/src/environments/environment.preprod.ts
+++ b/src/environments/environment.preprod.ts
@@ -1,39 +1,16 @@
-import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { commonEnv } from "./environment.common";
 import { IEnvironment } from "./environment.interface";
 
-export const environment: IEnvironment = {
-  production: true,
+const env: Partial<IEnvironment> = {
   name: "stage",
+  production: true,
   siteIds: ["UA-40570867-6"],
   hotJarId: 1980924,
-  hotJarSv: 6,
-  adminsUIHostUri: "https://stage-apps.tis.nhs.uk/",
-  supportLink:
-    "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
-  dateFormat: "dd/MM/yyyy",
-  appUrls: APP_URLS_CONFIG,
-  londonDBCs: [
-    {
-      key: "1-AIIDR8",
-      value: "Kent, Surrey and Sussex"
-    },
-    {
-      key: "1-AIIDVS",
-      value: "North Central and East London"
-    },
-    { key: "1-AIIDWA", value: "North West London" },
-    { key: "1-AIIDWI", value: "South London" }
-  ],
 
   awsConfig: {
-    ...AWS_CONFIG,
-
-    domain: "stage-auth.tis.nhs.uk",
-    bucketName: "tis-revalidation-concerns-upload-preprod",
-    mandatorySignIn: true,
     redirectSignIn: "https://stage-revalidation.tis.nhs.uk",
-    redirectSignOut: "https://stage-revalidation.tis.nhs.uk",
-    userPoolId: "eu-west-2_o5Es6Bpl8",
-    userPoolWebClientId: "r28c0u6jpc7scm9e2anhh274r"
+    redirectSignOut: "https://stage-revalidation.tis.nhs.uk"
   }
 };
+
+export const environment = { ...commonEnv, ...env };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,17 +1,11 @@
+import { commonEnv } from "./environment.common";
 import { IEnvironment } from "./environment.interface";
-import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
 
-export const environment: IEnvironment = {
-  production: true,
+const env: Partial<IEnvironment> = {
   name: "prod",
-  siteIds: ["UA-40570867-6"],
+  production: true,
   hotJarId: 3168055,
-  hotJarSv: 6,
   adminsUIHostUri: "https://apps.tis.nhs.uk/",
-  supportLink:
-    "https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab",
-  dateFormat: "dd/MM/yyyy",
-  appUrls: APP_URLS_CONFIG,
   londonDBCs: [
     {
       key: "1-1RUZV1D",
@@ -25,13 +19,12 @@ export const environment: IEnvironment = {
     { key: "1-1RSSQ5L", value: "South London" }
   ],
   awsConfig: {
-    ...AWS_CONFIG,
     bucketName: "tis-revalidation-concerns-upload-prod",
     domain: "auth.tis.nhs.uk",
-    mandatorySignIn: true,
     redirectSignIn: "https://revalidation.tis.nhs.uk",
     redirectSignOut: "https://revalidation.tis.nhs.uk",
     userPoolId: "eu-west-2_r3l1XtMDD",
     userPoolWebClientId: "4o37rm9tbid1u066hr500be5n3"
   }
 };
+export const environment = { ...commonEnv, ...env };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,38 +1,7 @@
-import { APP_URLS_CONFIG, AWS_CONFIG } from "./constants";
+import { commonEnv } from "./environment.common";
 import { IEnvironment } from "./environment.interface";
 
-export const environment: IEnvironment = {
-  production: false,
-  name: "dev",
-  siteIds: ["UA-40570867-6"],
-  hotJarId: 1662399,
-  hotJarSv: 6,
-  adminsUIHostUri: `https://stage-apps.tis.nhs.uk/`,
-  supportLink: `https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab`,
-  dateFormat: "dd/MM/yyyy",
-  appUrls: APP_URLS_CONFIG,
-  londonDBCs: [
-    {
-      key: "1-AIIDR8",
-      value: "Kent, Surrey and Sussex"
-    },
-    {
-      key: "1-AIIDVS",
-      value: "North Central and East London"
-    },
-    { key: "1-AIIDWA", value: "North West London" },
-    { key: "1-AIIDWI", value: "South London" }
-  ],
-  awsConfig: {
-    ...AWS_CONFIG,
-    bucketName: "tis-revalidation-concerns-upload-preprod",
-    domain: "stage-auth.tis.nhs.uk",
-    redirectSignIn: "http://localhost:4200",
-    redirectSignOut: "http://localhost:4200",
-    userPoolId: "eu-west-2_o5Es6Bpl8",
-    userPoolWebClientId: "r28c0u6jpc7scm9e2anhh274r"
-  }
-};
+export const environment: IEnvironment = commonEnv;
 
 /*
  * For easier debugging in development mode, you can import the following file


### PR DESCRIPTION
The main reason for creating the separate alpha environment is to enable the `redirectSignIn` and `redirectSignOut` properties to point to the alpha domain instead of stage.

Relates to this closed PR
https://github.com/Health-Education-England/tis-revalidation-v2/pull/1081

NO TICKET