### PR TITLE
Feat/exceptions log

### DIFF
--- a/cypress/e2e/app/connections/summary-records-list.cy.ts
+++ b/cypress/e2e/app/connections/summary-records-list.cy.ts
@@ -15,9 +15,14 @@ describe("Connections Summary Records List", () => {
     "Programme owner",
     "Programme membership"
   ];
-  const sortableColumns = ["First name", "Last name", "GMC Designated body", "Programme owner"];
+  const sortableColumns = [
+    "First name",
+    "Last name",
+    "GMC Designated body",
+    "Programme owner"
+  ];
 
-  const filters = ["DISCREPANCIES", "CURRENT CONNECTIONS"];
+  const filters = ["DISCREPANCIES", "CURRENT CONNECTIONS", "EXCEPTIONS LIST"];
 
   it("should display correct page filter tabs", () => {
     cy.get("app-record-list-filters a").each(($el) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revalidation",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "scripts": {
     "ng": "ng",
     "start": "npm run build:misc && ng serve",

--- a/src/app/connection/connection.component.html
+++ b/src/app/connection/connection.component.html
@@ -105,8 +105,8 @@
           (click)="currentExpanded(element, $event)"
           (keyup.enter)="currentExpanded(element, $event)"
           (keyup.space)="currentExpanded(element, $event)"
-          [class.highlight-row-warn]="element.responseCode !== 0"
-          [class.highlight-row-success]="element.responseCode === 0"
+          [class.highlight-row-warn]="element.responseCode !== '0'"
+          [class.highlight-row-success]="element.responseCode === '0'"
         ></tr>
         <tr
           mat-row

--- a/src/app/connections/connections.interfaces.ts
+++ b/src/app/connections/connections.interfaces.ts
@@ -28,7 +28,8 @@ export enum ConnectionsFilterType {
   CURRENT_CONNECTIONS = "currentConnections",
   DISCREPANCIES = "discrepancies",
   ALL = "all",
-  HIDDEN = "hidden"
+  HIDDEN = "hidden",
+  EXCEPTIONSLOG = "exceptionsLog"
 }
 
 export interface IConnectionsTableFilters extends ITableFilters {

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { ActivatedRouteSnapshot } from "@angular/router";
 import { Store } from "@ngxs/store";
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
 import { generateColumnData } from "../records/constants";
 import { RecordsResolver } from "../records/records.resolver";
 import { RecordsService } from "../records/services/records.service";
@@ -15,10 +15,7 @@ import { ITableFilters, stateName } from "../records/records.interfaces";
 import { TABLE_FILTERS_FORM_BASE } from "../connections/constants";
 import { FormControlBase } from "../shared/form-controls/form-contol-base.model";
 @Injectable()
-export class ConnectionsResolver
-  extends RecordsResolver
-  
-{
+export class ConnectionsResolver extends RecordsResolver {
   constructor(
     protected store: Store,
     protected recordsService: RecordsService,
@@ -47,6 +44,11 @@ export class ConnectionsResolver
       {
         label: "DISCREPANCIES",
         name: ConnectionsFilterType.DISCREPANCIES
+      },
+
+      {
+        label: "EXCEPTIONS LIST",
+        name: ConnectionsFilterType.EXCEPTIONSLOG
       }
     ];
 
@@ -62,7 +64,10 @@ export class ConnectionsResolver
       this.store.selectSnapshot(
         (snapshot) => snapshot.connections.tableFilters
       );
-
+    if (route.queryParams.filter === ConnectionsFilterType.EXCEPTIONSLOG) {
+      this.recordsService.filter(route.queryParams.filter);
+      return of(null);
+    }
     const filterParamsExists = Object.keys(route.queryParams).some((param) =>
       TABLE_FILTERS_FORM_BASE.map((tableFilter) => tableFilter.key).includes(
         param

--- a/src/app/connections/constants.ts
+++ b/src/app/connections/constants.ts
@@ -10,6 +10,11 @@ export const COLUMN_DATA: [string, string, boolean][] = [
   ["Programme owner", "tcsDesignatedBody", true],
   ["Programme membership", "programmeMembershipType", false]
 ];
+export const EXCEPTIONSLOG_COLUMN_DATA: { name: string; label: string }[] = [
+  { name: "timestamp", label: "Date/time" },
+  { name: "gmcId", label: "GMC Number" },
+  { name: "errorMessage", label: "Error message" }
+];
 
 export const TABLE_FILTERS_FORM_BASE: Array<
   FormControlBase | AutocompleteControl

--- a/src/app/connections/exceptions-log/exceptions-log.component.html
+++ b/src/app/connections/exceptions-log/exceptions-log.component.html
@@ -1,0 +1,66 @@
+<ng-container id="ShowError" *ngIf="pageStatus === 'error'">
+  <div data-test="ErrorMessage" class="mt-20 d-flex justify-content-center">
+    Exceptions data failed to load.
+  </div>
+</ng-container>
+<ng-container id="ShowLoadingSpinner" *ngIf="pageStatus === 'loading'">
+  <div
+    class="d-flex align-content-center justify-content-center align-items-center progress-spinner"
+  >
+    <mat-spinner></mat-spinner>
+  </div>
+</ng-container>
+
+<ng-container id="NoExceptionDataFound" *ngIf="pageStatus === 'empty'">
+  <div
+    data-test="NoExceptionsMessage"
+    class="mt-20 d-flex justify-content-center"
+  >
+    No exceptions found.
+  </div>
+</ng-container>
+
+<ng-container id="ExceptionDataFound" *ngIf="pageStatus === 'ok'">
+  <h2 class="ml-20 mt-20">
+    List of errors from unsuccessful connection updates made today by currennt
+    user.
+  </h2>
+
+  <table
+    class="w-100"
+    mat-table
+    [dataSource]="dataSource"
+    matSort
+    matSortActive="timestamp"
+    matSortDirection="desc"
+    matSortDisableClear
+  >
+    <caption class="collapsed no-height">
+      List of connection update errors from today.
+    </caption>
+    <ng-container
+      [matColumnDef]="column.name"
+      *ngFor="let column of displayedColumns"
+    >
+      <th mat-header-cell [mat-sort-header]="column.name" *matHeaderCellDef>
+        {{ column.label }}
+      </th>
+      <td mat-cell *matCellDef="let cell">
+        <ng-container *ngIf="column.name === 'timestamp'; else notDate">
+          {{ cell[column.name] | date: dateFormat }}
+        </ng-container>
+        <ng-template #notDate>
+          {{ cell[column.name] }}
+        </ng-template>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumnNames"></tr>
+    <tr
+      tabindex="0"
+      mat-row
+      *matRowDef="let row; columns: displayedColumnNames"
+      (click)="navigateToDetails($event, row)"
+    ></tr>
+  </table>
+</ng-container>

--- a/src/app/connections/exceptions-log/exceptions-log.component.html
+++ b/src/app/connections/exceptions-log/exceptions-log.component.html
@@ -16,14 +16,13 @@
     data-test="NoExceptionsMessage"
     class="mt-20 d-flex justify-content-center"
   >
-    No exceptions found.
+    No exceptions from today found.
   </div>
 </ng-container>
 
 <ng-container id="ExceptionDataFound" *ngIf="pageStatus === 'ok'">
   <h2 class="ml-20 mt-20">
-    List of errors from unsuccessful connection updates made today by currennt
-    user.
+    List of errors from unsuccessful connections made today by current user.
   </h2>
 
   <table

--- a/src/app/connections/exceptions-log/exceptions-log.component.spec.ts
+++ b/src/app/connections/exceptions-log/exceptions-log.component.spec.ts
@@ -1,0 +1,82 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ExceptionsLogService } from "./services/exceptions-log.service";
+import { ExceptionsLogComponent } from "./exceptions-log.component";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { of } from "rxjs";
+import { MaterialModule } from "src/app/shared/material/material.module";
+import { NgxsModule } from "@ngxs/store";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { By } from "@angular/platform-browser";
+import { mockExceptions } from "./mock-data/exceptions-log-spec-data";
+
+describe("ExceptionsLogComponent", () => {
+  let component: ExceptionsLogComponent;
+  let fixture: ComponentFixture<ExceptionsLogComponent>;
+  let service: jasmine.SpyObj<ExceptionsLogService>;
+  const expectedColumnNames = ["GMC Number", "Error message", "Date/time"];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        MaterialModule,
+        NgxsModule.forRoot(),
+        BrowserAnimationsModule
+      ],
+      providers: [
+        {
+          provide: ExceptionsLogService,
+          useValue: { getExceptions: () => of(mockExceptions) }
+        }
+      ],
+      declarations: [ExceptionsLogComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExceptionsLogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should get data when init", () => {
+    component.exceptionsLogData$.subscribe((exceptions) => {
+      expect(exceptions).toEqual(mockExceptions);
+    });
+  });
+
+  it("Display correct columns names", () => {
+    const tableHeaders = fixture.debugElement.queryAll(By.css("th"));
+    expect(tableHeaders.length).toEqual(expectedColumnNames.length);
+    tableHeaders.forEach((tableHeader) => {
+      expect(expectedColumnNames).toContain(
+        tableHeader.nativeElement.innerText
+      );
+    });
+  });
+
+  it("Should display message when no exceptions found.", () => {
+    component.exceptionsLogData$ = of([]);
+    fixture.detectChanges();
+    const header = fixture.debugElement.nativeElement.querySelector(
+      "[data-test='NoExceptionsMessage']"
+    );
+    expect(header).toBeTruthy;
+  });
+
+  it("should select correct GMC id when clicking on a row", () => {
+    const navigateSpy = spyOn(component, "navigateToDetails");
+    const pointerEvent: PointerEvent = new PointerEvent("PointerEvent");
+
+    const dataRow = fixture.debugElement.nativeElement.querySelector(
+      "tbody tr:first-child"
+    );
+    dataRow.click();
+    expect(navigateSpy).toHaveBeenCalledWith(pointerEvent, mockExceptions[0]);
+  });
+});

--- a/src/app/connections/exceptions-log/exceptions-log.component.ts
+++ b/src/app/connections/exceptions-log/exceptions-log.component.ts
@@ -1,0 +1,62 @@
+import { Component, ViewChild, OnInit } from "@angular/core";
+import { ExceptionsLogService } from "./services/exceptions-log.service";
+import { IException } from "./exceptions-log.interface";
+import { Observable, of } from "rxjs";
+import { catchError } from "rxjs/operators";
+import { environment } from "@environment";
+import { MatSort } from "@angular/material/sort";
+import { MatTableDataSource } from "@angular/material/table";
+import { RecordsService } from "src/app/records/services/records.service";
+import { Router } from "@angular/router";
+import { EXCEPTIONSLOG_COLUMN_DATA } from "../constants";
+@Component({
+  selector: "app-exceptions-log",
+  templateUrl: "./exceptions-log.component.html"
+})
+export class ExceptionsLogComponent implements OnInit {
+  constructor(
+    private exceptionsLogService: ExceptionsLogService,
+    protected router: Router,
+    private recordsService: RecordsService
+  ) {}
+
+  @ViewChild(MatSort) set matSort(sort: MatSort) {
+    if (sort && this.dataSource) {
+      this.dataSource.sort = sort;
+    }
+  }
+
+  pageStatus: string = "loading";
+  dataSource: MatTableDataSource<IException>;
+  dateFormat: string = environment.dateTimeFormat;
+  displayedColumns = EXCEPTIONSLOG_COLUMN_DATA;
+  displayedColumnNames = this.displayedColumns.map((column) => column.name);
+  exceptionsLogData$: Observable<IException[]> = this.exceptionsLogService
+    .getExceptions()
+    .pipe(
+      catchError(() => {
+        this.pageStatus = "error";
+        return of(null);
+      })
+    );
+
+  ngOnInit(): void {
+    this.exceptionsLogData$.subscribe((exceptions) => {
+      if (this.pageStatus !== "error") {
+        this.dataSource = new MatTableDataSource(exceptions);
+        if (exceptions?.length) {
+          this.pageStatus = "ok";
+        } else {
+          this.pageStatus = "empty";
+        }
+      }
+    });
+  }
+  navigateToDetails(event: Event, row: any): void {
+    event.stopPropagation();
+    this.pageStatus = "loading";
+    if (row.gmcId) {
+      this.router.navigate([this.recordsService.detailsRoute, row.gmcId]);
+    }
+  }
+}

--- a/src/app/connections/exceptions-log/exceptions-log.interface.ts
+++ b/src/app/connections/exceptions-log/exceptions-log.interface.ts
@@ -1,0 +1,6 @@
+export interface IException {
+  gmcId: number;
+  errorMessage: string;
+  timestamp: Date;
+  admin: string;
+}

--- a/src/app/connections/exceptions-log/mock-data/exceptions-log-spec-data.ts
+++ b/src/app/connections/exceptions-log/mock-data/exceptions-log-spec-data.ts
@@ -1,0 +1,26 @@
+import { IException } from "../exceptions-log.interface";
+
+export const exceptionsJson = `
+[
+    {
+        "gmcId": "1",
+        "errorMessage": "Error message",
+        "timestamp": "2023-10-18T14:45:43.793",
+        "admin": "admin"
+    },
+    {
+        "gmcId": "1",
+        "errorMessage": "Error message",
+        "timestamp": "2023-10-18T14:45:47.337",
+        "admin": "admin"
+    },
+    {
+        "gmcId": "3",
+        "errorMessage": "Error message",
+        "timestamp": "2023-10-18T14:45:47.337",
+        "admin": "admin"
+    }
+
+]
+`;
+export const mockExceptions: IException[] = JSON.parse(exceptionsJson);

--- a/src/app/connections/exceptions-log/mock-data/exceptions-log-spec-data.ts
+++ b/src/app/connections/exceptions-log/mock-data/exceptions-log-spec-data.ts
@@ -2,12 +2,7 @@ import { IException } from "../exceptions-log.interface";
 
 export const exceptionsJson = `
 [
-    {
-        "gmcId": "1",
-        "errorMessage": "Error message",
-        "timestamp": "2023-10-18T14:45:43.793",
-        "admin": "admin"
-    },
+   
     {
         "gmcId": "1",
         "errorMessage": "Error message",
@@ -18,6 +13,12 @@ export const exceptionsJson = `
         "gmcId": "3",
         "errorMessage": "Error message",
         "timestamp": "2023-10-18T14:45:47.337",
+        "admin": "admin"
+    },
+    {
+        "gmcId": "1",
+        "errorMessage": "Error message",
+        "timestamp": "2023-10-18T14:45:43.793",
         "admin": "admin"
     }
 

--- a/src/app/connections/exceptions-log/services/exceptions-log.service.spec.ts
+++ b/src/app/connections/exceptions-log/services/exceptions-log.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from "@angular/core/testing";
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from "@angular/common/http/testing";
+import { ExceptionsLogService } from "./exceptions-log.service";
+import { mockExceptions } from "../mock-data/exceptions-log-spec-data";
+
+describe("ExceptionsLogService", () => {
+  let service: ExceptionsLogService;
+  let httpMock: HttpTestingController;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(ExceptionsLogService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("should get exception log when 'getExceptions' method is called", () => {
+    service.getExceptions().subscribe((exceptions) => {
+      expect(exceptions).toBeTruthy();
+      expect(exceptions).toEqual(mockExceptions);
+    });
+
+    const mockHttp = httpMock.expectOne({
+      url: "api/connection/exceptionLog/today?admin="
+    });
+    const httpRequest = mockHttp.request;
+    expect(httpRequest.method).toEqual("GET");
+    mockHttp.flush(mockExceptions);
+  });
+});

--- a/src/app/connections/exceptions-log/services/exceptions-log.service.ts
+++ b/src/app/connections/exceptions-log/services/exceptions-log.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from "@angular/core";
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { Observable, catchError, throwError } from "rxjs";
+import { environment } from "@environment";
+import { IException } from "../exceptions-log.interface";
+import { AuthService } from "src/app/core/auth/auth.service";
+
+@Injectable({
+  providedIn: "root"
+})
+export class ExceptionsLogService {
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService
+  ) {}
+
+  getExceptions(): Observable<IException[]> {
+    const params: HttpParams = new HttpParams().set(
+      "admin",
+      this.authService.userName
+    );
+
+    return this.http
+      .get<IException[]>(`${environment.appUrls.getExceptionsLog}`, {
+        params
+      })
+      .pipe(
+        catchError((error) => {
+          return throwError(() => new Error(error));
+        })
+      );
+  }
+}

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -5,9 +5,8 @@ import {
   HttpEvent,
   HttpInterceptor
 } from "@angular/common/http";
-import { Observable, of, from } from "rxjs";
+import { Observable, throwError } from "rxjs";
 import { switchMap, catchError } from "rxjs/operators";
-import { Auth } from "aws-amplify";
 import { AuthService } from "./auth.service";
 
 @Injectable()
@@ -28,7 +27,7 @@ export class AuthInterceptor implements HttpInterceptor {
         });
         return next.handle(request);
       }),
-      catchError((error: any) => of(error))
+      catchError((error) => throwError(() => new Error(error)))
     );
   }
 }

--- a/src/app/records/records.component.html
+++ b/src/app/records/records.component.html
@@ -8,39 +8,42 @@
 </div>
 
 <ng-template #notLoading>
-  <div class="d-grid records-top-section align-items-center sticky-toolbar">
-    <app-record-search></app-record-search>
-    <app-refresh-data-btn class="d-grid pl-5"></app-refresh-data-btn>
-    <app-record-list-paginator></app-record-list-paginator>
-  </div>
+  <app-exceptions-log *ngIf="isExceptionsLog$ | async; else showRecords"></app-exceptions-log>
+  <ng-template #showRecords>
+    <div class="d-grid records-top-section align-items-center sticky-toolbar">
+      <app-record-search></app-record-search>
+      <app-refresh-data-btn class="d-grid pl-5"></app-refresh-data-btn>
+      <app-record-list-paginator></app-record-list-paginator>
+    </div>
 
-  <app-update-connection
-    *ngIf="enableUpdateConnections$ | async"
-    (submittFormEvent)="onSubmitConnections($event)"
-  >
-  </app-update-connection>
-  <app-allocate-admin-actions
-    *ngIf="enableAllocateAdmin$ | async"
-  ></app-allocate-admin-actions>
-
-  <mat-drawer-container
-    *ngIf="showTableFilters; else noTableFilters"
-    class="filters-drawer-container"
-  >
-    <mat-drawer
-      #filtersDrawer
-      mode="side"
-      [opened]="filterPanelOpen"
-      [disableClose]="true"
+    <app-update-connection
+      *ngIf="enableUpdateConnections$ | async"
+      (submittFormEvent)="onSubmitConnections($event)"
     >
-      <app-record-list-table-filters></app-record-list-table-filters>
-    </mat-drawer>
-    <mat-drawer-content>
-      <app-record-list></app-record-list>
-    </mat-drawer-content>
-  </mat-drawer-container>
+    </app-update-connection>
+    <app-allocate-admin-actions
+      *ngIf="enableAllocateAdmin$ | async"
+    ></app-allocate-admin-actions>
 
-  <ng-template #noTableFilters>
-    <app-record-list></app-record-list>
+    <mat-drawer-container
+      *ngIf="showTableFilters; else noTableFilters"
+      class="filters-drawer-container"
+    >
+      <mat-drawer
+        #filtersDrawer
+        mode="side"
+        [opened]="filterPanelOpen"
+        [disableClose]="true"
+      >
+        <app-record-list-table-filters></app-record-list-table-filters>
+      </mat-drawer>
+      <mat-drawer-content>
+        <app-record-list></app-record-list>
+      </mat-drawer-content>
+    </mat-drawer-container>
+
+    <ng-template #noTableFilters>
+      <app-record-list></app-record-list>
+    </ng-template>
   </ng-template>
 </ng-template>

--- a/src/app/records/records.component.ts
+++ b/src/app/records/records.component.ts
@@ -7,9 +7,10 @@ import {
   OnDestroy
 } from "@angular/core";
 import { Store } from "@ngxs/store";
-import { Observable, Subscription } from "rxjs";
+import { Observable, Subscription, map } from "rxjs";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { RecordsService } from "./services/records.service";
+import { ConnectionsFilterType } from "../connections/connections.interfaces";
 
 @Component({
   selector: "app-records",
@@ -31,6 +32,9 @@ export class RecordsComponent implements OnInit, OnDestroy {
     (state) => state[this.recordsService.stateName].enableAllocateAdmin
   );
 
+  public isExceptionsLog$: Observable<boolean> = this.store
+    .select((state) => state[this.recordsService.stateName].filter)
+    .pipe(map((filter) => filter === ConnectionsFilterType.EXCEPTIONSLOG));
   constructor(
     private store: Store,
     private recordsService: RecordsService,

--- a/src/app/records/records.module.ts
+++ b/src/app/records/records.module.ts
@@ -16,6 +16,7 @@ import { RecordsService } from "./services/records.service";
 import { RecordListTableFiltersComponent } from "./record-list-table-filters/record-list-table-filters.component";
 import { RecordListState } from "./record-list/state/record-list.state";
 import { NgxsModule } from "@ngxs/store";
+import { ExceptionsLogComponent } from "../connections/exceptions-log/exceptions-log.component";
 const components: any[] = [
   RecordListComponent,
   RecordListFiltersComponent,
@@ -24,7 +25,8 @@ const components: any[] = [
   RecordSearchComponent,
   RefreshDataBtnComponent,
   ResetRecordListComponent,
-  RecordListTableFiltersComponent
+  RecordListTableFiltersComponent,
+  ExceptionsLogComponent
 ];
 
 @NgModule({

--- a/src/environments/constants.ts
+++ b/src/environments/constants.ts
@@ -13,6 +13,7 @@ export const APP_URLS_CONFIG: IAppUrls = {
   getConnections: `api/connection`,
   getDbcs: `api/reference/dbcs`,
   getDetails: `api/trainee`,
+  getExceptionsLog: `api/connection/exceptionLog/today`,
   getNotes: `mocky/5ea2da614f00006c00d9f540`,
   getRecommendation: `api/recommendation`,
   getRecommendations: `api/v1/doctors`,

--- a/src/environments/environment.common.ts
+++ b/src/environments/environment.common.ts
@@ -10,6 +10,7 @@ export const commonEnv: IEnvironment = {
   adminsUIHostUri: `https://stage-apps.tis.nhs.uk/`,
   supportLink: `https://teams.microsoft.com/l/channel/19%3ac7943c6ffa9c49b881304863bb39ff7b%40thread.skype/General?groupId=102f33a3-f794-4089-8c5a-68e04897e72e&tenantId=ffa7912b-b097-4131-9c0f-d0e80755b2ab`,
   dateFormat: "dd/MM/yyyy",
+  dateTimeFormat: "dd/MM/yyyy HH:mm:ss",
   appUrls: APP_URLS_CONFIG,
   londonDBCs: [
     {

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -39,6 +39,7 @@ export interface IAppUrls {
   readonly getConnections: string;
   readonly getDbcs: string;
   readonly getDetails: string;
+  readonly getExceptionsLog: string;
   readonly getNotes: string;
   readonly getRecommendation: string;
   readonly getRecommendations: string;

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -2,6 +2,7 @@ export interface IEnvironment {
   readonly appVersion: string;
   readonly adminsUIHostUri: string; // admins-ui related links
   readonly dateFormat: string; // TODO: when implementing i18n localization use value from locale
+  readonly dateTimeFormat: string;
   readonly gtmID: string;
   readonly name: string; // environment name
   readonly production: boolean; // build mode


### PR DESCRIPTION
Display the exceptions log for connection updates made by the current user today. The records list component isn't suitable to display the exceptions due to the different data models and features like pagination, search and filtering are not required. However, it feels appropriate to add the link as a new tab under connections. A new component and service is used to fetch and display the exceptions log which is conditionally displayed in the connections section according to the filter property.

TIS21-5151: Show log of errors when adding/removing connections     