### PR TITLE
style: wrap text in table headers when autofit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revalidation",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "scripts": {
     "ng": "ng",
     "start": "npm run build:misc && ng serve",

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -16,8 +16,13 @@
   <ng-template #notLoading>
     <!--  error -->
     <div *ngIf="data.error; else items" class="d-grid justify-content-center">
-      <mat-chip-listbox class="mat-chip-list-stacked" aria-orientation="vertical">
-        <mat-chip-option selected color="warn">{{ data.error }}</mat-chip-option>
+      <mat-chip-listbox
+        class="mat-chip-list-stacked"
+        aria-orientation="vertical"
+      >
+        <mat-chip-option selected color="warn">{{
+          data.error
+        }}</mat-chip-option>
       </mat-chip-listbox>
     </div>
 
@@ -53,6 +58,7 @@
             >
               <!-- header cell -->
               <th
+                [ngClass]="(fixedColumns$ | async) && 'fixed'"
                 mat-header-cell
                 *matHeaderCellDef
                 [mat-sort-header]="i.name"

--- a/src/app/records/record-list/record-list.component.scss
+++ b/src/app/records/record-list/record-list.component.scss
@@ -7,9 +7,6 @@
 }
 
 ::ng-deep {
-  .mat-mdc-table th {
-    white-space: nowrap;
-  }
   .mat-column-programmeName {
     .split-item {
       display: block;
@@ -20,6 +17,9 @@
       padding-bottom: 4px;
     }
   }
+}
+th.fixed {
+  white-space: nowrap;
 }
 
 // common columns


### PR DESCRIPTION
When toggling the table columns to fit the screen, the table headers were not wrapping so the table extended outside the screen, especially when filter panel is open forcing scrolling. Set table headers to to not wrap when fixed and auto wrap when not.

NO TICKET