### PR TITLE
Fix/bulk update connections checkboxes

### DIFF
--- a/src/app/connections/state/connections.state.spec.ts
+++ b/src/app/connections/state/connections.state.spec.ts
@@ -242,14 +242,7 @@ describe("Connections state", () => {
     );
 
     items.forEach((item) => {
-      if (
-        item.programmeMembershipType === "Military" ||
-        item.programmeName.includes("Foundation")
-      ) {
-        expect(item.checked).toBeFalsy();
-      } else {
-        expect(item.checked).toBeTruthy();
-      }
+      expect(item.checked).toBeTruthy();
     });
   });
 });

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -92,8 +92,7 @@
                     showCheckbox(
                       data.enableAllocateAdmin,
                       data.enableUpdateConnections,
-                      i.name,
-                      element
+                      i.name
                     )
                   "
                   class="pr-20"

--- a/src/app/records/record-list/record-list.component.ts
+++ b/src/app/records/record-list/record-list.component.ts
@@ -109,20 +109,11 @@ export class RecordListComponent implements OnDestroy {
   public showCheckbox(
     enableAllocateAdmin: boolean,
     enableUpdateConnections: boolean,
-    columnName: string,
-    element: any
+    columnName: string
   ) {
-    const programmeMembershipType = "programmeMembershipType";
-    const programmeName = "programmeName";
     return (
       (enableAllocateAdmin || enableUpdateConnections) &&
-      columnName === "doctorFirstName" &&
-      !(
-        (this.recordsService.stateName === "connections" &&
-          element[programmeMembershipType] === "Military") ||
-        // TODO: Chnage this to placement grade condition
-        element[programmeName]?.includes("Foundation")
-      )
+      columnName === "doctorFirstName"
     );
   }
 

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -255,12 +255,7 @@ export class RecordsState {
       ctx.setState(
         patch({
           items: updateItem(
-            (item: any) =>
-              item === i &&
-              !(
-                i.programmeMembershipType === "Military" ||
-                i.programmeName?.includes("Foundation")
-              ),
+            (item: any) => item === i,
             patch({ checked: allChecked })
           )
         })


### PR DESCRIPTION
The checkboxes would not appear when programme name contained Foundation or membership type was Military. Since F1 and Military are excluded in data and the All Doctors tab is no longer required, these conditionals have been removed.

TICKET: TIS21-4928 - Bulk Connections seems to break when list is filtered by foundation (F2) programmes

