### PR TITLE
fix:awsConfig env variables being overwritten

### DIFF
--- a/src/environments/environment.alpha.ts
+++ b/src/environments/environment.alpha.ts
@@ -11,4 +11,8 @@ const env: Partial<IEnvironment> = {
   }
 };
 
-export const environment = { ...commonEnv, ...env };
+export const environment = {
+  ...commonEnv,
+  ...env,
+  awsConfig: { ...commonEnv.awsConfig, ...env.awsConfig }
+};

--- a/src/environments/environment.preprod.ts
+++ b/src/environments/environment.preprod.ts
@@ -13,4 +13,8 @@ const env: Partial<IEnvironment> = {
   }
 };
 
-export const environment = { ...commonEnv, ...env };
+export const environment = {
+  ...commonEnv,
+  ...env,
+  awsConfig: { ...commonEnv.awsConfig, ...env.awsConfig }
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -27,4 +27,8 @@ const env: Partial<IEnvironment> = {
     userPoolWebClientId: "4o37rm9tbid1u066hr500be5n3"
   }
 };
-export const environment = { ...commonEnv, ...env };
+export const environment = {
+  ...commonEnv,
+  ...env,
+  awsConfig: { ...commonEnv.awsConfig, ...env.awsConfig }
+};


### PR DESCRIPTION
The awsConfig settings are in a nested object in the env variables. The spread operator was simply overwriting rather than appending to these properties. Fix to append the awsConfig separately.
Relates to this closed PR
https://github.com/Health-Education-England/tis-revalidation-v2/pull/1082

NO TICKET