### PR TITLE
Fix/connection detail page

### DIFF
--- a/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
+++ b/cypress/e2e/app/recommendations/filter-summary-records.cy.ts
@@ -159,13 +159,14 @@ describe("Recommendations", () => {
 
       it("should filter summary records list by single gmc status when single option selected and submitted", () => {
         FilterRecords.initFilterPanel();
-
+        cy.get("[data-cy=filter-records-button_ALLDOCTORS]")
+          .should("exist")
+          .click();
         cy.get("[data-cy='selectionOptionApproved']").should("exist");
         cy.get("[data-cy='selectionOptionApproved']").click();
         FilterRecords.checkButtonsDisabled("not.be.disabled");
 
         FilterRecords.submitForm();
-
         cy.get("td.cdk-column-gmcOutcome").each(($el) => {
           expect($el.text().trim()).to.equal("Approved");
         });
@@ -173,6 +174,9 @@ describe("Recommendations", () => {
 
       it("should filter summary records list by multiple gmc statuses when multiple options selected and submitted", () => {
         FilterRecords.initFilterPanel();
+        cy.get("[data-cy=filter-records-button_ALLDOCTORS]")
+          .should("exist")
+          .click();
         const selectedGmcStatus = formFilters.gmcStatus.filter(
           (_, index) => index < 2
         );

--- a/cypress/e2e/app/records/filter-summary-records-po.ts
+++ b/cypress/e2e/app/records/filter-summary-records-po.ts
@@ -62,6 +62,7 @@ export class FilterRecords {
       "[data-cy='tableFiltersForm'] button[data-jasmine='submitFormButton']"
     ).click();
     cy.get("app-record-list .mat-table").should("exist");
+    cy.wait(1000);
   };
 
   static resetForm = () => {

--- a/src/app/connection/connection.component.spec.ts
+++ b/src/app/connection/connection.component.spec.ts
@@ -89,8 +89,7 @@ describe("ConnectionComponent", () => {
 
     component.doctorCurrentDbc = "1-ABCDE";
     component.gmcNumber = 123456;
-    component.programmeOwnerDBC =
-      mockConnectionResponse.programme.programmeHistory[0].designatedBodyCode;
+
     component.updateConnection(formValue);
 
     expect(component.submitting).toBeTruthy();
@@ -101,8 +100,7 @@ describe("ConnectionComponent", () => {
         doctors: [
           {
             gmcId: 123456,
-            currentDesignatedBodyCode: "1-ABCDE",
-            programmeOwnerDesignatedBodyCode: "1-AIIDVS"
+            currentDesignatedBodyCode: "1-ABCDE"
           }
         ]
       },
@@ -162,8 +160,6 @@ describe("ConnectionComponent", () => {
 
     component.doctorCurrentDbc = "1-ABCDE";
     component.gmcNumber = 123456;
-    component.programmeOwnerDBC =
-      mockConnectionResponse.programme.programmeHistory[0].designatedBodyCode;
     component.updateConnection(formValue);
 
     expect(component.submitting).toBeTruthy();
@@ -174,8 +170,7 @@ describe("ConnectionComponent", () => {
         doctors: [
           {
             gmcId: 123456,
-            currentDesignatedBodyCode: "1-ABCDE",
-            programmeOwnerDesignatedBodyCode: "1-AIIDVS"
+            currentDesignatedBodyCode: "1-ABCDE"
           }
         ]
       },

--- a/src/app/connection/connection.component.spec.ts
+++ b/src/app/connection/connection.component.spec.ts
@@ -8,12 +8,10 @@ import { of, Subscription, throwError } from "rxjs";
 import { MaterialModule } from "../shared/material/material.module";
 import { ConnectionState } from "../connection/state/connection.state";
 import { ConnectionComponent } from "./connection.component";
-import { mockDbcs } from "../reference/mock-data/reference-spec.data";
 import { SnackBarService } from "../shared/services/snack-bar/snack-bar.service";
 import { ActionType } from "../update-connections/update-connections.interfaces";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { IConnectionHistory } from "./connection.interfaces";
-import { mockConnectionResponse } from "./mock-data/conneciton-details-spec-data";
 
 describe("ConnectionComponent", () => {
   let component: ConnectionComponent;

--- a/src/app/connection/connection.component.ts
+++ b/src/app/connection/connection.component.ts
@@ -5,7 +5,6 @@ import { Observable, Subscription } from "rxjs";
 import { environment } from "@environment";
 import {
   IConnectionHistory,
-  IProgrammeHistory,
   IUpdateConnectionResponse
 } from "./connection.interfaces";
 import { ConnectionState } from "./state/connection.state";
@@ -46,9 +45,6 @@ import { IDetailsSideNav } from "../details/details-side-nav/details-side-nav.in
 export class ConnectionComponent implements OnInit, OnDestroy {
   @Select(ConnectionState.connectionHistory)
   public connectionHistory$: Observable<IConnectionHistory[]>;
-
-  @Select(ConnectionState.programmeHistory)
-  public programmeHistory$: Observable<IProgrammeHistory[]>;
 
   @Select(ConnectionState.gmcNumber)
   public gmcNumber$: Observable<number>;
@@ -93,11 +89,6 @@ export class ConnectionComponent implements OnInit, OnDestroy {
     this.gmcNumber$.subscribe((res) => (this.gmcNumber = res));
     this.doctorCurrentDbc$.subscribe((res) => (this.doctorCurrentDbc = res));
     this.updateConnectionsService.canSave$.next(true);
-    this.programmeHistory$.subscribe((res) => {
-      if (res) {
-        this.programmeOwnerDBC = res[0]?.designatedBodyCode;
-      }
-    });
   }
 
   ngOnDestroy(): void {
@@ -111,8 +102,7 @@ export class ConnectionComponent implements OnInit, OnDestroy {
     const doctors: IDoctor[] = [
       {
         gmcId: this.gmcNumber,
-        currentDesignatedBodyCode: this.doctorCurrentDbc,
-        programmeOwnerDesignatedBodyCode: this.programmeOwnerDBC
+        currentDesignatedBodyCode: this.doctorCurrentDbc
       }
     ];
 

--- a/src/app/connection/connection.interfaces.ts
+++ b/src/app/connection/connection.interfaces.ts
@@ -1,5 +1,4 @@
 export interface IConnectionResponse {
-  programme: IProgramme;
   designatedBodyCode: IUserDBC;
   connection: {
     connectionHistory: IConnectionHistory[];
@@ -8,26 +7,6 @@ export interface IConnectionResponse {
 
 export interface IUpdateConnectionResponse {
   message: string;
-}
-
-export interface IProgramme {
-  gmcNumber: number;
-  forenames: string;
-  surname: string;
-  curriculumEndDate: Date;
-  programmeMembershipType: string;
-  programmeName: string;
-  currentGrade: string;
-  programmeHistory: IProgrammeHistory[];
-}
-
-export interface IProgrammeHistory {
-  designatedBodyCode: string;
-  programmeMembershipType: string;
-  programmeName: string;
-  programmeOwner: string;
-  programmeMembershipStartDate: Date;
-  programmeMembershipEndDate: Date;
 }
 
 export interface IConnectionHistory {

--- a/src/app/connection/connection.resolver.spec.ts
+++ b/src/app/connection/connection.resolver.spec.ts
@@ -46,15 +46,14 @@ describe("ConnectionResolver", () => {
   });
 
   it("should call store.dispatch with new Get", () => {
+    const gmcNumber = 1234567;
     const route = new ActivatedRouteSnapshot();
     route.params = {
-      gmcNumber: mockConnectionResponse.programme.gmcNumber
+      gmcNumber
     };
 
     spyOn(store, "dispatch").and.callThrough();
     resolver.resolve(route);
-    expect(store.dispatch).toHaveBeenCalledWith(
-      new Get(mockConnectionResponse.programme.gmcNumber)
-    );
+    expect(store.dispatch).toHaveBeenCalledWith(new Get(gmcNumber));
   });
 });

--- a/src/app/connection/connection.resolver.spec.ts
+++ b/src/app/connection/connection.resolver.spec.ts
@@ -9,7 +9,6 @@ import { ConnectionResolver } from "./connection.resolver";
 import { MaterialModule } from "../shared/material/material.module";
 import { ConnectionState } from "./state/connection.state";
 import { Get } from "./state/connection.actions";
-import { mockConnectionResponse } from "./mock-data/conneciton-details-spec-data";
 import { RecordsService } from "../records/services/records.service";
 
 @Component({

--- a/src/app/connection/connection.resolver.ts
+++ b/src/app/connection/connection.resolver.ts
@@ -3,13 +3,13 @@ import { Observable } from "rxjs";
 import { Store } from "@ngxs/store";
 import { catchError } from "rxjs/operators";
 import { Injectable } from "@angular/core";
-import { IProgramme } from "./connection.interfaces";
 import { Get } from "./state/connection.actions";
 import { RecordsService } from "../records/services/records.service";
 import { stateName } from "../records/records.interfaces";
+import { IConnectionResponse } from "./connection.interfaces";
 
 @Injectable()
-export class ConnectionResolver implements Resolve<IProgramme> {
+export class ConnectionResolver implements Resolve<IConnectionResponse> {
   constructor(
     private store: Store,
     private router: Router,
@@ -18,7 +18,7 @@ export class ConnectionResolver implements Resolve<IProgramme> {
 
   resolve(
     route: ActivatedRouteSnapshot
-  ): Observable<IProgramme> | Observable<any> {
+  ): Observable<IConnectionResponse> | Observable<any> {
     const gmcNumber: number = Number(route.params.gmcNumber);
     this.recordsService.summaryRoute = "/connections";
     this.recordsService.stateName = stateName.CONNECTIONS;

--- a/src/app/connection/mock-data/conneciton-details-spec-data.ts
+++ b/src/app/connection/mock-data/conneciton-details-spec-data.ts
@@ -1,37 +1,8 @@
 import {
   IConnectionHistory,
   IConnectionResponse,
-  IProgramme,
   IUserDBC
 } from "../connection.interfaces";
-
-const programme: IProgramme = {
-  gmcNumber: 123456,
-  forenames: "Babul",
-  surname: "Yasa",
-  curriculumEndDate: new Date(),
-  programmeMembershipType: "prg type1",
-  programmeName: "prg name1",
-  currentGrade: "GRADE",
-  programmeHistory: [
-    {
-      designatedBodyCode: "1-AIIDVS",
-      programmeMembershipType: "prg type1",
-      programmeName: "prg name1",
-      programmeOwner: "prg owner1",
-      programmeMembershipStartDate: new Date("10/11/2021"),
-      programmeMembershipEndDate: new Date("10/11/2020")
-    },
-    {
-      designatedBodyCode: "1-AIIDMQ",
-      programmeMembershipType: "prg type2",
-      programmeName: "prg name2",
-      programmeOwner: "prg owner2",
-      programmeMembershipStartDate: new Date("09/08/2019"),
-      programmeMembershipEndDate: new Date("09/08/2020")
-    }
-  ]
-};
 
 const connectionHistory: IConnectionHistory[] = [
   {
@@ -67,7 +38,6 @@ const designatedBodyCode: IUserDBC = {
 };
 
 export const mockConnectionResponse: IConnectionResponse = {
-  programme,
   designatedBodyCode,
   connection: {
     connectionHistory

--- a/src/app/connection/services/connection.service.spec.ts
+++ b/src/app/connection/services/connection.service.spec.ts
@@ -6,7 +6,6 @@ import {
 } from "@angular/common/http/testing";
 
 import { environment } from "@environment";
-import { mockConnectionResponse } from "../mock-data/conneciton-details-spec-data";
 
 describe("ConcernService", () => {
   let http: HttpTestingController;

--- a/src/app/connection/services/connection.service.spec.ts
+++ b/src/app/connection/services/connection.service.spec.ts
@@ -25,11 +25,10 @@ describe("ConcernService", () => {
   });
 
   it("should call get connection details api", () => {
-    const endPoint = `${environment.appUrls.getConnections}/${mockConnectionResponse.programme.gmcNumber}`;
+    const gmcNumber = 1234567;
+    const endPoint = `${environment.appUrls.getConnections}/${gmcNumber}`;
 
-    service
-      .getConnectionHistory(mockConnectionResponse.programme.gmcNumber)
-      .subscribe();
+    service.getConnectionHistory(gmcNumber).subscribe();
 
     const mockHttp = http.expectOne(endPoint);
     expect(mockHttp.request.method).toBe("GET");

--- a/src/app/connection/state/connection.actions.ts
+++ b/src/app/connection/state/connection.actions.ts
@@ -1,6 +1,3 @@
-import { HttpErrorPayload } from "../../shared/services/error/error.service";
-import { IProgramme } from "../connection.interfaces";
-
 export class Get {
   static readonly type = "[Connection] Get";
   constructor(public payload: number) {}

--- a/src/app/connection/state/connection.state.spec.ts
+++ b/src/app/connection/state/connection.state.spec.ts
@@ -58,13 +58,6 @@ describe("Connection actions", () => {
       mockConnectionResponse.connection.connectionHistory
     );
 
-    const programmeHistory = store.selectSnapshot(
-      (state) => state.connection.programmeHistory
-    );
-
-    expect(programmeHistory).toEqual(
-      mockConnectionResponse.programme.programmeHistory
-    );
     httpMock.verify();
   }));
 

--- a/src/app/connection/state/connection.state.ts
+++ b/src/app/connection/state/connection.state.ts
@@ -2,7 +2,6 @@ import { Injectable } from "@angular/core";
 import { Action, Selector, State, StateContext } from "@ngxs/store";
 import { map } from "rxjs/operators";
 import {
-  IProgrammeHistory,
   IConnectionResponse,
   IConnectionHistory
 } from "../connection.interfaces";
@@ -11,7 +10,6 @@ import { Get } from "./connection.actions";
 
 export class ConnectionStateModel {
   public gmcNumber: number;
-  public programmeHistory: IProgrammeHistory[];
   public connectionHistory: IConnectionHistory[];
   public doctorCurrentDbc: string;
 }
@@ -20,7 +18,6 @@ export class ConnectionStateModel {
   name: "connection",
   defaults: {
     gmcNumber: null,
-    programmeHistory: [],
     connectionHistory: [],
     doctorCurrentDbc: null
   }
@@ -28,11 +25,6 @@ export class ConnectionStateModel {
 @Injectable()
 export class ConnectionState {
   constructor(private service: ConnectionService) {}
-
-  @Selector()
-  public static programmeHistory(state: ConnectionStateModel) {
-    return state.programmeHistory;
-  }
 
   @Selector()
   public static connectionHistory(state: ConnectionStateModel) {
@@ -59,7 +51,6 @@ export class ConnectionState {
       map((response: IConnectionResponse) => {
         patchState({
           gmcNumber: payload,
-          programmeHistory: response.programme.programmeHistory,
           connectionHistory: response.connection.connectionHistory,
           doctorCurrentDbc: response.designatedBodyCode.designatedBodyCode
         });

--- a/src/app/update-connections/update-connections.interfaces.ts
+++ b/src/app/update-connections/update-connections.interfaces.ts
@@ -24,5 +24,4 @@ export interface IUpdateConnection {
 export interface IDoctor {
   gmcId: number;
   currentDesignatedBodyCode: string;
-  programmeOwnerDesignatedBodyCode: string;
 }


### PR DESCRIPTION
The connection detail page returns an error as `programme` no longer returned in connection response as not required. FE code updated to remove references to `programme`.

TIS21-4548: Correctly handle situations where a doctor exists in GMC but not in TIS on the connection and recommendation details pages   