### PR TITLE
fix:move dispatch to resolver

### DIFF
--- a/src/app/connection/connection.resolver.ts
+++ b/src/app/connection/connection.resolver.ts
@@ -7,9 +7,9 @@ import { Get } from "./state/connection.actions";
 import { RecordsService } from "../records/services/records.service";
 import { stateName } from "../records/records.interfaces";
 import { IConnectionResponse } from "./connection.interfaces";
-
+import { Get as GetSideNavDetails } from "../details/details-side-nav/state/details-side-nav.actions";
 @Injectable()
-export class ConnectionResolver  {
+export class ConnectionResolver {
   constructor(
     private store: Store,
     private router: Router,
@@ -22,6 +22,7 @@ export class ConnectionResolver  {
     const gmcNumber: number = Number(route.params.gmcNumber);
     this.recordsService.summaryRoute = "/connections";
     this.recordsService.stateName = stateName.CONNECTIONS;
+    this.store.dispatch(new GetSideNavDetails(gmcNumber));
     return this.store.dispatch(new Get(gmcNumber)).pipe(
       catchError((error) => {
         return this.router.navigate(["/404"]);

--- a/src/app/details/details-side-nav/details-side-nav.component.ts
+++ b/src/app/details/details-side-nav/details-side-nav.component.ts
@@ -1,12 +1,11 @@
-import { Component, OnInit } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
-import { Select, Store } from "@ngxs/store";
+import { Component } from "@angular/core";
+
+import { Select } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { Breakpoints, BreakpointObserver } from "@angular/cdk/layout";
 import { map, shareReplay } from "rxjs/operators";
 import { environment } from "@environment";
 import { IDetailsSideNav } from "./details-side-nav.interfaces";
-import { Get } from "./state/details-side-nav.actions";
 import { DetailsSideNavState } from "./state/details-side-nav.state";
 
 @Component({
@@ -14,7 +13,7 @@ import { DetailsSideNavState } from "./state/details-side-nav.state";
   templateUrl: "./details-side-nav.component.html",
   styleUrls: ["./details-side-nav.component.scss"]
 })
-export class DetailsSideNavComponent implements OnInit {
+export class DetailsSideNavComponent {
   @Select(DetailsSideNavState.traineeDetails)
   traineeDetails$: Observable<IDetailsSideNav>;
   hostURI: string = environment.adminsUIHostUri;
@@ -28,11 +27,7 @@ export class DetailsSideNavComponent implements OnInit {
     );
 
   sideLinks = [];
-  constructor(
-    private breakpointObserver: BreakpointObserver,
-    private store: Store,
-    private activatedRoute: ActivatedRoute
-  ) {
+  constructor(private breakpointObserver: BreakpointObserver) {
     this.traineeDetails$.subscribe((traineeDetails) => {
       const path = `${this.hostURI}admin/people/person/${traineeDetails.tisPersonId}`;
       this.sideLinks = [
@@ -54,12 +49,5 @@ export class DetailsSideNavComponent implements OnInit {
         }
       ];
     });
-  }
-
-  ngOnInit(): void {
-    const gmcNumber: number = Number(
-      this.activatedRoute.snapshot.params.gmcNumber
-    );
-    this.store.dispatch(new Get(gmcNumber));
   }
 }

--- a/src/app/recommendation/recommendation.resolver.ts
+++ b/src/app/recommendation/recommendation.resolver.ts
@@ -7,9 +7,10 @@ import { Injectable } from "@angular/core";
 import { Get as GetRecommendationHistory } from "./state/recommendation-history.actions";
 import { RecordsService } from "../records/services/records.service";
 import { stateName } from "../records/records.interfaces";
+import { Get as GetSideNavDetails } from "../details/details-side-nav/state/details-side-nav.actions";
 
 @Injectable()
-export class RecommendationResolver  {
+export class RecommendationResolver {
   constructor(
     private store: Store,
     private router: Router,
@@ -22,7 +23,7 @@ export class RecommendationResolver  {
     this.recordsService.summaryRoute = "/recommendations";
     this.recordsService.stateName = stateName.RECOMMENDATIONS;
     const gmcNumber: number = Number(route.params.gmcNumber);
-
+    this.store.dispatch(new GetSideNavDetails(gmcNumber));
     return this.store
       .dispatch(new GetRecommendationHistory(gmcNumber))
       .pipe(catchError(() => this.router.navigate(["/404"])));


### PR DESCRIPTION
Fetching trainee details data to update state was triggered in OnInit of details-side-nav component after the details page was loaded. This resulted in any previous doctor's details held in state being initially displayed until new data is fetched.

The solution is to move the store dispatch method to the resolvers for recommendations and connections so that the data is fetched before the page loads and the details side nav displays the correct doctor.

TIS21-4868: Prevent details page from initially displaying previous loaded doctor's details in the trainee profile panel