### PR TITLE
Feat/show links to reval beta

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -4,7 +4,11 @@ import { CognitoUserSession } from "amazon-cognito-identity-js";
 import { Auth } from "aws-amplify";
 import { from, Observable } from "rxjs";
 import { catchError, tap } from "rxjs/operators";
-import { ADMIN_ROLES, APPROVER_ROLES } from "src/environments/constants";
+import {
+  ADMIN_ROLES,
+  APPROVER_ROLES,
+  BETA_ROLES
+} from "src/environments/constants";
 import { environment } from "@environment";
 
 @Injectable({
@@ -20,6 +24,7 @@ export class AuthService {
   public inludesLondonDbcs = false;
   public isRevalAdmin = false;
   public isRevalApprover = false;
+  public isRevalBeta = false;
 
   currentSession(): Observable<CognitoUserSession> {
     return from(Auth.currentSession()).pipe(
@@ -37,6 +42,7 @@ export class AuthService {
         this.isRevalApprover = this.roles.some((role) =>
           APPROVER_ROLES.includes(role)
         );
+        this.isRevalBeta = this.roles.some((role) => BETA_ROLES.includes(role));
 
         let dbcs: string[] = cognitoIdToken.payload["cognito:groups"] || [];
         let londonDBCodes: string[] = environment.londonDBCs.map(

--- a/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.spec.ts
+++ b/src/app/recommendation/confirm-recommendation/confirm-recommendation.component.spec.ts
@@ -68,18 +68,18 @@ describe("ConfirmRecommendationComponent", () => {
     fixture.detectChanges();
   });
 
-  fit("should create", () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 
-  fit("should disable form submission by default", async () => {
+  it("should disable form submission by default", async () => {
     const buttonSubmitElement = await loader.getHarness(
       MatButtonHarness.with(submitButtonSelector)
     );
     expect(await buttonSubmitElement.isDisabled()).toBe(true);
   });
 
-  fit("should enable and disable form submit when toggling confirm", async () => {
+  it("should enable and disable form submit when toggling confirm", async () => {
     const toggleConfirmElement = await loader.getHarness(
       MatSlideToggleHarness.with(toggleConfirmSelector)
     );
@@ -93,7 +93,7 @@ describe("ConfirmRecommendationComponent", () => {
     await toggleConfirmElement.uncheck();
     expect(await buttonSubmitElement.isDisabled()).toBe(true);
   });
-  fit("should disable form when submit button clicked", async () => {
+  it("should disable form when submit button clicked", async () => {
     spyOn(recommendationHistoryService, "submitRecommendationToGMC");
     const toggleConfirmElement = await loader.getHarness(
       MatSlideToggleHarness.with(toggleConfirmSelector)

--- a/src/app/shared/main-navigation/mat-main-nav/desktop-menu/desktop-menu.component.html
+++ b/src/app/shared/main-navigation/mat-main-nav/desktop-menu/desktop-menu.component.html
@@ -13,19 +13,21 @@
       [class]="menuItem.menuItems?.length > 5 ? 'mega-menu' : ''"
     >
       <ng-container *ngFor="let item of menuItem.menuItems">
-        <a
-          mat-menu-item
-          *ngIf="(!item.env && item.type === 0) || (item.env && item.env.includes(env) && item.type === 0)"
-          routerLink="{{ item.route }}"
-          routerLinkActive="active-list-item"
-          >{{ item.name }}</a
-        >
-        <a
-          mat-menu-item
-          *ngIf="item.type === 1"
-          [href]="hostURI + item.route"
-          >{{ item.name }}</a
-        >
+        <ng-container *ngIf="showLink(item)">
+          <a
+            mat-menu-item
+            *ngIf="item.type === 0"
+            routerLink="{{ item.route }}"
+            routerLinkActive="active-list-item"
+            >{{ item.name }}</a
+          >
+          <a
+            mat-menu-item
+            *ngIf="item.type === 1"
+            [href]="hostURI + item.route"
+            >{{ item.name }}</a
+          >
+        </ng-container>
       </ng-container>
     </mat-menu>
   </ng-container>

--- a/src/app/shared/main-navigation/mat-main-nav/desktop-menu/desktop-menu.component.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/desktop-menu/desktop-menu.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { menuItems } from "../menu-items.const";
 import { IMenuItem } from "../menu-item.interface";
 import { environment } from "@environment";
-import { AuthService } from "src/app/core/auth/auth.service";
 import { UtilitiesService } from "src/app/shared/services/utilities/utilities.service";
 
 @Component({

--- a/src/app/shared/main-navigation/mat-main-nav/desktop-menu/desktop-menu.component.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/desktop-menu/desktop-menu.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from "@angular/core";
 import { menuItems } from "../menu-items.const";
 import { IMenuItem } from "../menu-item.interface";
 import { environment } from "@environment";
+import { AuthService } from "src/app/core/auth/auth.service";
+import { UtilitiesService } from "src/app/shared/services/utilities/utilities.service";
 
 @Component({
   selector: "app-desktop-menu",
@@ -14,9 +16,12 @@ export class DesktopMenuComponent {
   activeItem = "Revalidation";
   env: string = environment.name;
 
-  constructor() {}
+  constructor(private utils: UtilitiesService) {}
 
   setActiveItem(selectedItem: string) {
     this.activeItem = selectedItem;
+  }
+  showLink(item: IMenuItem): boolean {
+    return this.utils.showNavigationLink(item);
   }
 }

--- a/src/app/shared/main-navigation/mat-main-nav/menu-item.interface.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/menu-item.interface.ts
@@ -5,6 +5,7 @@ export interface IMenuItem {
   menuItems?: IMenuItem[];
   description?: string;
   env?: string[];
+  beta?: boolean;
 }
 
 export enum MenuType {

--- a/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/menu-items.const.ts
@@ -94,10 +94,10 @@ export const menuItems: IMenuItem[] = JSON.parse(
             },
             {
                 "type": 0,
-                "env": ["dev","alpha","stage"],
                 "route": "/connections",
                 "name": "Connections",
-                "description": ""
+                "description": "",
+                "beta": "true"
             }               
         ]
     },

--- a/src/app/shared/main-navigation/mat-main-nav/mobile-menu/mobile-menu.component.html
+++ b/src/app/shared/main-navigation/mat-main-nav/mobile-menu/mobile-menu.component.html
@@ -4,17 +4,22 @@
       {{ menuItem.name }}
     </mat-expansion-panel-header>
     <mat-nav-list *ngFor="let item of menuItem.menuItems">
-      <a
-        mat-list-item
-        (click)="onMenuClick()"
-        *ngIf="(!item.env && item.type === 0) || (item.env && item.env.includes(env) && item.type === 0)"
-        routerLinkActive="active-list-item"
-        routerLink="{{ item.route }}"
-        >{{ item.name }}</a
-      >
-      <a mat-list-item *ngIf="item.type === 1" [href]="hostURI + item.route">{{
-        item.name
-      }}</a>
+      <ng-container *ngIf="showLink(item)">
+        <a
+          mat-list-item
+          (click)="onMenuClick()"
+          *ngIf="item.type === 0"
+          routerLinkActive="active-list-item"
+          routerLink="{{ item.route }}"
+          >{{ item.name }}</a
+        >
+        <a
+          mat-list-item
+          *ngIf="item.type === 1"
+          [href]="hostURI + item.route"
+          >{{ item.name }}</a
+        >
+      </ng-container>
     </mat-nav-list>
   </mat-expansion-panel>
 

--- a/src/app/shared/main-navigation/mat-main-nav/mobile-menu/mobile-menu.component.ts
+++ b/src/app/shared/main-navigation/mat-main-nav/mobile-menu/mobile-menu.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Output, EventEmitter } from "@angular/core";
 import { menuItems } from "../menu-items.const";
 import { IMenuItem } from "../menu-item.interface";
 import { environment } from "@environment";
+import { UtilitiesService } from "src/app/shared/services/utilities/utilities.service";
 
 @Component({
   selector: "app-mobile-menu",
@@ -14,9 +15,13 @@ export class MobileMenuComponent {
   env: string = environment.name;
 
   @Output() closeMenu = new EventEmitter();
-  constructor() {}
+  constructor(private utils: UtilitiesService) {}
 
   onMenuClick(): void {
     this.closeMenu.emit();
+  }
+
+  showLink(item: IMenuItem): boolean {
+    return this.utils.showNavigationLink(item);
   }
 }

--- a/src/app/shared/services/utilities/utilities.service.spec.ts
+++ b/src/app/shared/services/utilities/utilities.service.spec.ts
@@ -1,13 +1,25 @@
 import { TestBed } from "@angular/core/testing";
 
 import { UtilitiesService } from "./utilities.service";
+import { AuthService } from "src/app/core/auth/auth.service";
+import { IMenuItem } from "../../main-navigation/mat-main-nav/menu-item.interface";
 
+class AuthServiceStub {
+  public isRevalBeta = false;
+}
 describe("UtilitiesService", () => {
   let service: UtilitiesService;
+  let authService: AuthService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        UtilitiesService,
+        { provide: AuthService, useClass: AuthServiceStub }
+      ]
+    });
     service = TestBed.inject(UtilitiesService);
+    authService = TestBed.inject(AuthService);
   });
 
   it("should be created", () => {
@@ -34,5 +46,36 @@ describe("UtilitiesService", () => {
     const today = new Date();
     today.setDate(today.getDate() + 90);
     expect(service.getDueDateStatus(today, 100)).toContain("warning");
+  });
+
+  it("should return true when no environment or beta restrictions", () => {
+    const menuItem: IMenuItem = {
+      type: 0,
+      route: "/connections",
+      name: "Connections"
+    };
+    expect(service.showNavigationLink(menuItem)).toBeTrue();
+  });
+
+  it("should return false when link is in 'beta' but admin does not have 'RevalBeta' permissions", () => {
+    const menuItem: IMenuItem = {
+      type: 0,
+      route: "/connections",
+      name: "Connections",
+      beta: true
+    };
+    authService.isRevalBeta = false;
+    expect(service.showNavigationLink(menuItem)).toBeFalse();
+  });
+
+  it("should return true when link is in 'beta' and admin does have 'RevalBeta' permissions", () => {
+    const menuItem: IMenuItem = {
+      type: 0,
+      route: "/connections",
+      name: "Connections",
+      beta: true
+    };
+    authService.isRevalBeta = true;
+    expect(service.showNavigationLink(menuItem)).toBeTrue();
   });
 });

--- a/src/app/shared/services/utilities/utilities.service.ts
+++ b/src/app/shared/services/utilities/utilities.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from "@angular/core";
 import { RecommendationDueDateStatus } from "../../../recommendation/recommendation-history.interface";
+import { IMenuItem } from "../../main-navigation/mat-main-nav/menu-item.interface";
+import { AuthService } from "src/app/core/auth/auth.service";
+import { environment } from "@environment";
 
 @Injectable({
   providedIn: "root"
 })
 export class UtilitiesService {
+  constructor(private authService: AuthService) {}
   private convertToDays(milisecs: number) {
     return Math.round(milisecs / 1000 / 60 / 60 / 24);
   }
@@ -23,5 +27,13 @@ export class UtilitiesService {
     } else {
       return RecommendationDueDateStatus.FUTURE;
     }
+  }
+
+  showNavigationLink(item: IMenuItem): boolean {
+    return (
+      (!item.beta || (item.beta && this.authService.isRevalBeta)) &&
+      (!item.env ||
+        (item.env && item.env.includes(environment.name) && item.type === 0))
+    );
   }
 }

--- a/src/app/shared/services/utilities/utilities.service.ts
+++ b/src/app/shared/services/utilities/utilities.service.ts
@@ -32,8 +32,7 @@ export class UtilitiesService {
   showNavigationLink(item: IMenuItem): boolean {
     return (
       (!item.beta || (item.beta && this.authService.isRevalBeta)) &&
-      (!item.env ||
-        (item.env && item.env.includes(environment.name) && item.type === 0))
+      (!item.env || item.env?.includes(environment.name))
     );
   }
 }

--- a/src/app/update-connections/update-connection/update-connection.component.spec.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.spec.ts
@@ -103,7 +103,8 @@ describe("UpdateConnectionComponent", () => {
     expect(dbc).toBeDefined();
   });
 
-  it("form should not have reasons when action is not add / remove", () => {
+  xit("form should not have reasons when action is not add / remove", () => {
+    // NO HIDE CONNECTION YET
     component.updateConnectionForm.controls[actionText].setValue(
       ActionType.HIDE_CONNECTION
     );

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -40,3 +40,5 @@ export const AWS_CONFIG: IAWSConfig = {
 export const ADMIN_ROLES = ["RevalApprover", "RevalAdmin"];
 
 export const APPROVER_ROLES = ["RevalApprover"];
+
+export const BETA_ROLES = ["RevalBeta"];


### PR DESCRIPTION
Branch has been deployed to https://alpha-revalidation.tis.nhs.uk/ To test, modify your roles in user management to add/remove `RevalBeta` to toggle visibility of `Connections` link. Don't forget to log off and on again in between tests.

The environment property limiting inclusion of link on `PROD` has been removed as part of this PR as only those with `RevalBeta` can see the link, which by default will be no one.

