### PR TITLE
build: use OIDC for AWS credentials

### DIFF
--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -1,5 +1,9 @@
 name: Deploy to Amazon S3 on Alpha
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   workflow_dispatch:
 
@@ -21,9 +25,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Remove the unused ecr user tokens and replace it with a role reference to the github-actions-deployer-role accessible using OIDC.

TIS21-4862