### PR TITLE
test: change doctor used for connections E2E

### DIFF
--- a/cypress/e2e/app/connections/update-connection.cy.ts
+++ b/cypress/e2e/app/connections/update-connection.cy.ts
@@ -1,7 +1,7 @@
 describe("Update connections", () => {
   beforeEach(() => {
     cy.loginSession();
-    cy.visit("/connection/8999999");
+    cy.visit("/connection/7920092");
   });
 
   const updateActions = ["Add connection", "Remove connection"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revalidation",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "scripts": {
     "ng": "ng",
     "start": "npm run build:misc && ng serve",


### PR DESCRIPTION
The previous doctor used for testing connections was throwing an error possibly caused by using a fake doctor. This has been changed to use a different account.

NO TICKET