### PR TITLE
feat: disable recommendation submit on click

### DIFF
--- a/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.html
+++ b/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.html
@@ -21,9 +21,7 @@
         I am the appointed or nominated Responsible Officer for each medical
         practitioner named below.
       </p>
-      <p>
-        I have read the criteria for recommendations to revalidate.
-      </p>
+      <p>I have read the criteria for recommendations to revalidate.</p>
       <p>
         In determining my revalidation recommendation to the General Medical
         Council for the medical practitioners named below, it is my judgement
@@ -84,9 +82,7 @@
         I am the appointed or nominated Responsible Officer for the medical
         practitioner to whom this deferral request applies.
       </p>
-      <p>
-        I have read the criteria for a deferral and I am satisfied that:
-      </p>
+      <p>I have read the criteria for a deferral and I am satisfied that:</p>
       <ul>
         <li>
           the medical practitioner has engaged with the systems and processes
@@ -141,9 +137,7 @@
         I am the appointed or nominated Responsible Officer for the medical
         practitioner to whom this notification of non-engagement applies.
       </p>
-      <p>
-        I have read the criteria for non-engagement and I confirm that:
-      </p>
+      <p>I have read the criteria for non-engagement and I confirm that:</p>
 
       <ul>
         <li>
@@ -186,7 +180,7 @@
   <mat-divider></mat-divider>
   <section class="w-100 mt-20">
     <mat-slide-toggle
-      class="example-margin"
+      data-jasmine="toggleConfirm"
       color="primary"
       formControlName="confirm"
     >
@@ -204,13 +198,14 @@
       Back
     </button>
     <button
+      data-jasmine="buttonSubmit"
       mat-button
       mat-raised-button
       color="primary"
       type="submit"
-      [disabled]="form.invalid"
+      [disabled]="form.invalid || isFormSubmitting"
     >
-      Submit to GMC
+      {{ isFormSubmitting ? "Submitting..." : "Submit to GMC" }}
     </button>
     <span class="spacer"></span>
     <button

--- a/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.spec.ts
+++ b/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.spec.ts
@@ -3,16 +3,23 @@ import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
-import { NgxsModule } from "@ngxs/store";
+import { NgxsModule, Store } from "@ngxs/store";
 import { MaterialModule } from "../../shared/material/material.module";
 import { RecommendationHistoryState } from "../state/recommendation-history.state";
-
+import { RecommendationHistoryService } from "../services/recommendation-history.service";
 import { ConfirmRecommendationComponent } from "./confirm-recommendation.component";
-
+import { HarnessLoader } from "@angular/cdk/testing";
+import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
+import { MatButtonHarness } from "@angular/material/button/testing";
+import { MatSlideToggleHarness } from "@angular/material/slide-toggle/testing";
 describe("ConfirmRecommendationComponent", () => {
+  let store: Store;
+  let recommendationHistoryService: RecommendationHistoryService;
   let component: ConfirmRecommendationComponent;
   let fixture: ComponentFixture<ConfirmRecommendationComponent>;
-
+  let loader: HarnessLoader;
+  const toggleConfirmSelector = { selector: "[data-jasmine='toggleConfirm']" };
+  const submitButtonSelector = { selector: "[data-jasmine='buttonSubmit']" };
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ConfirmRecommendationComponent],
@@ -25,15 +32,81 @@ describe("ConfirmRecommendationComponent", () => {
         NgxsModule.forRoot([RecommendationHistoryState])
       ]
     }).compileComponents();
+    store = TestBed.inject(Store);
+    recommendationHistoryService = TestBed.inject(RecommendationHistoryService);
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfirmRecommendationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
+
+    store.reset({
+      recommendationHistory: {
+        item: {
+          revalidations: [
+            {
+              gmcNumber: "123456789",
+              recommendationId: "abcdefghijklmnopqrstuvwxyz",
+              gmcOutcome: null,
+              recommendationType: "REVALIDATE",
+              gmcSubmissionDate: "2022-10-31",
+              actualSubmissionDate: null,
+              gmcRevalidationId: null,
+              recommendationStatus: "READY_TO_REVIEW",
+              deferralDate: null,
+              deferralReason: null,
+              deferralSubReason: null,
+              deferralComment: null,
+              comments: [],
+              admin: ""
+            }
+          ]
+        }
+      }
+    });
     fixture.detectChanges();
   });
 
-  it("should create", () => {
+  fit("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  fit("should disable form submission by default", async () => {
+    const buttonSubmitElement = await loader.getHarness(
+      MatButtonHarness.with(submitButtonSelector)
+    );
+    expect(await buttonSubmitElement.isDisabled()).toBe(true);
+  });
+
+  fit("should enable and disable form submit when toggling confirm", async () => {
+    const toggleConfirmElement = await loader.getHarness(
+      MatSlideToggleHarness.with(toggleConfirmSelector)
+    );
+    const buttonSubmitElement = await loader.getHarness(
+      MatButtonHarness.with(submitButtonSelector)
+    );
+
+    await toggleConfirmElement.check();
+
+    expect(await buttonSubmitElement.isDisabled()).toBe(false);
+    await toggleConfirmElement.uncheck();
+    expect(await buttonSubmitElement.isDisabled()).toBe(true);
+  });
+  fit("should disable form when submit button clicked", async () => {
+    spyOn(recommendationHistoryService, "submitRecommendationToGMC");
+    const toggleConfirmElement = await loader.getHarness(
+      MatSlideToggleHarness.with(toggleConfirmSelector)
+    );
+    const buttonSubmitElement = await loader.getHarness(
+      MatButtonHarness.with(submitButtonSelector)
+    );
+
+    await toggleConfirmElement.check();
+    await buttonSubmitElement.click();
+
+    fixture.detectChanges();
+    expect(await buttonSubmitElement.isDisabled()).toBe(true);
+    expect(await buttonSubmitElement.getText()).toBe("Submitting...");
   });
 });

--- a/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.ts
+++ b/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Select, Store } from "@ngxs/store";
 import { Observable, of } from "rxjs";
-import { catchError, filter, take, tap } from "rxjs/operators";
+import { catchError, filter, finalize, take, tap } from "rxjs/operators";
 import { SnackBarService } from "../../shared/services/snack-bar/snack-bar.service";
 import {
   IRecommendationHistory,
@@ -11,7 +11,7 @@ import {
   RecommendationType
 } from "../recommendation-history.interface";
 import { RecommendationHistoryService } from "../services/recommendation-history.service";
-import { Get, Post } from "../state/recommendation-history.actions";
+import { Get } from "../state/recommendation-history.actions";
 import { RecommendationHistoryState } from "../state/recommendation-history.state";
 
 @Component({
@@ -24,7 +24,7 @@ export class ConfirmRecommendationComponent implements OnInit {
   public recommendationId: string;
   public recommendationType = RecommendationType;
   public designatedBody: string;
-
+  isFormSubmitting: boolean;
   @Select(RecommendationHistoryState.currentRecommendationType)
   public currentRecommendationType$: Observable<string>;
 
@@ -47,6 +47,7 @@ export class ConfirmRecommendationComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.isFormSubmitting = false;
     this.setupForm();
     this.getCurrentRecommendation();
   }
@@ -58,6 +59,7 @@ export class ConfirmRecommendationComponent implements OnInit {
   }
 
   public submitToGMC(): void {
+    this.isFormSubmitting = true;
     this.recommendationHistoryService
       .submitRecommendationToGMC(
         this.gmcNumber,
@@ -76,7 +78,8 @@ export class ConfirmRecommendationComponent implements OnInit {
               "Your recommendation was successfully submitted to GMC"
             )
           )
-        )
+        ),
+        finalize(() => (this.isFormSubmitting = false))
       )
       .subscribe(() => {
         this.store


### PR DESCRIPTION
Repeated clicking of button to submit recommendation triggers multiple requests to the GMC, which they have flagged. The button is now disabled after the first click preventing subsequent clicking until after the submission is complete.

TIS21-4371: Prevent repeated clicking of Submit to GMC button during submission