### PR TITLE
Fix/404 error response

### DIFF
--- a/cypress/e2e/app/connections/update-connection.cy.ts
+++ b/cypress/e2e/app/connections/update-connection.cy.ts
@@ -69,10 +69,6 @@ describe("Update connections", () => {
 
   it("should display 404 page opened with non existent doctor", () => {
     cy.visit("/connection/999999999999");
-    cy.get("app-info-dialog")
-      .should("exist")
-      .contains("Oops, something went wrong");
-    cy.get("app-info-dialog button").should("exist").click();
     cy.get("app-page-not-found h1").should("exist").contains("Page not found");
   });
 

--- a/cypress/e2e/app/recommendations/save-submit-recommendation.cy.ts
+++ b/cypress/e2e/app/recommendations/save-submit-recommendation.cy.ts
@@ -15,10 +15,7 @@ describe("Save and submit recommendation", () => {
   };
   it("should display 404 page opened with non existent doctor", () => {
     cy.visit("/recommendation/999999999999");
-    cy.get("app-info-dialog")
-      .should("exist")
-      .contains("Oops, something went wrong");
-    cy.get("app-info-dialog button").should("exist").click();
+
     cy.get("app-page-not-found h1").should("exist").contains("Page not found");
   });
 

--- a/src/app/connection/connection.resolver.ts
+++ b/src/app/connection/connection.resolver.ts
@@ -1,7 +1,6 @@
 import { ActivatedRouteSnapshot, Router } from "@angular/router";
 import { Observable } from "rxjs";
 import { Store } from "@ngxs/store";
-import { catchError } from "rxjs/operators";
 import { Injectable } from "@angular/core";
 import { Get } from "./state/connection.actions";
 import { RecordsService } from "../records/services/records.service";
@@ -23,10 +22,6 @@ export class ConnectionResolver {
     this.recordsService.summaryRoute = "/connections";
     this.recordsService.stateName = stateName.CONNECTIONS;
     this.store.dispatch(new GetSideNavDetails(gmcNumber));
-    return this.store.dispatch(new Get(gmcNumber)).pipe(
-      catchError((error) => {
-        return this.router.navigate(["/404"]);
-      })
-    );
+    return this.store.dispatch(new Get(gmcNumber));
   }
 }

--- a/src/app/core/http-error/http-error.interceptor.ts
+++ b/src/app/core/http-error/http-error.interceptor.ts
@@ -5,7 +5,7 @@ import {
   HttpInterceptor,
   HttpRequest
 } from "@angular/common/http";
-import { ErrorHandler, Injectable } from "@angular/core";
+import { Injectable } from "@angular/core";
 import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { ErrorService } from "../../shared/services/error/error.service";

--- a/src/app/core/http-error/http-error.interceptor.ts
+++ b/src/app/core/http-error/http-error.interceptor.ts
@@ -5,7 +5,7 @@ import {
   HttpInterceptor,
   HttpRequest
 } from "@angular/common/http";
-import { Injectable } from "@angular/core";
+import { ErrorHandler, Injectable } from "@angular/core";
 import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { ErrorService } from "../../shared/services/error/error.service";
@@ -29,11 +29,12 @@ export class HttpErrorInterceptor implements HttpInterceptor {
         if (error instanceof HttpErrorResponse) {
           if (error.status === 404) {
             this.router.navigateByUrl("/404");
+            return throwError(() => new Error("404 page not found"));
           }
         }
         const message: string = this.errorService.generateErrorMsg(error);
         this.snackBarService.openSnackBar(message);
-        return throwError(message);
+        return throwError(() => new Error(message));
       })
     );
   }

--- a/src/app/recommendation/recommendation.resolver.ts
+++ b/src/app/recommendation/recommendation.resolver.ts
@@ -2,7 +2,6 @@ import { ActivatedRouteSnapshot, Router } from "@angular/router";
 import { IRecommendationHistory } from "./recommendation-history.interface";
 import { Observable } from "rxjs";
 import { Store } from "@ngxs/store";
-import { catchError } from "rxjs/operators";
 import { Injectable } from "@angular/core";
 import { Get as GetRecommendationHistory } from "./state/recommendation-history.actions";
 import { RecordsService } from "../records/services/records.service";
@@ -24,8 +23,6 @@ export class RecommendationResolver {
     this.recordsService.stateName = stateName.RECOMMENDATIONS;
     const gmcNumber: number = Number(route.params.gmcNumber);
     this.store.dispatch(new GetSideNavDetails(gmcNumber));
-    return this.store
-      .dispatch(new GetRecommendationHistory(gmcNumber))
-      .pipe(catchError(() => this.router.navigate(["/404"])));
+    return this.store.dispatch(new GetRecommendationHistory(gmcNumber));
   }
 }


### PR DESCRIPTION
Changing the location of dispatch method call resulted in an additional pop-up message when there was a page not found error, which broke the E2E. These pop-ups seem unnecessary for 404 as there is a page not found error component displayed so they have been removed. 

TIS21-4868 Prevent details page from initially displaying previous loaded 
doctor's details in the trainee profile panel 