### PR TITLE
fix: setting filter state in resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15374,9 +15374,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001435",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
-      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
+      "version": "1.0.30001515",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
+      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
       "funding": [
         {
           "type": "opencollective",
@@ -15385,6 +15385,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -43576,9 +43580,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001435",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
-      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA=="
+      "version": "1.0.30001515",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
+      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA=="
     },
     "caseless": {
       "version": "0.12.0",


### PR DESCRIPTION
Changing tabs in recommendations and connections is opening the filter panel. This is due to core query params getting added when switching tabs and so params do then exist. Main change is checking if table filter params exist. The rest is refactoring to make it cleaner and more generic.

NO TICKET