### PR TITLE
Feat/add link to records list

### DIFF
--- a/src/app/connection/connection.resolver.spec.ts
+++ b/src/app/connection/connection.resolver.spec.ts
@@ -10,6 +10,7 @@ import { MaterialModule } from "../shared/material/material.module";
 import { ConnectionState } from "./state/connection.state";
 import { Get } from "./state/connection.actions";
 import { mockConnectionResponse } from "./mock-data/conneciton-details-spec-data";
+import { RecordsService } from "../records/services/records.service";
 
 @Component({
   template: `blank`
@@ -20,6 +21,7 @@ describe("ConnectionResolver", () => {
   let router: Router;
   let store: Store;
   let resolver: ConnectionResolver;
+  let service: RecordsService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -34,8 +36,9 @@ describe("ConnectionResolver", () => {
     }).compileComponents();
 
     store = TestBed.inject(Store);
+    service = TestBed.inject(RecordsService);
     router = TestBed.inject(Router);
-    resolver = new ConnectionResolver(store, router);
+    resolver = new ConnectionResolver(store, router, service);
   }));
 
   it("should create an instance", () => {

--- a/src/app/connection/connection.resolver.ts
+++ b/src/app/connection/connection.resolver.ts
@@ -5,16 +5,23 @@ import { catchError } from "rxjs/operators";
 import { Injectable } from "@angular/core";
 import { IProgramme } from "./connection.interfaces";
 import { Get } from "./state/connection.actions";
+import { RecordsService } from "../records/services/records.service";
+import { stateName } from "../records/records.interfaces";
 
 @Injectable()
 export class ConnectionResolver implements Resolve<IProgramme> {
-  constructor(private store: Store, private router: Router) {}
+  constructor(
+    private store: Store,
+    private router: Router,
+    private recordsService: RecordsService
+  ) {}
 
   resolve(
     route: ActivatedRouteSnapshot
   ): Observable<IProgramme> | Observable<any> {
     const gmcNumber: number = Number(route.params.gmcNumber);
-
+    this.recordsService.summaryRoute = "/connections";
+    this.recordsService.stateName = stateName.CONNECTIONS;
     return this.store.dispatch(new Get(gmcNumber)).pipe(
       catchError((error) => {
         return this.router.navigate(["/404"]);

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -63,9 +63,7 @@ export class ConnectionsResolver
     );
     const paramsExist: boolean = Object.keys(route.queryParams).length > 0;
 
-    // The use case for this is when launching Reval from a bookmarked page where querystring parameters
-    // have been set in order to load with filters applied.
-    if (paramsExist && !tableFiltersState) {
+    if (paramsExist) {
       const filters: IConnectionsTableFilters = {};
       if (
         route.queryParams.programmeName !== tableFiltersState?.programmeName
@@ -77,6 +75,10 @@ export class ConnectionsResolver
         this.recordsService.setTableFilters(filters);
         this.recordsService.toggleTableFilterPanel$.next(true);
       }
+    } else {
+      this.recordsService.clearTableFilters();
+      this.recordsService.toggleTableFilterPanel$.next(false);
+      this.recordsService.resetTableFiltersForm();
     }
     return super.resolve(route);
   }

--- a/src/app/connections/state/connections.actions.ts
+++ b/src/app/connections/state/connections.actions.ts
@@ -3,6 +3,7 @@ import {
   FilterPayload,
   GetSuccessPayload,
   PaginatePayload,
+  QueryParamsPayload,
   SearchPayload,
   SortPayload,
   TableFiltersPayload,
@@ -77,4 +78,8 @@ export class ToggleConnectionsCheckbox extends ToggleCheckboxPayload {
 
 export class ToggleAllConnectionsCheckboxes {
   static readonly type = `[Connections] Toggle All Checkboxes`;
+}
+
+export class UpdateConnectionsQueryParams extends QueryParamsPayload {
+  static readonly type = "[Connections] Update query params";
 }

--- a/src/app/connections/state/connections.state.ts
+++ b/src/app/connections/state/connections.state.ts
@@ -32,7 +32,8 @@ import {
   ToggleAllConnectionsCheckboxes,
   ToggleConnectionsCheckbox,
   SetConnectionsTableFilters,
-  ClearConnectionsTableFilters
+  ClearConnectionsTableFilters,
+  UpdateConnectionsQueryParams
 } from "./connections.actions";
 
 export class ConnectionsStateModel extends RecordsStateModel<
@@ -190,5 +191,13 @@ export class ConnectionsState extends RecordsState {
   @Action(ToggleAllConnectionsCheckboxes)
   toggleAllCheckboxes(ctx: StateContext<ConnectionsStateModel>) {
     return super.toggleAllCheckboxesHandler(ctx);
+  }
+
+  @Action(UpdateConnectionsQueryParams)
+  updateQueryParams(
+    ctx: StateContext<ConnectionsStateModel>,
+    action: UpdateConnectionsQueryParams
+  ) {
+    return super.updateQueryParamsHandler(ctx, action.params);
   }
 }

--- a/src/app/details/nav-bar/nav-bar.component.html
+++ b/src/app/details/nav-bar/nav-bar.component.html
@@ -1,5 +1,13 @@
 <nav mat-tab-nav-bar>
   <a
+    style="text-transform: capitalize"
+    mat-tab-link
+    [routerLink]="summaryRoute"
+    [queryParams]="queryParams$ | async"
+  >
+    {{ linkLabel }}
+  </a>
+  <a
     mat-tab-link
     *ngFor="let link of navLinks"
     [routerLink]="link.path"

--- a/src/app/details/nav-bar/nav-bar.component.html
+++ b/src/app/details/nav-bar/nav-bar.component.html
@@ -1,5 +1,7 @@
 <nav mat-tab-nav-bar>
   <a
+    data-jasmine="navBarLink"
+    id="navLinkToList"
     style="text-transform: capitalize"
     mat-tab-link
     [routerLink]="summaryRoute"
@@ -8,6 +10,7 @@
     {{ linkLabel }}
   </a>
   <a
+    data-jasmine="navBarLink"
     mat-tab-link
     *ngFor="let link of navLinks"
     [routerLink]="link.path"

--- a/src/app/details/nav-bar/nav-bar.component.html
+++ b/src/app/details/nav-bar/nav-bar.component.html
@@ -15,6 +15,7 @@
     #rla="routerLinkActive"
     [routerLinkActiveOptions]="{ exact: true }"
     [active]="rla.isActive"
+    [queryParams]="link.params || null"
   >
     {{ link.label }}
   </a>

--- a/src/app/details/nav-bar/nav-bar.component.spec.ts
+++ b/src/app/details/nav-bar/nav-bar.component.spec.ts
@@ -1,22 +1,74 @@
-import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  waitForAsync
+} from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MaterialModule } from "../../shared/material/material.module";
 import { INavLink } from "../details.interfaces";
-
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { NavBarComponent } from "./nav-bar.component";
+import { RecordsService } from "src/app/records/services/records.service";
+import { NgxsModule, Store } from "@ngxs/store";
+import { RecommendationsState } from "src/app/recommendations/state/recommendations.state";
+import { ActivatedRoute, Router, Routes } from "@angular/router";
+import { RecordsModule } from "src/app/records/records.module";
+import { By } from "@angular/platform-browser";
+import { of } from "rxjs";
+import { RecordsComponent } from "src/app/records/records.component";
 
 describe("NavBarComponent", () => {
+  let store: Store;
   let component: NavBarComponent;
   let fixture: ComponentFixture<NavBarComponent>;
+  let service: RecordsService;
+  let router: Router;
+  const routes = [
+    { path: "recommendations", component: RecordsComponent }
+  ] as Routes;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [NavBarComponent],
-      imports: [RouterTestingModule, MaterialModule]
+
+      imports: [
+        RecordsModule,
+        RouterTestingModule.withRoutes(routes),
+
+        MaterialModule,
+        HttpClientTestingModule,
+        NgxsModule.forRoot([RecommendationsState])
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { gmcNumver: "1234567" } }
+          }
+        }
+      ]
     }).compileComponents();
+    router = TestBed.inject(Router);
+    service = TestBed.inject(RecordsService);
+    store = TestBed.inject(Store);
   }));
 
   beforeEach(() => {
+    service.stateName = "recommendations";
+    service.setRecommendationsActions();
+    store.reset({
+      queryParams: {
+        active: "submissionDate",
+        direction: "asc",
+        pageIndex: "3",
+        filter: "allDoctors",
+        dbcs: "1-AIIDWI",
+        gmcStatus: "",
+        tisStatus: "NOT_STARTED"
+      }
+    });
     fixture = TestBed.createComponent(NavBarComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -26,15 +78,50 @@ describe("NavBarComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should create navLinks", () => {
-    expect(component.navLinks).toBeInstanceOf(Array);
-    expect(component.navLinks.length).toEqual(2);
+  it("should create 3 navLinks", () => {
+    expect(
+      fixture.debugElement.queryAll(By.css("[data-jasmine='navBarLink']"))
+        .length
+    ).toBe(3);
   });
 
-  it("navLinks should have a label", () => {
-    const emptyLabelNavLinks: INavLink[] = component.navLinks.filter(
-      (item) => !item.label.length
-    );
-    expect(emptyLabelNavLinks.length).toBe(0);
+  it("navLinks should have the correct label", () => {
+    fixture.debugElement
+      .queryAll(By.css("[data-jasmine='navBarLink']"))
+
+      .forEach((el) => {
+        expect([
+          "Recommendation",
+          "Connection",
+          "recommendations List"
+        ]).toContain(el.nativeElement.innerHTML.trim());
+      });
   });
+
+  it("should open the recommendations list with query params when link is clicked", fakeAsync(() => {
+    component.summaryRoute = "/recommendations";
+    const params = {
+      active: "submissionDate",
+      direction: "asc",
+      pageIndex: "3",
+      filter: "allDoctors",
+      dbcs: "1-AIIDWI",
+      gmcStatus: "",
+      tisStatus: "NOT_STARTED"
+    };
+    const queryParams = Object.keys(params)
+      .map((key) => key + "=" + params[key])
+      .join("&");
+    component.queryParams$ = of(params);
+    fixture.detectChanges();
+    tick();
+    const link = fixture.debugElement.query(
+      By.css("#navLinkToList")
+    ).nativeElement;
+    link.click();
+    fixture.detectChanges();
+    tick();
+
+    expect(router.url).toBe(`/recommendations?${queryParams}`);
+  }));
 });

--- a/src/app/details/nav-bar/nav-bar.component.ts
+++ b/src/app/details/nav-bar/nav-bar.component.ts
@@ -20,7 +20,6 @@ export class NavBarComponent implements OnInit {
   );
   navLinks: INavLink[] = [];
   summaryRoute: string;
-  queryParams: Params;
   linkLabel: string;
   ngOnInit() {
     this.summaryRoute = this.recordsService.summaryRoute;

--- a/src/app/details/nav-bar/nav-bar.component.ts
+++ b/src/app/details/nav-bar/nav-bar.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Params } from "@angular/router";
 import { INavLink } from "../details.interfaces";
 import { RecordsService } from "src/app/records/services/records.service";
 import { Store } from "@ngxs/store";
-import { Observable, Subscription } from "rxjs";
+import { Observable } from "rxjs";
 @Component({
   selector: "app-nav-bar",
   templateUrl: "./nav-bar.component.html"

--- a/src/app/details/nav-bar/nav-bar.component.ts
+++ b/src/app/details/nav-bar/nav-bar.component.ts
@@ -1,17 +1,25 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { INavLink } from "../details.interfaces";
-
+import { RecordsService } from "src/app/records/services/records.service";
+import { Store } from "@ngxs/store";
 @Component({
   selector: "app-nav-bar",
   templateUrl: "./nav-bar.component.html"
 })
 export class NavBarComponent implements OnInit {
-  public navLinks: INavLink[] = [];
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private recordsService: RecordsService,
+    private store: Store
+  ) {}
 
-  constructor(private activatedRoute: ActivatedRoute) {}
-
+  navLinks: INavLink[] = [];
+  summaryRoute: string;
+  linkLabel: string;
   ngOnInit() {
+    this.summaryRoute = this.recordsService.summaryRoute;
+    this.linkLabel = `${this.recordsService.stateName} List`;
     const gmcNumber: number = this.activatedRoute.snapshot.params.gmcNumber;
     this.navLinks = [
       {

--- a/src/app/details/nav-bar/nav-bar.component.ts
+++ b/src/app/details/nav-bar/nav-bar.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Params } from "@angular/router";
 import { INavLink } from "../details.interfaces";
 import { RecordsService } from "src/app/records/services/records.service";
 import { Store } from "@ngxs/store";
+import { Observable, Subscription } from "rxjs";
 @Component({
   selector: "app-nav-bar",
   templateUrl: "./nav-bar.component.html"
@@ -14,8 +15,12 @@ export class NavBarComponent implements OnInit {
     private store: Store
   ) {}
 
+  public queryParams$: Observable<Params> = this.store.select(
+    (state) => state[this.recordsService.stateName].queryParams
+  );
   navLinks: INavLink[] = [];
   summaryRoute: string;
+  queryParams: Params;
   linkLabel: string;
   ngOnInit() {
     this.summaryRoute = this.recordsService.summaryRoute;

--- a/src/app/recommendation/recommendation.resolver.spec.ts
+++ b/src/app/recommendation/recommendation.resolver.spec.ts
@@ -8,6 +8,7 @@ import { RecommendationHistoryState } from "./state/recommendation-history.state
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RecommendationNotesState } from "./state/recommendation-notes.state";
 import { MaterialModule } from "../shared/material/material.module";
+import { RecordsService } from "../records/services/records.service";
 
 @Component({
   template: `blank`
@@ -17,6 +18,7 @@ export class BlankComponent {}
 describe("RecommendationResolver", () => {
   let router: Router;
   let store: Store;
+  let service: RecordsService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -30,11 +32,12 @@ describe("RecommendationResolver", () => {
         ])
       ]
     }).compileComponents();
+    service = TestBed.inject(RecordsService);
     store = TestBed.inject(Store);
     router = TestBed.inject(Router);
   }));
 
   it("should create an instance", () => {
-    expect(new RecommendationResolver(store, router)).toBeTruthy();
+    expect(new RecommendationResolver(store, router, service)).toBeTruthy();
   });
 });

--- a/src/app/recommendation/recommendation.resolver.ts
+++ b/src/app/recommendation/recommendation.resolver.ts
@@ -1,25 +1,28 @@
-import {
-  Resolve,
-  ActivatedRouteSnapshot,
-  RouterStateSnapshot,
-  Router
-} from "@angular/router";
+import { Resolve, ActivatedRouteSnapshot, Router } from "@angular/router";
 import { IRecommendationHistory } from "./recommendation-history.interface";
 import { Observable } from "rxjs";
 import { Store } from "@ngxs/store";
 import { catchError } from "rxjs/operators";
 import { Injectable } from "@angular/core";
 import { Get as GetRecommendationHistory } from "./state/recommendation-history.actions";
+import { RecordsService } from "../records/services/records.service";
+import { stateName } from "../records/records.interfaces";
 
 @Injectable()
 export class RecommendationResolver implements Resolve<IRecommendationHistory> {
-  constructor(private store: Store, private router: Router) {}
+  constructor(
+    private store: Store,
+    private router: Router,
+    private recordsService: RecordsService
+  ) {}
 
   resolve(
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
+    route: ActivatedRouteSnapshot
   ): Observable<IRecommendationHistory> | Observable<any> {
+    this.recordsService.summaryRoute = "/recommendations";
+    this.recordsService.stateName = stateName.RECOMMENDATIONS;
     const gmcNumber: number = Number(route.params.gmcNumber);
+
     return this.store
       .dispatch(new GetRecommendationHistory(gmcNumber))
       .pipe(catchError(() => this.router.navigate(["/404"])));

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -108,10 +108,7 @@ export class RecommendationsResolver
       (snapshot) => snapshot.recommendations.tableFilters
     );
     const paramsExist: boolean = Object.keys(route.queryParams).length > 0;
-
-    // The use case for this is when launching Reval from a bookmarked page where querystring parameters
-    // have been set in order to load with filters applied.
-    if (paramsExist && !tableFiltersState) {
+    if (paramsExist) {
       const filters: IRecommendationsTableFilters = {};
       if (
         route.queryParams.programmeName !== tableFiltersState?.programmeName
@@ -135,6 +132,10 @@ export class RecommendationsResolver
         this.recordsService.setTableFilters(filters);
         this.recordsService.toggleTableFilterPanel$.next(true);
       }
+    } else {
+      this.recordsService.clearTableFilters();
+      this.recordsService.toggleTableFilterPanel$.next(false);
+      this.recordsService.resetTableFiltersForm();
     }
     return super.resolve(route);
   }

--- a/src/app/recommendations/state/recommendations.actions.ts
+++ b/src/app/recommendations/state/recommendations.actions.ts
@@ -1,4 +1,3 @@
-import { Params } from "@angular/router";
 import {
   EnableAllocateAdminPayload,
   FilterPayload,

--- a/src/app/recommendations/state/recommendations.actions.ts
+++ b/src/app/recommendations/state/recommendations.actions.ts
@@ -1,3 +1,4 @@
+import { Params } from "@angular/router";
 import {
   EnableAllocateAdminPayload,
   FilterPayload,
@@ -6,7 +7,8 @@ import {
   SearchPayload,
   SortPayload,
   ToggleCheckboxPayload,
-  TableFiltersPayload
+  TableFiltersPayload,
+  QueryParamsPayload
 } from "../../records/state/records.actions";
 import { HttpErrorPayload } from "../../shared/services/error/error.service";
 import {
@@ -77,4 +79,8 @@ export class ToggleRecommendationsCheckbox extends ToggleCheckboxPayload {
 
 export class ToggleAllRecommendationsCheckboxes {
   static readonly type = `[Recommendations] Toggle All Checkboxes`;
+}
+
+export class UpdateRecommendationsQueryParams extends QueryParamsPayload {
+  static readonly type = "[Recommendations] Update query params";
 }

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -1,7 +1,7 @@
 import { HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { environment } from "@environment";
-import { Action, Selector, State, StateContext } from "@ngxs/store";
+import { Action, State, StateContext } from "@ngxs/store";
 import { catchError, concatMap, finalize, map, take } from "rxjs/operators";
 import { RecommendationStatus } from "../../recommendation/recommendation-history.interface";
 import { RecordsService } from "../../records/services/records.service";

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -1,7 +1,7 @@
 import { HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { environment } from "@environment";
-import { Action, State, StateContext } from "@ngxs/store";
+import { Action, Selector, State, StateContext } from "@ngxs/store";
 import { catchError, concatMap, finalize, map, take } from "rxjs/operators";
 import { RecommendationStatus } from "../../recommendation/recommendation-history.interface";
 import { RecordsService } from "../../records/services/records.service";
@@ -34,7 +34,8 @@ import {
   ResetRecommendationsSort,
   SortRecommendations,
   ToggleAllRecommendationsCheckboxes,
-  ToggleRecommendationsCheckbox
+  ToggleRecommendationsCheckbox,
+  UpdateRecommendationsQueryParams
 } from "./recommendations.actions";
 
 export class RecommendationsStateModel extends RecordsStateModel<
@@ -204,5 +205,13 @@ export class RecommendationsState extends RecordsState {
   @Action(ToggleAllRecommendationsCheckboxes)
   toggleAllCheckboxes(ctx: StateContext<RecommendationsStateModel>) {
     return super.toggleAllCheckboxesHandler(ctx);
+  }
+
+  @Action(UpdateRecommendationsQueryParams)
+  updateQueryParams(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: UpdateRecommendationsQueryParams
+  ) {
+    return super.updateQueryParamsHandler(ctx, action.params);
   }
 }

--- a/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
+++ b/src/app/records/record-list-table-filters/record-list-table-filters.component.ts
@@ -50,6 +50,9 @@ export class RecordListTableFiltersComponent implements OnInit, OnDestroy {
       }
     });
 
+    this.recordsService.onTableFilterFormReset.subscribe(() => {
+      this.form.reset();
+    });
     this.recordsService.tableFiltersFormData.subscribe((formData) => {
       this.formControls = formData;
       this.form = this.recordsService.toFormGroup(

--- a/src/app/records/records.resolver.ts
+++ b/src/app/records/records.resolver.ts
@@ -18,7 +18,9 @@ export class RecordsResolver {
    * Then invoke api and fetch data
    * @param route ActivatedRouteSnapshot
    */
+
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    this.recordsService.updateQueryParams(route.queryParams);
     const paramsExist: boolean = Object.keys(route.queryParams).length > 0;
     if (paramsExist) {
       const state: any = this.store.selectSnapshot(

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -70,6 +70,7 @@ export class RecordsService {
   public dateColumns: string[];
   public columnData: IRecordDataCell[];
   public detailsRoute: string;
+  public summaryRoute: string;
   public filters: IFilter[];
   public showTableFilters: boolean;
   public tableFiltersFormData: BehaviorSubject<

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -65,6 +65,7 @@ import { IFilter, IRecordDataCell, ITableFilters } from "../records.interfaces";
 })
 export class RecordsService {
   public resetSearchForm$: BehaviorSubject<boolean> = new BehaviorSubject(null);
+  public onTableFilterFormReset = new Subject<void>();
   public toggleTableFilterPanel$: BehaviorSubject<boolean> =
     new BehaviorSubject(false);
 
@@ -180,6 +181,9 @@ export class RecordsService {
    * which is great for performance.
    */
 
+  public resetTableFiltersForm(): void {
+    this.onTableFilterFormReset.next();
+  }
   private buildQueryParamsForRoute() {
     const snapshot: any = this.store.snapshot()[this.stateName];
     const params = {

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -1,9 +1,9 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { FormControl, FormGroup } from "@angular/forms";
-import { Router } from "@angular/router";
+import { Router, Params } from "@angular/router";
 import { Store } from "@ngxs/store";
-import { BehaviorSubject, forkJoin, Observable } from "rxjs";
+import { BehaviorSubject, forkJoin, Observable, Subject } from "rxjs";
 import { switchMap, take } from "rxjs/operators";
 
 import {
@@ -38,7 +38,8 @@ import {
   ToggleAllConnectionsCheckboxes,
   ToggleConnectionsCheckbox,
   SetConnectionsTableFilters,
-  ClearConnectionsTableFilters
+  ClearConnectionsTableFilters,
+  UpdateConnectionsQueryParams
 } from "../../connections/state/connections.actions";
 import {
   ClearRecommendationsSearch,
@@ -54,7 +55,8 @@ import {
   ToggleAllRecommendationsCheckboxes,
   ToggleRecommendationsCheckbox,
   SetRecommendationsTableFilters,
-  ClearRecommendationsTableFilters
+  ClearRecommendationsTableFilters,
+  UpdateRecommendationsQueryParams
 } from "../../recommendations/state/recommendations.actions";
 import { IFilter, IRecordDataCell, ITableFilters } from "../records.interfaces";
 
@@ -92,6 +94,7 @@ export class RecordsService {
   public toggleAllCheckboxesAction: any;
   public setTableFiltersAction: any;
   public clearTableFiltersAction: any;
+  public updateQueryParamsAction: any;
 
   constructor(
     private http: HttpClient,
@@ -114,6 +117,7 @@ export class RecordsService {
     this.toggleAllCheckboxesAction = ToggleAllRecommendationsCheckboxes;
     this.setTableFiltersAction = SetRecommendationsTableFilters;
     this.clearTableFiltersAction = ClearRecommendationsTableFilters;
+    this.updateQueryParamsAction = UpdateRecommendationsQueryParams;
   }
 
   public setConcernsActions(): void {
@@ -146,6 +150,7 @@ export class RecordsService {
     this.toggleAllCheckboxesAction = ToggleAllConnectionsCheckboxes;
     this.setTableFiltersAction = SetConnectionsTableFilters;
     this.clearTableFiltersAction = ClearConnectionsTableFilters;
+    this.updateQueryParamsAction = UpdateConnectionsQueryParams;
   }
 
   public getRecords<T>(endPoint: string, params?: HttpParams): Observable<T> {
@@ -312,5 +317,10 @@ export class RecordsService {
       );
     });
     return new FormGroup(group);
+  }
+
+  public updateQueryParams(params: Params): Observable<any> {
+    this.handleUndefinedAction("updateQueryParams");
+    return this.store.dispatch(new this.updateQueryParamsAction(params));
   }
 }

--- a/src/app/records/state/records.actions.ts
+++ b/src/app/records/state/records.actions.ts
@@ -1,5 +1,5 @@
 import { SortDirection } from "@angular/material/sort/sort-direction";
-
+import { Params } from "@angular/router";
 export class GetSuccessPayload<T> {
   constructor(public response: T) {}
 }
@@ -29,4 +29,8 @@ export class EnableAllocateAdminPayload {
 
 export class ToggleCheckboxPayload {
   constructor(public gmcReferenceNumber: string) {}
+}
+
+export class QueryParamsPayload {
+  constructor(public params: Params) {}
 }

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -5,7 +5,7 @@ import { patch, updateItem } from "@ngxs/store/operators";
 import { DEFAULT_SORT } from "../constants";
 import { ITotalCounts } from "../records.interfaces";
 import { RecordsService } from "../services/records.service";
-
+import { Params } from "@angular/router";
 export class RecordsStateModel<T, F, T2 = {}> {
   public allChecked: boolean;
   public enableAllocateAdmin?: boolean;
@@ -21,6 +21,7 @@ export class RecordsStateModel<T, F, T2 = {}> {
   public totalResults: number;
   public totalCounts: ITotalCounts;
   public tableFilters: T2;
+  public queryParams: Params;
 }
 
 export const defaultRecordsState = {
@@ -34,7 +35,8 @@ export const defaultRecordsState = {
   totalPages: null,
   totalResults: null,
   totalCounts: null,
-  tableFilters: null
+  tableFilters: null,
+  queryParams: null
 };
 
 export class RecordsState {
@@ -206,6 +208,12 @@ export class RecordsState {
   protected enableAllocateAdminHandler(ctx: StateContext<any>, action: any) {
     ctx.patchState({
       enableAllocateAdmin: action
+    });
+  }
+
+  protected updateQueryParamsHandler(ctx: StateContext<any>, action: any) {
+    ctx.patchState({
+      queryParams: action
     });
   }
 


### PR DESCRIPTION
The details nav bar is common between recommendation and connection details screen. The link to summary needs to include the correct path (either recommendations or connections) plus any filters/pagination query `params` that were previously applied to the list page. The chosen approach is to store any params in the corresponding slice of state. It is acknowledged that the params are available elsewhere in state but it was decided that simply storing and retrieving all params was more straightforward. A text link label was preferred to an icon to maintain consistency with existing links and include label for list type.

TIS21-4574: Add link to navigate from details page to summary list page