### PR TITLE
fix: return both data fetches once complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revalidation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "ng": "ng",
     "start": "npm run build:misc && ng serve",

--- a/src/app/connection/connection.resolver.ts
+++ b/src/app/connection/connection.resolver.ts
@@ -1,5 +1,5 @@
 import { ActivatedRouteSnapshot, Router } from "@angular/router";
-import { Observable } from "rxjs";
+import { Observable, combineLatest } from "rxjs";
 import { Store } from "@ngxs/store";
 import { Injectable } from "@angular/core";
 import { Get } from "./state/connection.actions";
@@ -21,7 +21,10 @@ export class ConnectionResolver {
     const gmcNumber: number = Number(route.params.gmcNumber);
     this.recordsService.summaryRoute = "/connections";
     this.recordsService.stateName = stateName.CONNECTIONS;
-    this.store.dispatch(new GetSideNavDetails(gmcNumber));
-    return this.store.dispatch(new Get(gmcNumber));
+
+    return combineLatest([
+      this.store.dispatch(new Get(gmcNumber)),
+      this.store.dispatch(new GetSideNavDetails(gmcNumber))
+    ]);
   }
 }

--- a/src/app/recommendation/recommendation.resolver.ts
+++ b/src/app/recommendation/recommendation.resolver.ts
@@ -1,6 +1,6 @@
 import { ActivatedRouteSnapshot, Router } from "@angular/router";
 import { IRecommendationHistory } from "./recommendation-history.interface";
-import { Observable } from "rxjs";
+import { Observable, combineLatest } from "rxjs";
 import { Store } from "@ngxs/store";
 import { Injectable } from "@angular/core";
 import { Get as GetRecommendationHistory } from "./state/recommendation-history.actions";
@@ -22,7 +22,10 @@ export class RecommendationResolver {
     this.recordsService.summaryRoute = "/recommendations";
     this.recordsService.stateName = stateName.RECOMMENDATIONS;
     const gmcNumber: number = Number(route.params.gmcNumber);
-    this.store.dispatch(new GetSideNavDetails(gmcNumber));
-    return this.store.dispatch(new GetRecommendationHistory(gmcNumber));
+
+    return combineLatest([
+      this.store.dispatch(new GetSideNavDetails(gmcNumber)),
+      this.store.dispatch(new GetRecommendationHistory(gmcNumber))
+    ]);
   }
 }


### PR DESCRIPTION
Due to the intermittent delay in fetching data from Trainee endpoint on Prod, the previous fix wasn't sufficient. CombineLatest waits for items to be emitted from both observables before returning and resolving to the details page.

The browser won't navigate to the details page until data is returned so when there is any significant delay, there is no indication in the UI that the details page is loading. Either the performance issues will need addressing or some form of loading spinner could be added.

TIS21-4868 - Prevent details page from initially displaying previous loaded doctor's details in the trainee profile panel