### PR TITLE
Feat/show list of hidden discrepancies

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,14 +24,25 @@ module.exports = function (config) {
     reporters: ["mocha", "kjhtml"],
     port: 9876,
     colors: true,
-    logLevel: config.LOG_DISABLE,
+    logLevel: config.LOG_INFO,
     browserConsoleLogOptions: {
-      level: "error",
+      level: "",
       format: "%b %T: %m",
       terminal: true
     },
     autoWatch: true,
-    browsers: ["Chrome"],
+    browsers: ["CustomChromeHeadless"],
+    customLaunchers: {
+      CustomChromeHeadless: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox", "--disable-web-security", "--disable-gpu"]
+      },
+      Chrome_with_debugging: {
+        base: "Chrome",
+        flags: ["--remote-debugging-port=9222"],
+        debug: true
+      }
+    },
     singleRun: false,
     restartOnFileChange: true,
     mochaReporter: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,9 +24,9 @@ module.exports = function (config) {
     reporters: ["mocha", "kjhtml"],
     port: 9876,
     colors: true,
-    logLevel: config.LOG_INFO,
+    logLevel: config.LOG_DISABLE,
     browserConsoleLogOptions: {
-      level: "",
+      level: "disable",
       format: "%b %T: %m",
       terminal: true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revalidation",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "scripts": {
     "ng": "ng",
     "start": "npm run build:misc && ng serve",

--- a/src/app/concerns/concerns.resolver.ts
+++ b/src/app/concerns/concerns.resolver.ts
@@ -3,14 +3,13 @@ import { ActivatedRouteSnapshot } from "@angular/router";
 import { Store } from "@ngxs/store";
 import { Observable } from "rxjs";
 import { ConcernStatus } from "../concern/concern.interfaces";
-import { generateColumnData } from "../records/constants";
 import { RecordsResolver } from "../records/records.resolver";
 import { RecordsService } from "../records/services/records.service";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { COLUMN_DATA } from "./constants";
 
 @Injectable()
-export class ConcernsResolver extends RecordsResolver  {
+export class ConcernsResolver extends RecordsResolver {
   constructor(
     protected store: Store,
     protected recordsService: RecordsService,
@@ -25,13 +24,7 @@ export class ConcernsResolver extends RecordsResolver  {
     this.recordsService.detailsRoute = "/concern";
     this.recordsService.showTableFilters = false;
     this.recordsService.setConcernsActions();
-    this.recordsService.dateColumns = [
-      "closedDate",
-      "dateRaised",
-      "dateAdded",
-      "followUpDate"
-    ];
-    this.recordsService.columnData = generateColumnData(COLUMN_DATA);
+    this.recordsService.columnData = [...COLUMN_DATA];
     this.recordsService.filters = [
       {
         label: "OPEN",

--- a/src/app/concerns/constants.ts
+++ b/src/app/concerns/constants.ts
@@ -1,11 +1,28 @@
-export const COLUMN_DATA: [string, string, boolean][] = [
-  ["Programme", "programme", false],
-  ["Date raised", "dateRaised", false],
-  ["Type", "type", false],
-  ["Site", "site", false],
-  ["Source", "source", false],
-  ["Status", "status", false],
-  ["Admin", "admin", false],
-  ["Follow-up date", "followUpDate", false],
-  ["Closed date", "closedDate", false]
+import { IRecordDataCell } from "../records/records.interfaces";
+
+export const COLUMN_DATA: IRecordDataCell[] = [
+  { label: "Programme", name: "programme", enableSort: false },
+  {
+    label: "Date raised",
+    name: "dateRaised",
+    enableSort: false,
+    displayType: "date"
+  },
+  { label: "Type", name: "type", enableSort: false },
+  { label: "Site", name: "site", enableSort: false },
+  { label: "Source", name: "source", enableSort: false },
+  { label: "Status", name: "status", enableSort: false },
+  { label: "Admin", name: "admin", enableSort: false },
+  {
+    label: "Follow-up date",
+    name: "followUpDate",
+    enableSort: false,
+    displayType: "date"
+  },
+  {
+    label: "Closed date",
+    name: "closedDate",
+    enableSort: false,
+    displayType: "date"
+  }
 ];

--- a/src/app/connections/connections.component.ts
+++ b/src/app/connections/connections.component.ts
@@ -56,7 +56,7 @@ export class ConnectionsComponent implements OnDestroy {
             (c) => c.action !== ActionType.UNHIDE_CONNECTION
           );
           break;
-        case ConnectionsFilterType.HIDDEN:
+        case ConnectionsFilterType.HIDDEN_DISCREPANCIES:
           actions = actions.filter(
             (c) => c.action !== ActionType.HIDE_CONNECTION
           );

--- a/src/app/connections/connections.interfaces.ts
+++ b/src/app/connections/connections.interfaces.ts
@@ -28,7 +28,7 @@ export enum ConnectionsFilterType {
   CURRENT_CONNECTIONS = "currentConnections",
   DISCREPANCIES = "discrepancies",
   ALL = "all",
-  HIDDEN = "hidden",
+  HIDDEN_DISCREPANCIES = "hiddenDiscrepancies",
   EXCEPTIONSLOG = "exceptionsLog"
 }
 

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -48,6 +48,10 @@ export class ConnectionsResolver extends RecordsResolver {
         label: "DISCREPANCIES",
         name: ConnectionsFilterType.DISCREPANCIES
       },
+      {
+        label: "HIDDEN DISCREPANCIES",
+        name: ConnectionsFilterType.HIDDEN_DISCREPANCIES
+      },
 
       {
         label: "FAILED GMC UPDATES",

--- a/src/app/connections/connections.resolver.ts
+++ b/src/app/connections/connections.resolver.ts
@@ -13,7 +13,8 @@ import {
 import {
   COLUMN_DATA,
   TABLE_FILTERS_FORM_DBC_LONDON,
-  TABLE_FILTERS_FORM_DBC
+  TABLE_FILTERS_FORM_DBC,
+  HIDDEN_DISCREPANCIES_COLUMN_DATA
 } from "./constants";
 import { stateName } from "../records/records.interfaces";
 import { TABLE_FILTERS_FORM_BASE } from "../connections/constants";
@@ -73,9 +74,21 @@ export class ConnectionsResolver extends RecordsResolver {
   }
 
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
-    if (route.queryParams.filter === ConnectionsFilterType.EXCEPTIONSLOG) {
-      this.recordsService.filter(route.queryParams.filter);
-      return of(null);
+    switch (route.queryParams.filter) {
+      case ConnectionsFilterType.EXCEPTIONSLOG:
+        this.recordsService.filter(route.queryParams.filter);
+        return of(null);
+      case ConnectionsFilterType.HIDDEN_DISCREPANCIES:
+        this.recordsService.updateColumnData([
+          ...RECORDS_COLUMN_DATA,
+          ...HIDDEN_DISCREPANCIES_COLUMN_DATA
+        ]);
+        break;
+      default:
+        this.recordsService.updateColumnData([
+          ...RECORDS_COLUMN_DATA,
+          ...COLUMN_DATA
+        ]);
     }
 
     const tableFiltersState: IConnectionsTableFilters =

--- a/src/app/connections/constants.ts
+++ b/src/app/connections/constants.ts
@@ -67,6 +67,28 @@ export const COLUMN_DATA: IRecordDataCell[] = [
   }
 ];
 
+export const HIDDEN_DISCREPANCIES_COLUMN_DATA: IRecordDataCell[] = [
+  {
+    label: "GMC Designated body",
+    name: "designatedBody",
+    enableSort: true,
+    displayType: "dbc"
+  },
+
+  {
+    label: "Programme owner",
+    name: "tcsDesignatedBody",
+    enableSort: true,
+    displayType: "dbc"
+  },
+
+  {
+    label: "Programme name",
+    name: "programmeName",
+    enableSort: false
+  }
+];
+
 export const EXCEPTIONSLOG_COLUMN_DATA: { name: string; label: string }[] = [
   { name: "timestamp", label: "Date/time" },
   { name: "gmcId", label: "GMC Number" },

--- a/src/app/connections/constants.ts
+++ b/src/app/connections/constants.ts
@@ -10,6 +10,12 @@ import { IRecordDataCell } from "../records/records.interfaces";
 
 export const COLUMN_DATA: IRecordDataCell[] = [
   {
+    label: "Notes",
+    name: "notes",
+    enableSort: false,
+    displayType: "boolean"
+  },
+  {
     label: "GMC Submission date",
     name: "submissionDate",
     enableSort: true,

--- a/src/app/connections/constants.ts
+++ b/src/app/connections/constants.ts
@@ -117,7 +117,11 @@ export const TABLE_FILTERS_FORM_BASE: Array<
     order: 4,
     controlType: FormControlType.DATERANGE,
     startRangeControl: "From",
-    endRangeControl: "To"
+    endRangeControl: "To",
+    filterType: [
+      ConnectionsFilterType.DISCREPANCIES,
+      ConnectionsFilterType.CURRENT_CONNECTIONS
+    ]
   },
   {
     key: "membershipEndDate",
@@ -125,7 +129,11 @@ export const TABLE_FILTERS_FORM_BASE: Array<
     order: 5,
     controlType: FormControlType.DATERANGE,
     startRangeControl: "From",
-    endRangeControl: "To"
+    endRangeControl: "To",
+    filterType: [
+      ConnectionsFilterType.DISCREPANCIES,
+      ConnectionsFilterType.CURRENT_CONNECTIONS
+    ]
   },
   {
     key: "lastConnectionDateTime",
@@ -133,7 +141,11 @@ export const TABLE_FILTERS_FORM_BASE: Array<
     order: 6,
     controlType: FormControlType.DATERANGE,
     startRangeControl: "From",
-    endRangeControl: "To"
+    endRangeControl: "To",
+    filterType: [
+      ConnectionsFilterType.DISCREPANCIES,
+      ConnectionsFilterType.CURRENT_CONNECTIONS
+    ]
   },
   {
     key: "updatedBy",
@@ -142,7 +154,11 @@ export const TABLE_FILTERS_FORM_BASE: Array<
     controlType: FormControlType.AUTOCOMPLETE,
     placeholder: "Start typing...",
     minLengthTerm: 1,
-    dataService: "getAdmins"
+    dataService: "getAdmins",
+    filterType: [
+      ConnectionsFilterType.DISCREPANCIES,
+      ConnectionsFilterType.CURRENT_CONNECTIONS
+    ]
   }
 ];
 
@@ -153,7 +169,7 @@ export const TABLE_FILTERS_FORM_DBC: FormControlBase[] = [
     order: 1,
     valueProperty: "userDesignatedBodies",
     controlType: FormControlType.CHECKBOX,
-    filterType: ConnectionsFilterType.DISCREPANCIES
+    filterType: [ConnectionsFilterType.DISCREPANCIES]
   },
   {
     key: "dbcs",
@@ -161,7 +177,7 @@ export const TABLE_FILTERS_FORM_DBC: FormControlBase[] = [
     order: 2,
     valueProperty: "userDesignatedBodies",
     controlType: FormControlType.CHECKBOX,
-    filterType: ConnectionsFilterType.DISCREPANCIES
+    filterType: [ConnectionsFilterType.DISCREPANCIES]
   }
 ];
 
@@ -173,7 +189,7 @@ export const TABLE_FILTERS_FORM_DBC_LONDON: FormControlBase[] = [
     order: 1,
     controlType: FormControlType.SELECTION_LIST,
     initialValue: [],
-    filterType: ConnectionsFilterType.DISCREPANCIES
+    filterType: [ConnectionsFilterType.DISCREPANCIES]
   },
   {
     key: "tisDesignatedBodies",
@@ -182,6 +198,6 @@ export const TABLE_FILTERS_FORM_DBC_LONDON: FormControlBase[] = [
     order: 2,
     controlType: FormControlType.SELECTION_LIST,
     initialValue: [],
-    filterType: ConnectionsFilterType.DISCREPANCIES
+    filterType: [ConnectionsFilterType.DISCREPANCIES]
   }
 ];

--- a/src/app/connections/state/connections.actions.ts
+++ b/src/app/connections/state/connections.actions.ts
@@ -1,4 +1,5 @@
 import {
+  ColumnDataPayload,
   EnableAllocateAdminPayload,
   FilterPayload,
   GetSuccessPayload,
@@ -82,4 +83,8 @@ export class ToggleAllConnectionsCheckboxes {
 
 export class UpdateConnectionsQueryParams extends QueryParamsPayload {
   static readonly type = "[Connections] Update query params";
+}
+
+export class UpdateConnectionsColumnData extends ColumnDataPayload {
+  static readonly type = "[Connections] Update column data";
 }

--- a/src/app/connections/state/connections.state.ts
+++ b/src/app/connections/state/connections.state.ts
@@ -71,11 +71,12 @@ export class ConnectionsState extends RecordsState {
       case ConnectionsFilterType.DISCREPANCIES:
         endPoint = `${endPoint}/discrepancies`;
         break;
-
+      case ConnectionsFilterType.HIDDEN_DISCREPANCIES:
+        endPoint = `${endPoint}/discrepancies/hidden`;
+        break;
       case ConnectionsFilterType.CURRENT_CONNECTIONS:
         endPoint = `${endPoint}/connected`;
         break;
-
       default:
         endPoint = `${endPoint}/connected`;
     }
@@ -106,7 +107,14 @@ export class ConnectionsState extends RecordsState {
     ctx: StateContext<ConnectionsStateModel>,
     action: GetConnectionsSuccess
   ) {
-    return super.getSuccessHandler(ctx, action, "connections");
+    let itemsKey: string = "connections";
+    if (
+      this.connectionsService.getFilter() ===
+      ConnectionsFilterType.HIDDEN_DISCREPANCIES
+    ) {
+      itemsKey = ConnectionsFilterType.HIDDEN_DISCREPANCIES;
+    }
+    return super.getSuccessHandler(ctx, action, itemsKey);
   }
 
   @Action(GetConnectionsError)
@@ -156,7 +164,7 @@ export class ConnectionsState extends RecordsState {
       filter: action.filter,
       disableSearchAndSort:
         action.filter !== ConnectionsFilterType.ALL &&
-        action.filter !== ConnectionsFilterType.HIDDEN &&
+        action.filter !== ConnectionsFilterType.HIDDEN_DISCREPANCIES &&
         action.filter !== ConnectionsFilterType.CURRENT_CONNECTIONS &&
         action.filter !== ConnectionsFilterType.HISTORIC_CONNECTIONS &&
         action.filter !== ConnectionsFilterType.DISCREPANCIES

--- a/src/app/connections/state/connections.state.ts
+++ b/src/app/connections/state/connections.state.ts
@@ -33,8 +33,10 @@ import {
   ToggleConnectionsCheckbox,
   SetConnectionsTableFilters,
   ClearConnectionsTableFilters,
-  UpdateConnectionsQueryParams
+  UpdateConnectionsQueryParams,
+  UpdateConnectionsColumnData
 } from "./connections.actions";
+import { IRecordDataCell } from "src/app/records/records.interfaces";
 
 export class ConnectionsStateModel extends RecordsStateModel<
   ConnectionsFilterType,
@@ -43,6 +45,7 @@ export class ConnectionsStateModel extends RecordsStateModel<
 > {
   public filter: ConnectionsFilterType;
   public disableSearchAndSort: boolean;
+  public columnData: IRecordDataCell[];
 }
 
 @State<ConnectionsStateModel>({
@@ -207,5 +210,13 @@ export class ConnectionsState extends RecordsState {
     action: UpdateConnectionsQueryParams
   ) {
     return super.updateQueryParamsHandler(ctx, action.params);
+  }
+
+  @Action(UpdateConnectionsColumnData)
+  updateColumnData(
+    ctx: StateContext<ConnectionsStateModel>,
+    action: UpdateConnectionsColumnData
+  ) {
+    return super.updateColumnDataHandler(ctx, action.columnData);
   }
 }

--- a/src/app/recommendations/constants.ts
+++ b/src/app/recommendations/constants.ts
@@ -22,6 +22,12 @@ function getEnumKeyByEnumValue<T extends { [index: string]: string }>(
 
 export const COLUMN_DATA: IRecordDataCell[] = [
   {
+    label: "Notes",
+    name: "notes",
+    enableSort: false,
+    displayType: "boolean"
+  },
+  {
     label: "Designated body",
     name: "designatedBody",
     enableSort: false,

--- a/src/app/recommendations/recommendations.resolver.ts
+++ b/src/app/recommendations/recommendations.resolver.ts
@@ -49,12 +49,15 @@ export class RecommendationsResolver extends RecordsResolver {
     this.initFiltersFormData();
 
     if (this.authService.inludesLondonDbcs) {
-      this.recordsService.columnData = [...RECORDS_COLUMN_DATA, ...COLUMN_DATA];
+      this.recordsService.updateColumnData([
+        ...RECORDS_COLUMN_DATA,
+        ...COLUMN_DATA
+      ]);
     } else {
-      this.recordsService.columnData = [
+      this.recordsService.updateColumnData([
         ...RECORDS_COLUMN_DATA,
         ...COLUMN_DATA.filter((column) => column.isLondonOnly !== true)
-      ];
+      ]);
     }
 
     this.recordsService.filters = [

--- a/src/app/recommendations/state/recommendations.actions.ts
+++ b/src/app/recommendations/state/recommendations.actions.ts
@@ -7,7 +7,8 @@ import {
   SortPayload,
   ToggleCheckboxPayload,
   TableFiltersPayload,
-  QueryParamsPayload
+  QueryParamsPayload,
+  ColumnDataPayload
 } from "../../records/state/records.actions";
 import { HttpErrorPayload } from "../../shared/services/error/error.service";
 import {
@@ -82,4 +83,8 @@ export class ToggleAllRecommendationsCheckboxes {
 
 export class UpdateRecommendationsQueryParams extends QueryParamsPayload {
   static readonly type = "[Recommendations] Update query params";
+}
+
+export class UpdateRecommendationsColumnData extends ColumnDataPayload {
+  static readonly type = "[Recommendations] Update column data";
 }

--- a/src/app/recommendations/state/recommendations.state.ts
+++ b/src/app/recommendations/state/recommendations.state.ts
@@ -35,7 +35,8 @@ import {
   SortRecommendations,
   ToggleAllRecommendationsCheckboxes,
   ToggleRecommendationsCheckbox,
-  UpdateRecommendationsQueryParams
+  UpdateRecommendationsQueryParams,
+  UpdateRecommendationsColumnData
 } from "./recommendations.actions";
 
 export class RecommendationsStateModel extends RecordsStateModel<
@@ -213,5 +214,13 @@ export class RecommendationsState extends RecordsState {
     action: UpdateRecommendationsQueryParams
   ) {
     return super.updateQueryParamsHandler(ctx, action.params);
+  }
+
+  @Action(UpdateRecommendationsColumnData)
+  updateColumnData(
+    ctx: StateContext<RecommendationsStateModel>,
+    action: UpdateRecommendationsColumnData
+  ) {
+    return super.updateColumnDataHandler(ctx, action.columnData);
   }
 }

--- a/src/app/records/constants.ts
+++ b/src/app/records/constants.ts
@@ -30,17 +30,3 @@ export const RECORDS_COLUMN_DATA: IRecordDataCell[] = [
     displayType: "boolean"
   }
 ];
-
-export const generateColumnData = (data: any[][]): IRecordDataCell[] => {
-  const generatedData: IRecordDataCell[] = [...RECORDS_COLUMN_DATA];
-
-  data.forEach((item: any[]) => {
-    generatedData.push({
-      label: item[0],
-      name: item[1],
-      enableSort: item[2],
-      sortBy: item[3] || item[1]
-    });
-  });
-  return generatedData;
-};

--- a/src/app/records/constants.ts
+++ b/src/app/records/constants.ts
@@ -22,11 +22,5 @@ export const RECORDS_COLUMN_DATA: IRecordDataCell[] = [
     label: "GMC No",
     name: "gmcReferenceNumber",
     enableSort: true
-  },
-  {
-    label: "Notes",
-    name: "notes",
-    enableSort: false,
-    displayType: "boolean"
   }
 ];

--- a/src/app/records/record-list/record-list.component.html
+++ b/src/app/records/record-list/record-list.component.html
@@ -53,7 +53,7 @@
               Records list
             </caption>
             <ng-container
-              *ngFor="let i of columnData"
+              *ngFor="let i of columnData$ | async"
               matColumnDef="{{ i.name }}"
             >
               <!-- header cell -->
@@ -149,9 +149,11 @@
                 <ng-container
                   *ngIf="!i.displayType || i.displayType === 'string'"
                 >
-                 <span  *ngIf="i.name === 'programmeName'; else NotProgramme" [innerHTML]="element[i.name] | splitStringToHTML"></span>
-                 <ng-template #NotProgramme>{{element[i.name]}}</ng-template>
-                
+                  <span
+                    *ngIf="i.name === 'programmeName'; else NotProgramme"
+                    [innerHTML]="element[i.name] | splitStringToHTML"
+                  ></span>
+                  <ng-template #NotProgramme>{{ element[i.name] }}</ng-template>
                 </ng-container>
               </td>
             </ng-container>

--- a/src/app/records/record-list/record-list.component.spec.ts
+++ b/src/app/records/record-list/record-list.component.spec.ts
@@ -1,5 +1,11 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  waitForAsync
+} from "@angular/core/testing";
 import { Sort as ISort } from "@angular/material/sort";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Router } from "@angular/router";
@@ -17,10 +23,35 @@ import { IRecommendation } from "../../recommendations/recommendations.interface
 import { mockRecommendationsResponse } from "../../recommendations/services/recommendations.service.spec";
 import { RecommendationsState } from "../../recommendations/state/recommendations.state";
 import { MaterialModule } from "../../shared/material/material.module";
-import { DEFAULT_SORT, generateColumnData } from "../constants";
+import { DEFAULT_SORT } from "../constants";
 import { RecordsService } from "../services/records.service";
 import { RecordListComponent } from "./record-list.component";
 import { RecordListState } from "./state/record-list.state";
+import { IRecordDataCell } from "../records.interfaces";
+import { FormatDesignatedBodyPipe } from "src/app/shared/pipes/format-designated-body.pipe";
+
+const MOCK_COLUMN_DATA: IRecordDataCell[] = [
+  {
+    label: "Designated body",
+    name: "designatedBody",
+    enableSort: false,
+    displayType: "dbc",
+    isLondonOnly: true
+  },
+
+  {
+    label: "GMC Submission due date",
+    name: "submissionDate",
+    enableSort: true,
+    displayType: "date"
+  },
+
+  {
+    label: "GMC Status",
+    name: "gmcOutcome",
+    enableSort: false
+  }
+];
 
 describe("RecordListComponent", () => {
   let store: Store;
@@ -31,7 +62,7 @@ describe("RecordListComponent", () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [RecordListComponent],
+      declarations: [RecordListComponent, FormatDesignatedBodyPipe],
       imports: [
         MaterialModule,
         NoopAnimationsModule,
@@ -60,14 +91,11 @@ describe("RecordListComponent", () => {
         enableUpdateConnections: false,
         disableSearchAndSort: false,
         allChecked: false,
-        someChecked: false
+        someChecked: false,
+        columnData: [...MOCK_COLUMN_DATA]
       },
       recordList: { fixedColumns: true }
     });
-    component.columnData = generateColumnData(COLUMN_DATA);
-    component.dateColumns = [
-      "curriculumEndDate,submissionDate,dateAdded,lastUpdatedDate"
-    ];
 
     fixture.detectChanges();
   });
@@ -129,11 +157,23 @@ describe("RecordListComponent", () => {
     });
   });
 
-  it("`columnNames()` should return an array of strings", () => {
-    component.columnData = generateColumnData(COLUMN_DATA);
+  it("columnNames should return an array of strings", fakeAsync(() => {
+    store.reset({
+      recommendations: {
+        columnData: [
+          {
+            label: "New label",
+            name: "newName",
+            enableSort: true
+          }
+        ]
+      }
+    });
+    tick();
+
     expect(component.columnNames).toBeInstanceOf(Array);
-    expect(component.columnNames[0]).toEqual("doctorFirstName");
-  });
+    expect(component.columnNames[0]).toEqual("newName");
+  }));
 
   it("'navigateToDetails()' should navigate to details route", () => {
     const mockEvent: Event = new MouseEvent("click");

--- a/src/app/records/record-list/record-list.component.spec.ts
+++ b/src/app/records/record-list/record-list.component.spec.ts
@@ -8,13 +8,11 @@ import {
 } from "@angular/core/testing";
 import { Sort as ISort } from "@angular/material/sort";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { Router } from "@angular/router";
-import { RouterTestingModule } from "@angular/router/testing";
+import { Router, RouterModule } from "@angular/router";
 import { NgxsModule, Store } from "@ngxs/store";
 import { AdminsModule } from "../../admins/admins.module";
 import { ClearAllocateList } from "../../admins/state/admins.actions";
 import { AdminsState } from "../../admins/state/admins.state";
-import { COLUMN_DATA } from "../../concerns/constants";
 import {
   RecommendationStatus,
   RecommendationGmcOutcome
@@ -67,7 +65,7 @@ describe("RecordListComponent", () => {
         MaterialModule,
         NoopAnimationsModule,
         HttpClientTestingModule,
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         AdminsModule,
         NgxsModule.forRoot([RecommendationsState, AdminsState, RecordListState])
       ]

--- a/src/app/records/record-list/record-list.component.ts
+++ b/src/app/records/record-list/record-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy } from "@angular/core";
+import { Component, OnDestroy, OnInit } from "@angular/core";
 import { Sort as ISort } from "@angular/material/sort";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { environment } from "@environment";
@@ -16,8 +16,7 @@ import { IAdmin } from "src/app/admins/admins.interfaces";
   templateUrl: "./record-list.component.html",
   styleUrls: ["./record-list.component.scss"]
 })
-export class RecordListComponent implements OnDestroy {
-  public columnData: IRecordDataCell[] = this.recordsService.columnData;
+export class RecordListComponent implements OnInit, OnDestroy {
   public dateColumns: string[] = this.recordsService.dateColumns;
   public detailsRoute: string = this.recordsService.detailsRoute;
 
@@ -65,6 +64,10 @@ export class RecordListComponent implements OnDestroy {
     (state) => state.admins.items
   );
 
+  public columnData$: Observable<IRecordDataCell[]> = this.store.select(
+    (state) => state[this.recordsService.stateName].columnData
+  );
+
   constructor(
     protected activatedRoute: ActivatedRoute,
     protected recordsService: RecordsService,
@@ -72,10 +75,13 @@ export class RecordListComponent implements OnDestroy {
     protected store: Store,
     private updateConnectionsService: UpdateConnectionsService
   ) {}
-
-  public get columnNames(): string[] {
-    return this.columnData.map((i) => i.name);
+  ngOnInit(): void {
+    this.columnData$.subscribe((columnData) => {
+      this.columnNames = columnData?.map((i) => i.name);
+    });
   }
+
+  columnNames: string[] = [];
 
   /**
    * Handler method for navigating from summary to details screen

--- a/src/app/records/record-search/record-search.component.html
+++ b/src/app/records/record-search/record-search.component.html
@@ -40,7 +40,11 @@
       *ngIf="isRevalAdmin && !isConnectionsSummary"
     ></app-allocate-admin-btn>
     <app-update-connetions-btn
-      *ngIf="isRevalAdmin && isConnectionsSummary"
+      *ngIf="
+        isRevalAdmin &&
+        isConnectionsSummary &&
+        (filter$ | async) !== 'hiddenDiscrepancies'
+      "
     ></app-update-connetions-btn>
     <form
       (ngSubmit)="checkForm()"

--- a/src/app/records/services/records.service.ts
+++ b/src/app/records/services/records.service.ts
@@ -41,7 +41,8 @@ import {
   ToggleConnectionsCheckbox,
   SetConnectionsTableFilters,
   ClearConnectionsTableFilters,
-  UpdateConnectionsQueryParams
+  UpdateConnectionsQueryParams,
+  UpdateConnectionsColumnData
 } from "../../connections/state/connections.actions";
 import {
   ClearRecommendationsSearch,
@@ -58,7 +59,8 @@ import {
   ToggleRecommendationsCheckbox,
   SetRecommendationsTableFilters,
   ClearRecommendationsTableFilters,
-  UpdateRecommendationsQueryParams
+  UpdateRecommendationsQueryParams,
+  UpdateRecommendationsColumnData
 } from "../../recommendations/state/recommendations.actions";
 import { IFilter, IRecordDataCell, ITableFilters } from "../records.interfaces";
 
@@ -98,6 +100,7 @@ export class RecordsService {
   public setTableFiltersAction: any;
   public clearTableFiltersAction: any;
   public updateQueryParamsAction: any;
+  public updateColumnDataAction: any;
 
   constructor(
     private http: HttpClient,
@@ -121,6 +124,7 @@ export class RecordsService {
     this.setTableFiltersAction = SetRecommendationsTableFilters;
     this.clearTableFiltersAction = ClearRecommendationsTableFilters;
     this.updateQueryParamsAction = UpdateRecommendationsQueryParams;
+    this.updateColumnDataAction = UpdateRecommendationsColumnData;
   }
 
   public setConcernsActions(): void {
@@ -154,6 +158,7 @@ export class RecordsService {
     this.setTableFiltersAction = SetConnectionsTableFilters;
     this.clearTableFiltersAction = ClearConnectionsTableFilters;
     this.updateQueryParamsAction = UpdateConnectionsQueryParams;
+    this.updateColumnDataAction = UpdateConnectionsColumnData;
   }
 
   public getRecords<T>(endPoint: string, params?: HttpParams): Observable<T> {
@@ -346,5 +351,10 @@ export class RecordsService {
   public updateQueryParams(params: Params): Observable<any> {
     this.handleUndefinedAction("updateQueryParams");
     return this.store.dispatch(new this.updateQueryParamsAction(params));
+  }
+
+  public updateColumnData(columnData: IRecordDataCell[]): Observable<any> {
+    this.handleUndefinedAction("updateColumnData");
+    return this.store.dispatch(new this.updateColumnDataAction(columnData));
   }
 }

--- a/src/app/records/state/records.actions.ts
+++ b/src/app/records/state/records.actions.ts
@@ -1,11 +1,15 @@
 import { Params } from "@angular/router";
+import { IRecordDataCell } from "../records.interfaces";
 
 export class GetSuccessPayload<T> {
   constructor(public response: T) {}
 }
 
 export class SortPayload {
-  constructor(public column: string, public direction: "asc" | "desc" | "") {}
+  constructor(
+    public column: string,
+    public direction: "asc" | "desc" | ""
+  ) {}
 }
 
 export class FilterPayload<T> {
@@ -33,4 +37,8 @@ export class ToggleCheckboxPayload {
 
 export class QueryParamsPayload {
   constructor(public params: Params) {}
+}
+
+export class ColumnDataPayload {
+  constructor(public columnData: IRecordDataCell[]) {}
 }

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -129,10 +129,10 @@ export class RecordsState {
   protected getSuccessHandler(
     ctx: StateContext<any>,
     action: any,
-    sliceName: string
+    itemsKey: string
   ) {
     ctx.patchState({
-      items: action.response[sliceName],
+      items: action.response[itemsKey],
       totalResults: action.response.totalResults,
       allChecked: false,
       someChecked: false

--- a/src/app/records/state/records.state.ts
+++ b/src/app/records/state/records.state.ts
@@ -35,7 +35,8 @@ export const defaultRecordsState = {
   totalResults: null,
   totalCounts: null,
   tableFilters: null,
-  queryParams: null
+  queryParams: null,
+  columnData: []
 };
 
 export class RecordsState {
@@ -213,6 +214,12 @@ export class RecordsState {
   protected updateQueryParamsHandler(ctx: StateContext<any>, action: any) {
     ctx.patchState({
       queryParams: action
+    });
+  }
+
+  protected updateColumnDataHandler(ctx: StateContext<any>, action: any) {
+    ctx.patchState({
+      columnData: action
     });
   }
 

--- a/src/app/shared/form-controller/form-controller.component.spec.ts
+++ b/src/app/shared/form-controller/form-controller.component.spec.ts
@@ -19,6 +19,7 @@ import { MaterialSelectionListComponent } from "../form-controls/material-select
 import { RemoveWhitespacePipe } from "../pipes/remove-whitespace.pipe";
 import { NgxsModule, Store } from "@ngxs/store";
 import { RecordsService } from "src/app/records/services/records.service";
+import { ConnectionsFilterType } from "src/app/connections/connections.interfaces";
 describe("FormControllerComponent", () => {
   let component: FormControllerComponent;
   let fixture: ComponentFixture<FormControllerComponent>;
@@ -42,7 +43,7 @@ describe("FormControllerComponent", () => {
         }
       ],
       order: 1,
-      filterType: "discrepancies",
+      filterType: [ConnectionsFilterType.CURRENT_CONNECTIONS],
       controlType: "selectionList",
       initialValue: []
     },
@@ -81,13 +82,14 @@ describe("FormControllerComponent", () => {
     store = TestBed.inject(Store);
     store.reset({
       connections: {
-        filter: "currentConnections",
+        filter: ConnectionsFilterType.CURRENT_CONNECTIONS,
         sort: {
           active: "submissionDate",
           direction: "asc"
         },
         pageIndex: 1,
-        tableFilters: null
+        tableFilters: null,
+        columnData: []
       }
     });
 

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -34,10 +34,13 @@ export class FormControllerComponent implements OnInit {
 
   ngOnInit(): void {
     this.filter$.subscribe((filter: string) => {
-      if (this.control?.filterType.includes(filter)) {
-        this.hidden = false;
-      } else {
-        this.hidden = true;
+      this.hidden = false;
+      if (this.control?.filterType) {
+        if (this.control?.filterType.includes(filter)) {
+          this.hidden = false;
+        } else {
+          this.hidden = true;
+        }
       }
     });
     if (this.control?.valueProperty) {

--- a/src/app/shared/form-controller/form-controller.component.ts
+++ b/src/app/shared/form-controller/form-controller.component.ts
@@ -34,10 +34,10 @@ export class FormControllerComponent implements OnInit {
 
   ngOnInit(): void {
     this.filter$.subscribe((filter: string) => {
-      if (this.control?.filterType && this.control?.filterType !== filter) {
-        this.hidden = true;
-      } else {
+      if (this.control?.filterType.includes(filter)) {
         this.hidden = false;
+      } else {
+        this.hidden = true;
       }
     });
     if (this.control?.valueProperty) {

--- a/src/app/shared/form-controls/form-contol-base.model.ts
+++ b/src/app/shared/form-controls/form-contol-base.model.ts
@@ -9,7 +9,7 @@ export interface FormControlBase {
   controlType: string;
   text?: string;
   placeholder?: string;
-  filterType?: string;
+  filterType?: string[];
   options?: {
     key: string;
     value?: string;


### PR DESCRIPTION
Add a new tab under connections to show hidden discrepancies. Key updates include
* The summary table column data for connections and recommendations is now stored in state to allow for differnt columns for hidden discrepancies
* The visibility of table filter fields now supports multiple views
* Bulk update connection button hidden for hidden discrepancies view
* 
TIS21-8545