### PR TITLE
Feat/add frutiger font

### DIFF
--- a/cypress/e2e/app/recommendations/recommendations-filters.cy.ts
+++ b/cypress/e2e/app/recommendations/recommendations-filters.cy.ts
@@ -7,8 +7,8 @@ describe("Recommendations filters", () => {
   const filterButtonLabels = ["ALL DOCTORS", "UNDER NOTICE"];
 
   it("should contain correct filter button labels", () => {
-    cy.get("app-record-list-filters a").each(($el) => {
-      expect(filterButtonLabels.join("|")).to.contain($el.text().trim());
+    filterButtonLabels.forEach((btnLabel) => {
+      cy.get("app-record-list-filters a").contains(btnLabel).should("exist");
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revalidation",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "ng": "ng",
     "start": "npm run build:misc && ng serve",

--- a/src/index.html
+++ b/src/index.html
@@ -26,6 +26,12 @@
     <meta name="theme-color" content="#005eb8" />
     <link
       rel="preload"
+      href="https://assets.nhs.uk/fonts/nhsuk-fonts-1.3.0.css"
+      as="style"
+      onload="this.onload=null;this.rel='stylesheet'"
+    />
+    <link
+      rel="preload"
       href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp&display=swap"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"

--- a/src/scss/material/_index.scss
+++ b/src/scss/material/_index.scss
@@ -5,7 +5,7 @@
 @import "palette";
 
 $nhsuk-typography: mat.define-legacy-typography-config(
-  $font-family: $nhsuk-font + $nhsuk-font-fallback
+  $font-family: $nhsuk-font
 );
 // Include the common styles for Angular Material. We include this here so that you only
 // have to load a single css file for Angular Material in your app.
@@ -38,7 +38,8 @@ $nhsuk-theme: mat.define-light-theme(
       accent: $nhsuk-accent,
       warn: $nhsuk-warn
     ),
-    density: 0
+    density: 0,
+    typography: $nhsuk-typography
   )
 );
 
@@ -51,10 +52,8 @@ $nhsuk-theme: mat.define-light-theme(
 
 html,
 body {
+  font-family: $nhsuk-font;
   height: 100%;
-}
-body {
-  font-family: $nhsuk-font, $nhsuk-font-fallback, Serif, Sans-serif; // sonar error fall-back variable is Serif, Sans-serif
   margin: 0;
   padding: 0;
   color: $color_nhsuk-black;

--- a/src/scss/nhsuk/_globals.scss
+++ b/src/scss/nhsuk/_globals.scss
@@ -8,8 +8,7 @@
 // 1. Fallback fonts if Frutiger fails to load
 //
 
-$nhsuk-font: "Frutiger W01";
-$nhsuk-font-fallback: "Arial", "Sans-serif"; // [1] //
+$nhsuk-font: "Frutiger W01", "Arial", "Sans-serif" !default;
 $nhsuk-font-family-print: sans-serif !default;
 $nhsuk-font-bold: 600;
 $nhsuk-font-normal: 400;

--- a/src/scss/nhsuk/_index.scss
+++ b/src/scss/nhsuk/_index.scss
@@ -1,5 +1,3 @@
 // Settings
 @import "colours";
 @import "globals";
-
-@import "nhsuk-frontend/packages/core/generic/font-face";


### PR DESCRIPTION
The NHS has adopted the font Frutiger, which had been partially added as the core font to Reval, but it wasn't working, principally because the font was not being downloaded. This adds the web fonts via a link attribute added to the index.html file in the same way as material icons. 

The app with Frutiger can be tested at https://alpha-revalidation.tis.nhs.uk/recommendations [v1.0.3]

NO TICKET