### PR TITLE
test: update tab label

### DIFF
--- a/cypress/e2e/app/connections/summary-records-list.cy.ts
+++ b/cypress/e2e/app/connections/summary-records-list.cy.ts
@@ -22,7 +22,11 @@ describe("Connections Summary Records List", () => {
     "Programme owner"
   ];
 
-  const filters = ["DISCREPANCIES", "CURRENT CONNECTIONS", "EXCEPTIONS LIST"];
+  const filters = [
+    "DISCREPANCIES",
+    "CURRENT CONNECTIONS",
+    "FAILED GMC UPDATES"
+  ];
 
   it("should display correct page filter tabs", () => {
     cy.get("app-record-list-filters a").each(($el) => {


### PR DESCRIPTION
TIS21-5250: Rename Exception Logs to "Failed GMC Updates" in FE