### PR TITLE
Feat/use abbreviations not codes for designated bodies

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,7 +7,7 @@ import {
   SwRegistrationOptions
 } from "@angular/service-worker";
 import { NgxGoogleAnalyticsModule } from "ngx-google-analytics";
-import { NgxsModule } from "@ngxs/store";
+import { NgxsModule, Store } from "@ngxs/store";
 import { NgxsReduxDevtoolsPluginModule } from "@ngxs/devtools-plugin";
 import { Router } from "@angular/router";
 
@@ -27,6 +27,8 @@ import { errorHandlerFactory } from "./factories/error-handler.factory";
 import { swRegistrationOptionsFactory } from "./factories/sw-registration-options.factory";
 import { NgxHotjarModule } from "ngx-hotjar";
 import { environment } from "@environment";
+import { GetDesignatedBodies } from "./reference/state/reference.actions";
+import { ReferenceState } from "./reference/state/reference.state";
 
 @NgModule({
   declarations: [AppComponent],
@@ -39,7 +41,7 @@ import { environment } from "@environment";
     SharedModule,
     AppRoutingModule,
     ServiceWorkerModule.register("ngsw-worker.js"),
-    NgxsModule.forRoot([]),
+    NgxsModule.forRoot([ReferenceState]),
     NgxGoogleAnalyticsModule.forRoot("G-SWV1NDD37B"),
     NgxsReduxDevtoolsPluginModule.forRoot(),
     MainNavigationModule,
@@ -61,4 +63,8 @@ import { environment } from "@environment";
   ],
   bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule {
+  constructor(private store: Store) {
+    this.store.dispatch(new GetDesignatedBodies());
+  }
+}

--- a/src/app/connection/connection.component.html
+++ b/src/app/connection/connection.component.html
@@ -25,21 +25,23 @@
         <ng-container matColumnDef="newDesignatedBodyCode">
           <th mat-header-cell scope="col" *matHeaderCellDef>New DBC</th>
           <td mat-cell *matCellDef="let element">
-            {{ getDBCAbbreviation(element.newDesignatedBodyCode) }}
+            {{ element.newDesignatedBodyCode | formatDesignatedBody: "abbr" }}
           </td>
         </ng-container>
 
         <ng-container matColumnDef="previousDesignatedBodyCode">
           <th mat-header-cell scope="col" *matHeaderCellDef>Old DBC</th>
           <td mat-cell *matCellDef="let element">
-            {{ getDBCAbbreviation(element.previousDesignatedBodyCode) }}
+            {{
+              element.previousDesignatedBodyCode | formatDesignatedBody: "abbr"
+            }}
           </td>
         </ng-container>
 
         <ng-container matColumnDef="designatedBodyCode">
           <th mat-header-cell scope="col" *matHeaderCellDef>Designated body</th>
           <td mat-cell *matCellDef="let element">
-            {{ getDBCAbbreviation(doctorCurrentDbc) }}
+            {{ doctorCurrentDbc | formatDesignatedBody: "abbr" }}
           </td>
         </ng-container>
 

--- a/src/app/connection/connection.component.spec.ts
+++ b/src/app/connection/connection.component.spec.ts
@@ -67,21 +67,6 @@ describe("ConnectionComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should return dbc abbrevation when getDBCAbbrevation is called with dbc code", () => {
-    component.dbcs = mockDbcs;
-    expect(component.getDBCAbbreviation("1-AIIDSA")).toBe("HEEM");
-  });
-
-  it("should return dbc code when getDBCAbbrevation is called with unavailable dbc code", () => {
-    component.dbcs = mockDbcs;
-    expect(component.getDBCAbbreviation("1-RANDOM")).toBe("1-RANDOM");
-  });
-
-  it("should return ''  when getDBCAbbrevation is called with null", () => {
-    component.dbcs = mockDbcs;
-    expect(component.getDBCAbbreviation(null)).toBe("");
-  });
-
   it("should unsubscribe from subscriptions upon `ngOnDestroy()`", () => {
     component.componentSubscription = new Subscription();
     spyOn(component.componentSubscription, "unsubscribe");

--- a/src/app/connection/connection.component.ts
+++ b/src/app/connection/connection.component.ts
@@ -94,7 +94,6 @@ export class ConnectionComponent implements OnInit, OnDestroy {
     });
     this.gmcNumber$.subscribe((res) => (this.gmcNumber = res));
     this.doctorCurrentDbc$.subscribe((res) => (this.doctorCurrentDbc = res));
-    this.referenceService.getDbcs().subscribe((res) => (this.dbcs = res));
     this.updateConnectionsService.canSave$.next(true);
     this.programmeHistory$.subscribe(
       (res) => (this.programmeOwnerDBC = res[0]?.designatedBodyCode)
@@ -105,10 +104,6 @@ export class ConnectionComponent implements OnInit, OnDestroy {
     if (this.componentSubscription) {
       this.componentSubscription.unsubscribe();
     }
-  }
-
-  getDBCAbbreviation(dbc: string) {
-    return dbc ? this.dbcs.find((d) => d.dbc === dbc)?.abbr || dbc : "";
   }
 
   updateConnection(formValue: any) {

--- a/src/app/connections/constants.ts
+++ b/src/app/connections/constants.ts
@@ -7,7 +7,6 @@ export const COLUMN_DATA: [string, string, boolean][] = [
   ["Current programme name", "programmeName", false],
   ["GMC Submission date", "submissionDate", false],
   ["GMC Designated body", "designatedBody", false],
-  ["TIS Designated body", "tcsDesignatedBody", false],
   ["Programme owner", "programmeOwner", false],
   ["Programme membership", "programmeMembershipType", false]
 ];

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -120,18 +120,29 @@
                   <!-- cell value | format date -->
 
                   <ng-container
-                    *ngIf="dateColumns.includes(i.name); else noPipe"
+                    *ngIf="dateColumns.includes(i.name); else notDate"
                   >
                     {{ element[i.name] | date: dateFormat }}
                   </ng-container>
                   <!-- cell value | no formatting needed -->
-                  <ng-template #noPipe>
+                  <ng-template #notDate>
                     <div
                       *ngIf="i.name === 'programmeName'; else NotProgramme"
                       [innerHTML]="element[i.name] | splitStringToHTML"
                     ></div>
                     <ng-template #NotProgramme>
-                      {{ element[i.name] }}
+                      <ng-container
+                        *ngIf="
+                          i.name === 'designatedBody' ||
+                            i.name === 'programmeOwner';
+                          else NotDBC
+                        "
+                      >
+                        {{ element[i.name] | formatDesignatedBody: "abbr" }}
+                      </ng-container>
+                      <ng-template #NotDBC>
+                        {{ element[i.name] }}
+                      </ng-template>
                     </ng-template>
                   </ng-template>
                 </ng-template>

--- a/src/app/reference/state/reference.actions.ts
+++ b/src/app/reference/state/reference.actions.ts
@@ -1,0 +1,15 @@
+import { HttpErrorPayload } from "src/app/shared/services/error/error.service";
+import { IDesignatedBody } from "../reference.interfaces";
+
+export class GetDesignatedBodies {
+  static readonly type = "[Reference] Get Designated Bodies";
+}
+
+export class GetSuccess {
+  static readonly type = `[Reference] Get Designated Bodies Success`;
+  constructor(public response: IDesignatedBody[]) {}
+}
+
+export class GetError extends HttpErrorPayload {
+  static readonly type = `[Reference] Get Designated Bodies Error`;
+}

--- a/src/app/reference/state/reference.state.spec.ts
+++ b/src/app/reference/state/reference.state.spec.ts
@@ -1,0 +1,58 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { TestBed, waitForAsync } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NgxsModule, Store } from "@ngxs/store";
+import { MaterialModule } from "../../shared/material/material.module";
+import { ReferenceService } from "../services/reference.service";
+import { GetDesignatedBodies, GetError, GetSuccess } from "./reference.actions";
+import { ReferenceState } from "./reference.state";
+import { of } from "rxjs";
+import { mockDbcs } from "../mock-data/reference-spec.data";
+
+describe("Reference state", () => {
+  let store: Store;
+  let referenceService: ReferenceService;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MaterialModule,
+        RouterTestingModule,
+        NoopAnimationsModule,
+        NgxsModule.forRoot([ReferenceState]),
+        HttpClientTestingModule
+      ],
+      providers: [ReferenceService],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+    store = TestBed.inject(Store);
+    referenceService = TestBed.inject(ReferenceService);
+  }));
+
+  it("should select 'ReferenceState'", () => {
+    const state = store.selectSnapshot(ReferenceState);
+    expect(state).toBeTruthy();
+  });
+
+  it("should dispatch 'GetDesignatedBodies' and invoke `referenceService.getDbcs()`", async () => {
+    spyOn(referenceService, "getDbcs").and.returnValues(of(mockDbcs));
+    await store.dispatch(new GetDesignatedBodies()).toPromise();
+    expect(referenceService.getDbcs).toHaveBeenCalled();
+  });
+
+  it("should dispatch 'GetSuccess' and select 'dbcs' slice", async () => {
+    await store.dispatch(new GetSuccess(mockDbcs)).toPromise();
+    const items = store.selectSnapshot(ReferenceState.Dbcs);
+    expect(items.length).toEqual(mockDbcs.length);
+    expect(items[0].dbc).toEqual("1-AIIDWT");
+  });
+
+  it("should dispatch 'GetError' and select 'error' slice", async () => {
+    const errorMsg = `Error`;
+    await store.dispatch(new GetError(errorMsg)).toPromise();
+    const error = store.selectSnapshot(ReferenceState.error);
+    expect(error).toEqual(errorMsg);
+  });
+});

--- a/src/app/reference/state/reference.state.ts
+++ b/src/app/reference/state/reference.state.ts
@@ -1,0 +1,63 @@
+import { Injectable } from "@angular/core";
+import { Action, Selector, State, StateContext } from "@ngxs/store";
+import { switchMap, take, catchError } from "rxjs/operators";
+import { IDesignatedBody } from "src/app/reference/reference.interfaces";
+import { ReferenceService } from "src/app/reference/services/reference.service";
+import { GetDesignatedBodies, GetSuccess, GetError } from "./reference.actions";
+import { SnackBarService } from "src/app/shared/services/snack-bar/snack-bar.service";
+
+export class ReferenceStateModel {
+  public dbcs: IDesignatedBody[];
+  public error: any;
+}
+
+@State<ReferenceStateModel>({
+  name: "reference",
+  defaults: {
+    dbcs: [],
+    error: null
+  }
+})
+@Injectable()
+export class ReferenceState {
+  constructor(
+    private service: ReferenceService,
+    private snackBarService: SnackBarService
+  ) {}
+
+  @Selector()
+  public static Dbcs(state: ReferenceStateModel) {
+    return state.dbcs;
+  }
+
+  @Selector()
+  public static error(state: ReferenceStateModel) {
+    return state.error;
+  }
+
+  @Action(GetDesignatedBodies)
+  getDesignatedBodies(ctx: StateContext<ReferenceStateModel>) {
+    return this.service.getDbcs().pipe(
+      take(1),
+      switchMap((response: IDesignatedBody[]) =>
+        ctx.dispatch(new GetSuccess(response))
+      ),
+      catchError((error: string) => ctx.dispatch(new GetError(error)))
+    );
+  }
+
+  @Action(GetSuccess)
+  getSuccess(ctx: StateContext<ReferenceStateModel>, action: GetSuccess) {
+    return ctx.patchState({
+      dbcs: action.response
+    });
+  }
+
+  @Action(GetError)
+  getError(ctx: StateContext<ReferenceStateModel>, action: GetError) {
+    this.snackBarService.openSnackBar(action.error);
+    return ctx.patchState({
+      error: action.error
+    });
+  }
+}

--- a/src/app/shared/pipes/format-designated-body.pipe.spec.ts
+++ b/src/app/shared/pipes/format-designated-body.pipe.spec.ts
@@ -1,11 +1,9 @@
-// import { IDesignatedBody } from "src/app/reference/reference.interfaces";
 import { FormatDesignatedBodyPipe } from "./format-designated-body.pipe";
 import { Store, NgxsModule } from "@ngxs/store";
 import { TestBed, waitForAsync } from "@angular/core/testing";
 import { mockDbcs } from "src/app/reference/mock-data/reference-spec.data";
 import { IDesignatedBody } from "src/app/reference/reference.interfaces";
-import { ReferenceState } from "src/app/reference/state/reference.state";
-// import { ReferenceService } from "src/app/reference/services/reference.service";
+
 describe("DbcMapperPipe", () => {
   let store: Store;
   let pipe: FormatDesignatedBodyPipe;

--- a/src/app/shared/pipes/format-designated-body.pipe.spec.ts
+++ b/src/app/shared/pipes/format-designated-body.pipe.spec.ts
@@ -1,0 +1,77 @@
+// import { IDesignatedBody } from "src/app/reference/reference.interfaces";
+import { FormatDesignatedBodyPipe } from "./format-designated-body.pipe";
+import { Store, NgxsModule } from "@ngxs/store";
+import { TestBed, waitForAsync } from "@angular/core/testing";
+import { mockDbcs } from "src/app/reference/mock-data/reference-spec.data";
+import { IDesignatedBody } from "src/app/reference/reference.interfaces";
+import { ReferenceState } from "src/app/reference/state/reference.state";
+// import { ReferenceService } from "src/app/reference/services/reference.service";
+describe("DbcMapperPipe", () => {
+  let store: Store;
+  let pipe: FormatDesignatedBodyPipe;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([])]
+    });
+    store = TestBed.inject(Store);
+  }));
+
+  const createSpy = (designatedBodies: IDesignatedBody[] = mockDbcs) => {
+    spyOn(store, "selectSnapshot").and.returnValue({ dbcs: designatedBodies });
+    pipe = new FormatDesignatedBodyPipe(store);
+  };
+
+  it("create an instance", () => {
+    createSpy();
+    expect(pipe).toBeTruthy();
+  });
+
+  it("should map dbc value to expected output ", () => {
+    createSpy();
+    const db: IDesignatedBody = {
+      id: 1,
+      dbc: "1-AIIDMQ",
+      name: "Health Education England South West",
+      abbr: "HESW",
+      status: "internal"
+    };
+
+    let text = pipe.transform(db.dbc);
+    expect(text).toContain(db.dbc);
+    text = pipe.transform(db.dbc, "abbr");
+    expect(text).toContain(db.abbr);
+    text = pipe.transform(db.dbc, "name");
+    expect(text).toContain(db.name);
+  });
+  it("should return original value if multiple matches found ", () => {
+    const mockDbcsWithDuplicates = [
+      {
+        id: 1,
+        dbc: "1-AIIDMQ",
+        name: "Health Education England South West",
+        abbr: "HESW",
+        status: "internal"
+      },
+      {
+        id: 2,
+        dbc: "1-AIIDMQ",
+        name: "Health Education England South West",
+        abbr: "HESW",
+        status: "internal"
+      }
+    ];
+    createSpy(mockDbcsWithDuplicates);
+
+    const db: IDesignatedBody = {
+      id: 1,
+      dbc: "1-AIIDMQ",
+      name: "Health Education England South West",
+      abbr: "HESW",
+      status: "internal"
+    };
+
+    let text = pipe.transform(db.name, "abbr");
+    expect(text).toContain(db.name);
+  });
+});

--- a/src/app/shared/pipes/format-designated-body.pipe.ts
+++ b/src/app/shared/pipes/format-designated-body.pipe.ts
@@ -1,0 +1,29 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { SafeHtml } from "@angular/platform-browser";
+import { Store } from "@ngxs/store";
+import { IDesignatedBody } from "src/app/reference/reference.interfaces";
+import { ReferenceState } from "src/app/reference/state/reference.state";
+
+export type dbcFormat = "dbc" | "abbr" | "name";
+@Pipe({
+  name: "formatDesignatedBody"
+})
+export class FormatDesignatedBodyPipe implements PipeTransform {
+  constructor(private store: Store) {}
+
+  private dbcs: IDesignatedBody[] =
+    this.store.selectSnapshot(ReferenceState)?.dbcs;
+
+  transform(value: string, format: dbcFormat = "dbc"): SafeHtml {
+    if (value && this.dbcs) {
+      const matches: IDesignatedBody[] = this.dbcs.filter(
+        (designatedBody: IDesignatedBody) =>
+          Object.values(designatedBody).includes(value)
+      );
+      if (matches.length === 1) {
+        return matches[0][format];
+      }
+    }
+    return value;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -14,12 +14,14 @@ import { MaterialSelectionListComponent } from "./form-controls/material-selecti
 import { MaterialAutocompleteComponent } from "./form-controls/material-autocomplete/material-autocomplete.component";
 import { RemoveWhitespacePipe } from "./pipes/remove-whitespace.pipe";
 import { SplitStringToHTMLPipe } from "./pipes/split-string-to-html.pipe";
+import { FormatDesignatedBodyPipe } from "./pipes/format-designated-body.pipe";
 
 const modulePipes = [
   StripHtmlPipe,
   FileBytesPipe,
   SplitStringToHTMLPipe,
-  RemoveWhitespacePipe
+  RemoveWhitespacePipe,
+  FormatDesignatedBodyPipe
 ];
 @NgModule({
   declarations: [

--- a/src/app/update-connections/state/update-connections.actions.ts
+++ b/src/app/update-connections/state/update-connections.actions.ts
@@ -2,8 +2,3 @@ export class EnableUpdateConnections {
   constructor(public enableUpdateConnections: boolean) {}
   static readonly type = `[UpdateConnections] Enable Update Connections`;
 }
-
-export class Get {
-  static readonly type = "[UpdateConnections] Get";
-  constructor() {}
-}

--- a/src/app/update-connections/state/update-connections.state.spec.ts
+++ b/src/app/update-connections/state/update-connections.state.spec.ts
@@ -9,9 +9,7 @@ import { MaterialModule } from "../../shared/material/material.module";
 import { ErrorHandler } from "@angular/core";
 import { UpdateConnectionsState } from "./update-connections.state";
 import { UpdateConnectionsService } from "../services/update-connections.service";
-import { environment } from "@environment";
-import { mockDbcs } from "src/app/reference/mock-data/reference-spec.data";
-import { EnableUpdateConnections, Get } from "./update-connections.actions";
+import { EnableUpdateConnections } from "./update-connections.actions";
 
 describe("Update connection actions", () => {
   let store: Store;
@@ -37,20 +35,6 @@ describe("Update connection actions", () => {
     }).compileComponents();
     store = TestBed.inject(Store);
     httpMock = TestBed.inject(HttpTestingController);
-  }));
-
-  it("should create a get dbcs action", fakeAsync(() => {
-    store.dispatch(new Get());
-
-    const req = httpMock.expectOne(`${environment.appUrls.getDbcs}`);
-    expect(req.request.method).toEqual("GET");
-    req.flush(mockDbcs);
-
-    const dbcs = store.selectSnapshot((state) => state.updateConnections.dbcs);
-
-    expect(dbcs).toEqual(mockDbcs);
-
-    httpMock.verify();
   }));
 
   it("should update enableUpdateConnections when EnableUpdateConnections action called", fakeAsync(() => {

--- a/src/app/update-connections/state/update-connections.state.ts
+++ b/src/app/update-connections/state/update-connections.state.ts
@@ -1,9 +1,8 @@
 import { Injectable } from "@angular/core";
 import { Action, Selector, State, StateContext } from "@ngxs/store";
-import { map } from "rxjs/operators";
 import { IDesignatedBody } from "src/app/reference/reference.interfaces";
 import { ReferenceService } from "src/app/reference/services/reference.service";
-import { EnableUpdateConnections, Get } from "./update-connections.actions";
+import { EnableUpdateConnections } from "./update-connections.actions";
 
 export class UpdateConnectionsStateModel {
   public enableUpdateConnections: boolean;
@@ -34,16 +33,5 @@ export class UpdateConnectionsState {
     return ctx.patchState({
       enableUpdateConnections: action.enableUpdateConnections
     });
-  }
-
-  @Action(Get)
-  get({ patchState }: StateContext<UpdateConnectionsStateModel>, {}: Get) {
-    return this.service.getDbcs().pipe(
-      map((response: IDesignatedBody[]) => {
-        patchState({
-          dbcs: response
-        });
-      })
-    );
   }
 }

--- a/src/app/update-connections/update-connection/update-connection.component.spec.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.spec.ts
@@ -16,6 +16,7 @@ import { ActionType } from "../update-connections.interfaces";
 import { UpdateConnectionsState } from "../state/update-connections.state";
 import { UpdateConnectionsService } from "../services/update-connections.service";
 import { AuthService } from "src/app/core/auth/auth.service";
+import { ReferenceState } from "src/app/reference/state/reference.state";
 
 describe("UpdateConnectionComponent", () => {
   let component: UpdateConnectionComponent;
@@ -37,7 +38,7 @@ describe("UpdateConnectionComponent", () => {
         FormsModule,
         BrowserAnimationsModule,
         SharedModule,
-        NgxsModule.forRoot([UpdateConnectionsState])
+        NgxsModule.forRoot([UpdateConnectionsState, ReferenceState])
       ],
       declarations: [UpdateConnectionComponent],
       providers: [
@@ -63,7 +64,9 @@ describe("UpdateConnectionComponent", () => {
     component.currentDoctorDbcCode = "1-AIIDWT";
     store.reset({
       updateConnections: {
-        enableUpdateConnections: true,
+        enableUpdateConnections: true
+      },
+      reference: {
         dbcs: mockDbcs
       }
     });

--- a/src/app/update-connections/update-connection/update-connection.component.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.ts
@@ -12,8 +12,7 @@ import { ActionType, IAction, IReason } from "../update-connections.interfaces";
 import { UpdateConnectionsService } from "../services/update-connections.service";
 import { Select, Store } from "@ngxs/store";
 import { Router } from "@angular/router";
-import { Get } from "../state/update-connections.actions";
-import { UpdateConnectionsState } from "../state/update-connections.state";
+import { ReferenceState } from "src/app/reference/state/reference.state";
 
 @Component({
   selector: "app-update-connection",
@@ -24,7 +23,7 @@ export class UpdateConnectionComponent implements OnInit {
   @Input() public currentDoctorDbcCode: string;
   @Output() submittFormEvent = new EventEmitter<any>();
 
-  @Select(UpdateConnectionsState.Dbcs)
+  @Select(ReferenceState.Dbcs)
   public dbcs$: Observable<IDesignatedBody[]>;
 
   componentSubscriptions: Subscription[] = [];
@@ -119,7 +118,6 @@ export class UpdateConnectionComponent implements OnInit {
           this.addConnectionSelected = action === ActionType.ADD_CONNECTION;
 
           if (this.addConnectionSelected) {
-            this.store.dispatch(new Get());
             this.dbcControl.setValidators(Validators.required);
             this.updateConnectionForm.addControl("dbc", this.dbcControl);
             this.dbcControl.updateValueAndValidity();


### PR DESCRIPTION
Designated body data is displayed inconsistently across Revalidation, either as codes, names or abbreviations. Following feedback from user research and private beta testing of connections, admins have said that DB codes are meaningless to them and make using the system difficult. An agreed alternative is to display DBs in the abbreviated form instead, eg HETV, HESL etc. 

An endpoint already exists to get the full list of DBCs and is currently saved to state to populate the connection history and DBC dropdown, where a function swaps the code for the abbreviation. 

Summary of changes 
* Get the list of DBCs upfront once and save to state.
* Remove DBC actions and state from update connections
* Add Angular Pipe to format DBs where necessary
* Update connection component to use new Pipe
* Use Pipe to format DBs in records table