### PR TITLE
feat: add 'hide discrepancy" as update option

### DIFF
--- a/src/app/connection/connection.component.ts
+++ b/src/app/connection/connection.component.ts
@@ -165,23 +165,13 @@ export class ConnectionComponent implements OnInit, OnDestroy {
       }
     ];
 
-    let payload: {};
-    if (formValue.action === ActionType.HIDE_DISCREPANCY) {
-      payload = {
-        adminDesignatedBodyCodes,
-        doctors,
-        hiddenBy: admin,
-        reason: formValue.reason
-      };
-    } else {
-      payload = {
-        changeReason: formValue.reason,
-        designatedBodyCode:
-          formValue.action === ActionType.ADD_CONNECTION ? formValue.dbc : null,
-        doctors,
-        admin
-      };
-    }
+    const payload = {
+      changeReason: formValue.reason,
+      designatedBodyCode:
+        formValue.action === ActionType.ADD_CONNECTION ? formValue.dbc : null,
+      doctors,
+      admin
+    };
     this.componentSubscription = this.updateConnectionsService
       .updateConnection(payload, formValue.action)
       .subscribe({

--- a/src/app/connection/connection.component.ts
+++ b/src/app/connection/connection.component.ts
@@ -156,7 +156,6 @@ export class ConnectionComponent implements OnInit, OnDestroy {
 
   updateConnection(formValue: any) {
     const admin = this.authService.userName;
-    const adminDesignatedBodyCodes = this.authService.userDesignatedBodies;
     this.submitting = true;
     const doctors: IDoctor[] = [
       {

--- a/src/app/connection/connection.component.ts
+++ b/src/app/connection/connection.component.ts
@@ -28,6 +28,7 @@ import {
 } from "../shared/confirm-dialog/confirm-dialog.component";
 import { MatDialog } from "@angular/material/dialog";
 import { FormatDesignatedBodyPipe } from "../shared/pipes/format-designated-body.pipe";
+import { CONNECTION_ACTIONS } from "../update-connections/constants";
 
 @Component({
   selector: "app-connection",
@@ -86,6 +87,10 @@ export class ConnectionComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    let actions = CONNECTION_ACTIONS;
+    actions = actions.filter((c) => c.action !== ActionType.HIDE_DISCREPANCY);
+    this.updateConnectionsService.actions$.next(actions);
+
     this.traineeDetails$.subscribe((trainee) => {
       this.enableUpdateConnection =
         this.authService.isRevalAdmin &&
@@ -151,6 +156,7 @@ export class ConnectionComponent implements OnInit, OnDestroy {
 
   updateConnection(formValue: any) {
     const admin = this.authService.userName;
+    const adminDesignatedBodyCodes = this.authService.userDesignatedBodies;
     this.submitting = true;
     const doctors: IDoctor[] = [
       {
@@ -159,14 +165,23 @@ export class ConnectionComponent implements OnInit, OnDestroy {
       }
     ];
 
-    const payload = {
-      changeReason: formValue.reason,
-      designatedBodyCode:
-        formValue.action === ActionType.ADD_CONNECTION ? formValue.dbc : null,
-      doctors,
-      admin
-    };
-
+    let payload: {};
+    if (formValue.action === ActionType.HIDE_DISCREPANCY) {
+      payload = {
+        adminDesignatedBodyCodes,
+        doctors,
+        hiddenBy: admin,
+        reason: formValue.reason
+      };
+    } else {
+      payload = {
+        changeReason: formValue.reason,
+        designatedBodyCode:
+          formValue.action === ActionType.ADD_CONNECTION ? formValue.dbc : null,
+        doctors,
+        admin
+      };
+    }
     this.componentSubscription = this.updateConnectionsService
       .updateConnection(payload, formValue.action)
       .subscribe({

--- a/src/app/connection/connection.interfaces.ts
+++ b/src/app/connection/connection.interfaces.ts
@@ -10,6 +10,15 @@ export interface IUpdateConnectionResponse {
   message: string;
 }
 
+export interface IHideDiscrepancyResponse {
+  results: IHideDiscrepancyResult[];
+}
+
+export interface IHideDiscrepancyResult {
+  gmcId: string;
+  successfulDbcCodes: string[];
+}
+
 export interface IConnectionHistory {
   connectionId: string;
   gmcId: string;

--- a/src/app/connections/connections.component.spec.ts
+++ b/src/app/connections/connections.component.spec.ts
@@ -1,5 +1,10 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick
+} from "@angular/core/testing";
 import { NgxsModule } from "@ngxs/store";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
@@ -116,11 +121,12 @@ describe("ConnectionsComponent", () => {
     expect(component.loading).toBeFalsy();
   });
 
-  it("should display snackbar error message when bulk Add connection request fails", () => {
+  it("should display snackbar error message when bulk Add connection request fails", fakeAsync(() => {
     const message = "Request failed";
     spyOn(snackBarService, "openSnackBar");
+    spyOn(component, "onCompleteUpdate");
     spyOn(updateConnectionsService, "updateConnection").and.returnValue(
-      throwError({ message })
+      throwError(() => new Error(message))
     );
 
     const formValue = {
@@ -131,10 +137,11 @@ describe("ConnectionsComponent", () => {
 
     component.selectedItems = mockConnectionsResponse.connections;
     component.updateConnections(formValue);
+    tick();
 
     expect(component.loading).toBeTruthy();
     expect(snackBarService.openSnackBar).toHaveBeenCalledWith(message);
-  });
+  }));
 
   it("should display snackbar to prompt user to select doctors if no doctors selected", () => {
     spyOn(updateConnectionsService, "updateConnection").and.callThrough();

--- a/src/app/connections/connections.component.spec.ts
+++ b/src/app/connections/connections.component.spec.ts
@@ -3,9 +3,10 @@ import {
   ComponentFixture,
   TestBed,
   fakeAsync,
+  flush,
   tick
 } from "@angular/core/testing";
-import { NgxsModule } from "@ngxs/store";
+import { NgxsModule, Store } from "@ngxs/store";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MaterialModule } from "../shared/material/material.module";
@@ -16,6 +17,8 @@ import { ActionType } from "../update-connections/update-connections.interfaces"
 import { mockConnectionsResponse } from "./mock-data/connections-spec-data";
 import { of, throwError } from "rxjs";
 import { RecordsService } from "../records/services/records.service";
+import { ConnectionsState } from "./state/connections.state";
+import { EnableUpdateConnections } from "../update-connections/state/update-connections.actions";
 
 describe("ConnectionsComponent", () => {
   let component: ConnectionsComponent;
@@ -23,16 +26,18 @@ describe("ConnectionsComponent", () => {
   let updateConnectionsService: UpdateConnectionsService;
   let snackBarService: SnackBarService;
   let recordsService: RecordsService;
+  let store: Store;
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [
-        NgxsModule.forRoot(),
+        NgxsModule.forRoot([ConnectionsState]),
         HttpClientTestingModule,
         RouterTestingModule,
         MaterialModule
       ],
       declarations: [ConnectionsComponent],
+      providers: [UpdateConnectionsService, SnackBarService, RecordsService],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
   });
@@ -41,8 +46,10 @@ describe("ConnectionsComponent", () => {
     updateConnectionsService = TestBed.inject(UpdateConnectionsService);
     snackBarService = TestBed.inject(SnackBarService);
     recordsService = TestBed.inject(RecordsService);
+    store = TestBed.inject(Store);
     fixture = TestBed.createComponent(ConnectionsComponent);
     component = fixture.componentInstance;
+    recordsService.setConnectionsActions();
     fixture.detectChanges();
   });
 
@@ -99,9 +106,10 @@ describe("ConnectionsComponent", () => {
     expect(component.loading).toBeTruthy();
   });
 
-  it("should display snackbar success message and set loading to false when bulk Add connection request succeeds", () => {
+  it("should display snackbar success message and set loading to false when bulk Add connection request succeeds", fakeAsync(() => {
     const message = "Connections updated!";
     spyOn(snackBarService, "openSnackBar");
+    spyOn(component, "onCompleteUpdate").and.callThrough();
     spyOn(updateConnectionsService, "updateConnection").and.returnValue(
       of({ message })
     );
@@ -116,10 +124,12 @@ describe("ConnectionsComponent", () => {
 
     component.selectedItems = mockConnectionsResponse.connections;
     component.updateConnections(formValue);
-
+    tick(500);
     expect(snackBarService.openSnackBar).toHaveBeenCalledWith(message);
+    expect(component.onCompleteUpdate).toHaveBeenCalled();
     expect(component.loading).toBeFalsy();
-  });
+    flush();
+  }));
 
   it("should display snackbar error message when bulk Add connection request fails", fakeAsync(() => {
     const message = "Request failed";
@@ -139,8 +149,52 @@ describe("ConnectionsComponent", () => {
     component.updateConnections(formValue);
     tick();
 
+    expect(component.onCompleteUpdate).toHaveBeenCalled();
     expect(component.loading).toBeTruthy();
     expect(snackBarService.openSnackBar).toHaveBeenCalledWith(message);
+    flush();
+  }));
+
+  it("should dispatch EnableUpdateConnections action as false after update connection completes", fakeAsync(() => {
+    spyOn(store, "dispatch");
+    spyOn(updateConnectionsService, "updateConnection").and.returnValue(
+      of({ message: "Connections updated!" })
+    );
+
+    const formValue = {
+      action: ActionType.ADD_CONNECTION,
+      reason: "Conflict of interest",
+      dbc: "1-FGHIJ"
+    };
+
+    component.selectedItems = mockConnectionsResponse.connections;
+    component.updateConnections(formValue);
+    tick();
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new EnableUpdateConnections(false)
+    );
+    flush();
+  }));
+
+  it("should dispatch EnableUpdateConnections action as false after update connection errors", fakeAsync(() => {
+    spyOn(store, "dispatch");
+    spyOn(updateConnectionsService, "updateConnection").and.returnValue(
+      throwError(() => new Error("New error message"))
+    );
+
+    const formValue = {
+      action: ActionType.ADD_CONNECTION,
+      reason: "Conflict of interest",
+      dbc: "1-FGHIJ"
+    };
+
+    component.selectedItems = mockConnectionsResponse.connections;
+    component.updateConnections(formValue);
+    tick();
+    expect(store.dispatch).toHaveBeenCalledWith(
+      new EnableUpdateConnections(false)
+    );
+    flush();
   }));
 
   it("should display snackbar to prompt user to select doctors if no doctors selected", () => {

--- a/src/app/connections/connections.component.ts
+++ b/src/app/connections/connections.component.ts
@@ -51,23 +51,18 @@ export class ConnectionsComponent implements OnDestroy {
     this.filter$.subscribe((filter) => {
       let actions = CONNECTION_ACTIONS;
       switch (filter) {
-        case ConnectionsFilterType.ALL:
+        case ConnectionsFilterType.CURRENT_CONNECTIONS:
           actions = actions.filter(
-            (c) => c.action !== ActionType.UNHIDE_CONNECTION
+            (c) => c.action !== ActionType.HIDE_DISCREPANCY
           );
           break;
+
         case ConnectionsFilterType.HIDDEN_DISCREPANCIES:
           actions = actions.filter(
-            (c) => c.action !== ActionType.HIDE_CONNECTION
-          );
-          break;
-        case ConnectionsFilterType.HISTORIC_CONNECTIONS:
-          actions = actions.filter(
-            (c) => c.action !== ActionType.REMOVE_CONNECTION
+            (c) => c.action !== ActionType.HIDE_DISCREPANCY
           );
           break;
       }
-
       this.updateConnectionsService.actions$.next(actions);
     });
   }
@@ -82,15 +77,27 @@ export class ConnectionsComponent implements OnDestroy {
       }));
 
       const admin = this.authService.userName;
+      const adminDesignatedBodyCodes = this.authService.userDesignatedBodies;
+      let payload: {};
 
-      const payload = {
-        changeReason: formValue.reason,
-        designatedBodyCode:
-          formValue.action === ActionType.ADD_CONNECTION ? formValue.dbc : null,
-        doctors,
-        admin: admin
-      };
-
+      if (formValue.action === ActionType.HIDE_DISCREPANCY) {
+        payload = {
+          adminDesignatedBodyCodes,
+          doctors,
+          hiddenBy: admin,
+          reason: formValue.reason
+        };
+      } else {
+        payload = {
+          changeReason: formValue.reason,
+          designatedBodyCode:
+            formValue.action === ActionType.ADD_CONNECTION
+              ? formValue.dbc
+              : null,
+          doctors,
+          admin: admin
+        };
+      }
       this.componentSubscription = this.updateConnectionsService
         .updateConnection(payload, formValue.action)
         .subscribe(

--- a/src/app/connections/connections.component.ts
+++ b/src/app/connections/connections.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from "@angular/core";
 import { Store } from "@ngxs/store";
-import { Observable, Subscription } from "rxjs";
+import { Observable, Subscription, finalize } from "rxjs";
 import { IUpdateConnectionResponse } from "../connection/connection.interfaces";
 import { RecordsService } from "../records/services/records.service";
 import { SnackBarService } from "../shared/services/snack-bar/snack-bar.service";
@@ -114,16 +114,13 @@ export class ConnectionsComponent implements OnDestroy {
 
         this.componentSubscription = this.updateConnectionsService
           .updateConnection(payload, formValue.action)
+          .pipe(finalize(() => this.onCompleteUpdate()))
           .subscribe({
             next: (response: IUpdateConnectionResponse) => {
               this.snackBarService.openSnackBar(response.message);
             },
             error: (error) => {
               this.snackBarService.openSnackBar(error.message);
-              this.onCompleteUpdate();
-            },
-            complete: () => {
-              this.onCompleteUpdate();
             }
           });
       }

--- a/src/app/connections/connections.component.ts
+++ b/src/app/connections/connections.component.ts
@@ -1,16 +1,19 @@
 import { Component, OnDestroy } from "@angular/core";
 import { Store } from "@ngxs/store";
 import { Observable, Subscription } from "rxjs";
-import {
-  IHideDiscrepancyResponse,
-  IUpdateConnectionResponse
-} from "../connection/connection.interfaces";
+import { IUpdateConnectionResponse } from "../connection/connection.interfaces";
 import { RecordsService } from "../records/services/records.service";
 import { SnackBarService } from "../shared/services/snack-bar/snack-bar.service";
-import { CONNECTION_ACTIONS } from "../update-connections/constants";
+import {
+  CONNECTION_ACTIONS,
+  HIDE_DISCREPANCY_ACTION
+} from "../update-connections/constants";
 import { UpdateConnectionsService } from "../update-connections/services/update-connections.service";
 import { EnableUpdateConnections } from "../update-connections/state/update-connections.actions";
-import { ActionType } from "../update-connections/update-connections.interfaces";
+import {
+  ActionType,
+  IAction
+} from "../update-connections/update-connections.interfaces";
 import { ConnectionsFilterType } from "./connections.interfaces";
 import { AuthService } from "../core/auth/auth.service";
 
@@ -52,19 +55,11 @@ export class ConnectionsComponent implements OnDestroy {
     });
 
     this.filter$.subscribe((filter) => {
-      let actions = CONNECTION_ACTIONS;
-      switch (filter) {
-        case ConnectionsFilterType.CURRENT_CONNECTIONS:
-          actions = actions.filter(
-            (c) => c.action !== ActionType.HIDE_DISCREPANCY
-          );
-          break;
-
-        case ConnectionsFilterType.HIDDEN_DISCREPANCIES:
-          actions = actions.filter(
-            (c) => c.action !== ActionType.HIDE_DISCREPANCY
-          );
-          break;
+      let actions: IAction[];
+      if (filter === ConnectionsFilterType.DISCREPANCIES) {
+        actions = [...CONNECTION_ACTIONS, { ...HIDE_DISCREPANCY_ACTION }];
+      } else {
+        actions = [...CONNECTION_ACTIONS];
       }
       this.updateConnectionsService.actions$.next(actions);
     });
@@ -82,7 +77,6 @@ export class ConnectionsComponent implements OnDestroy {
       const admin = this.authService.userName;
       const adminDesignatedBodyCodes = this.authService.userDesignatedBodies;
       let payload: {};
-
       if (formValue.action === ActionType.HIDE_DISCREPANCY) {
         payload = {
           adminDesignatedBodyCodes,
@@ -101,6 +95,7 @@ export class ConnectionsComponent implements OnDestroy {
             },
             error: (error) => {
               this.snackBarService.openSnackBar(error.message);
+              this.onCompleteUpdate();
             },
             complete: () => {
               this.onCompleteUpdate();
@@ -125,6 +120,7 @@ export class ConnectionsComponent implements OnDestroy {
             },
             error: (error) => {
               this.snackBarService.openSnackBar(error.message);
+              this.onCompleteUpdate();
             },
             complete: () => {
               this.onCompleteUpdate();

--- a/src/app/connections/connections.component.ts
+++ b/src/app/connections/connections.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnDestroy } from "@angular/core";
 import { Store } from "@ngxs/store";
 import { Observable, Subscription } from "rxjs";
-import { IUpdateConnectionResponse } from "../connection/connection.interfaces";
+import {
+  IHideDiscrepancyResponse,
+  IUpdateConnectionResponse
+} from "../connection/connection.interfaces";
 import { RecordsService } from "../records/services/records.service";
 import { SnackBarService } from "../shared/services/snack-bar/snack-bar.service";
 import { CONNECTION_ACTIONS } from "../update-connections/constants";
@@ -87,6 +90,22 @@ export class ConnectionsComponent implements OnDestroy {
           hiddenBy: admin,
           reason: formValue.reason
         };
+
+        this.componentSubscription = this.updateConnectionsService
+          .hideDiscrepancy(payload)
+          .subscribe({
+            next: () => {
+              this.snackBarService.openSnackBar(
+                "Discrepancies hidden successfully"
+              );
+            },
+            error: (error) => {
+              this.snackBarService.openSnackBar(error.message);
+            },
+            complete: () => {
+              this.onCompleteUpdate();
+            }
+          });
       } else {
         payload = {
           changeReason: formValue.reason,
@@ -97,28 +116,33 @@ export class ConnectionsComponent implements OnDestroy {
           doctors,
           admin: admin
         };
+
+        this.componentSubscription = this.updateConnectionsService
+          .updateConnection(payload, formValue.action)
+          .subscribe({
+            next: (response: IUpdateConnectionResponse) => {
+              this.snackBarService.openSnackBar(response.message);
+            },
+            error: (error) => {
+              this.snackBarService.openSnackBar(error.message);
+            },
+            complete: () => {
+              this.onCompleteUpdate();
+            }
+          });
       }
-      this.componentSubscription = this.updateConnectionsService
-        .updateConnection(payload, formValue.action)
-        .subscribe(
-          (response: IUpdateConnectionResponse) => {
-            this.snackBarService.openSnackBar(response.message);
-          },
-          (error) => {
-            this.snackBarService.openSnackBar(error.message);
-          },
-          () => {
-            this.store.dispatch(new EnableUpdateConnections(false));
-            this.recordsService.enableAllocateAdmin(false);
-            this.recordsService.get();
-            this.loading = false;
-          }
-        );
     } else {
       this.snackBarService.openSnackBar(
         "Please select doctors to update connections"
       );
     }
+  }
+
+  onCompleteUpdate() {
+    this.store.dispatch(new EnableUpdateConnections(false));
+    this.recordsService.enableAllocateAdmin(false);
+    this.recordsService.get();
+    this.loading = false;
   }
 
   ngOnDestroy(): void {

--- a/src/app/connections/connections.interfaces.ts
+++ b/src/app/connections/connections.interfaces.ts
@@ -24,10 +24,8 @@ export interface IConnection {
 }
 
 export enum ConnectionsFilterType {
-  HISTORIC_CONNECTIONS = "historicConnections",
   CURRENT_CONNECTIONS = "currentConnections",
   DISCREPANCIES = "discrepancies",
-  ALL = "all",
   HIDDEN_DISCREPANCIES = "hiddenDiscrepancies",
   EXCEPTIONSLOG = "exceptionsLog"
 }

--- a/src/app/connections/services/connections.service.spec.ts
+++ b/src/app/connections/services/connections.service.spec.ts
@@ -23,7 +23,7 @@ describe("ConnectionsService", () => {
       active: sortColumn,
       direction: sortDirection
     },
-    filter: ConnectionsFilterType.HISTORIC_CONNECTIONS,
+    filter: ConnectionsFilterType.CURRENT_CONNECTIONS,
     dbcs: userLocalOffice
   };
 
@@ -68,6 +68,6 @@ describe("ConnectionsService", () => {
     const filter = connectionsService.getFilter();
 
     expect(connectionsService.getFilter).toHaveBeenCalled();
-    expect(filter).toBe(ConnectionsFilterType.HISTORIC_CONNECTIONS);
+    expect(filter).toBe(ConnectionsFilterType.CURRENT_CONNECTIONS);
   });
 });

--- a/src/app/connections/state/connections.state.spec.ts
+++ b/src/app/connections/state/connections.state.spec.ts
@@ -114,30 +114,16 @@ describe("Connections state", () => {
     store.dispatch(new ResetConnectionsFilter());
     const filter = store.selectSnapshot((state) => state.connections.filter);
 
-    expect(filter).toBe(ConnectionsFilterType.ALL);
+    expect(filter).toBe(ConnectionsFilterType.CURRENT_CONNECTIONS);
   });
 
   it("should set the filter when FilterConnections is dispatched", () => {
-    store.dispatch(
-      new FilterConnections(ConnectionsFilterType.HISTORIC_CONNECTIONS)
-    );
+    store.dispatch(new FilterConnections(ConnectionsFilterType.DISCREPANCIES));
     const filter = store.selectSnapshot((state) => state.connections.filter);
 
     store.selectSnapshot((state) => state.connections.disableSearchAndSort);
 
-    expect(filter).toBe(ConnectionsFilterType.HISTORIC_CONNECTIONS);
-  });
-
-  it("should not disableSearchAndSort when FilterConnections is dispatched with ALL filter", () => {
-    store.dispatch(new FilterConnections(ConnectionsFilterType.ALL));
-    const filter = store.selectSnapshot((state) => state.connections.filter);
-
-    const disableSearchAndSort = store.selectSnapshot(
-      (state) => state.connections.disableSearchAndSort
-    );
-
-    expect(filter).toBe(ConnectionsFilterType.ALL);
-    expect(disableSearchAndSort).toBeFalsy();
+    expect(filter).toBe(ConnectionsFilterType.DISCREPANCIES);
   });
 
   it("should set searchQuery when ConnectionsSearch is dispatched", () => {

--- a/src/app/connections/state/connections.state.spec.ts
+++ b/src/app/connections/state/connections.state.spec.ts
@@ -110,7 +110,7 @@ describe("Connections state", () => {
     }));
   });
 
-  it("should reset filter to ALL when ResetConnectionsFilter is dispatched", () => {
+  it("should reset filter to CURRENT_CONNECTIONS when ResetConnectionsFilter is dispatched", () => {
     store.dispatch(new ResetConnectionsFilter());
     const filter = store.selectSnapshot((state) => state.connections.filter);
 

--- a/src/app/connections/state/connections.state.ts
+++ b/src/app/connections/state/connections.state.ts
@@ -166,17 +166,18 @@ export class ConnectionsState extends RecordsState {
     return ctx.patchState({
       filter: action.filter,
       disableSearchAndSort:
-        action.filter !== ConnectionsFilterType.ALL &&
         action.filter !== ConnectionsFilterType.HIDDEN_DISCREPANCIES &&
         action.filter !== ConnectionsFilterType.CURRENT_CONNECTIONS &&
-        action.filter !== ConnectionsFilterType.HISTORIC_CONNECTIONS &&
         action.filter !== ConnectionsFilterType.DISCREPANCIES
     });
   }
 
   @Action(ResetConnectionsFilter)
   resetFilter(ctx: StateContext<ConnectionsStateModel>) {
-    return super.resetFilterHandler(ctx, ConnectionsFilterType.ALL);
+    return super.resetFilterHandler(
+      ctx,
+      ConnectionsFilterType.CURRENT_CONNECTIONS
+    );
   }
   @Action(SetConnectionsTableFilters)
   setRecommendationsTableFilters(

--- a/src/app/update-connections/constants.ts
+++ b/src/app/update-connections/constants.ts
@@ -22,9 +22,10 @@ export const CONNECTION_ACTIONS: IAction[] = [
         code: "3"
       }
     ]
-  },
-  {
-    action: ActionType.HIDE_DISCREPANCY,
-    reasons: []
   }
 ];
+
+export const HIDE_DISCREPANCY_ACTION: IAction = {
+  action: ActionType.HIDE_DISCREPANCY,
+  reasons: []
+};

--- a/src/app/update-connections/constants.ts
+++ b/src/app/update-connections/constants.ts
@@ -22,5 +22,9 @@ export const CONNECTION_ACTIONS: IAction[] = [
         code: "3"
       }
     ]
+  },
+  {
+    action: ActionType.HIDE_DISCREPANCY,
+    reasons: []
   }
 ];

--- a/src/app/update-connections/services/update-connections.service.spec.ts
+++ b/src/app/update-connections/services/update-connections.service.spec.ts
@@ -2,13 +2,14 @@ import {
   HttpClientTestingModule,
   HttpTestingController
 } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
+import { TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { environment } from "@environment";
 import { NgxsModule, Store } from "@ngxs/store";
 import { EnableUpdateConnections } from "../state/update-connections.actions";
 import { UpdateConnectionsState } from "../state/update-connections.state";
 import { ActionType } from "../update-connections.interfaces";
 import { UpdateConnectionsService } from "./update-connections.service";
+import { HttpErrorResponse } from "@angular/common/http";
 
 describe("UpdateConnectionsService", () => {
   let service: UpdateConnectionsService;
@@ -63,20 +64,9 @@ describe("UpdateConnectionsService", () => {
   });
 
   it("should hide selected connection", () => {
-    const endPoint = `${environment.appUrls.getConnections}/hide`;
+    const endPoint = `${environment.appUrls.getConnections}/discrepancies/hidden`;
 
-    service.updateConnection({}, ActionType.HIDE_CONNECTION).subscribe();
-
-    const mockHttp = http.expectOne(endPoint);
-    expect(mockHttp.request.method).toBe("POST");
-
-    http.verify();
-  });
-
-  it("should unhide selected connection", () => {
-    const endPoint = `${environment.appUrls.getConnections}/unhide`;
-
-    service.updateConnection({}, ActionType.UNHIDE_CONNECTION).subscribe();
+    service.updateConnection({}, ActionType.HIDE_DISCREPANCY).subscribe();
 
     const mockHttp = http.expectOne(endPoint);
     expect(mockHttp.request.method).toBe("POST");
@@ -85,18 +75,18 @@ describe("UpdateConnectionsService", () => {
   });
 
   it("should throw error when add/remove connection api call fail", () => {
-    let errResponse: any;
-    const mockErrorResponse = { status: 400, statusText: "Bad Request" };
-    const data = "Invalid request parameters";
+    const data = "Server error";
+    service.updateConnection({}, ActionType.REMOVE_CONNECTION).subscribe({
+      next: () => {},
+      error: (err) => {
+        expect(err.error).toBe(data);
+        expect(err.status).toBe(500);
+      }
+    });
 
-    service.updateConnection({}, ActionType.REMOVE_CONNECTION).subscribe(
-      () => {},
-      (err) => (errResponse = err)
-    );
-    http
-      .expectOne(`${environment.appUrls.getConnections}/remove`)
-      .flush(data, mockErrorResponse);
-
-    expect(errResponse.error).toBe(data);
+    http.expectOne(`${environment.appUrls.getConnections}/remove`).flush(data, {
+      status: 500,
+      statusText: "Internal Server Error"
+    });
   });
 });

--- a/src/app/update-connections/services/update-connections.service.spec.ts
+++ b/src/app/update-connections/services/update-connections.service.spec.ts
@@ -62,7 +62,7 @@ describe("UpdateConnectionsService", () => {
     http.verify();
   });
 
-  it("should hide selected connection", () => {
+  it("should hide selected discrepancy", () => {
     const endPoint = `${environment.appUrls.getConnections}/discrepancies/hidden`;
 
     service.hideDiscrepancy({}).subscribe();

--- a/src/app/update-connections/services/update-connections.service.spec.ts
+++ b/src/app/update-connections/services/update-connections.service.spec.ts
@@ -2,14 +2,13 @@ import {
   HttpClientTestingModule,
   HttpTestingController
 } from "@angular/common/http/testing";
-import { TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { TestBed, fakeAsync, flush } from "@angular/core/testing";
 import { environment } from "@environment";
 import { NgxsModule, Store } from "@ngxs/store";
 import { EnableUpdateConnections } from "../state/update-connections.actions";
 import { UpdateConnectionsState } from "../state/update-connections.state";
 import { ActionType } from "../update-connections.interfaces";
 import { UpdateConnectionsService } from "./update-connections.service";
-import { HttpErrorResponse } from "@angular/common/http";
 
 describe("UpdateConnectionsService", () => {
   let service: UpdateConnectionsService;
@@ -66,7 +65,7 @@ describe("UpdateConnectionsService", () => {
   it("should hide selected connection", () => {
     const endPoint = `${environment.appUrls.getConnections}/discrepancies/hidden`;
 
-    service.updateConnection({}, ActionType.HIDE_DISCREPANCY).subscribe();
+    service.hideDiscrepancy({}).subscribe();
 
     const mockHttp = http.expectOne(endPoint);
     expect(mockHttp.request.method).toBe("POST");
@@ -74,7 +73,7 @@ describe("UpdateConnectionsService", () => {
     http.verify();
   });
 
-  it("should throw error when add/remove connection api call fail", () => {
+  it("should throw error when add/remove connection api call fail", fakeAsync(() => {
     const data = "Server error";
     service.updateConnection({}, ActionType.REMOVE_CONNECTION).subscribe({
       next: () => {},
@@ -88,5 +87,8 @@ describe("UpdateConnectionsService", () => {
       status: 500,
       statusText: "Internal Server Error"
     });
-  });
+
+    http.verify();
+    flush();
+  }));
 });

--- a/src/app/update-connections/services/update-connections.service.ts
+++ b/src/app/update-connections/services/update-connections.service.ts
@@ -29,8 +29,8 @@ export class UpdateConnectionsService {
   public stateName = "updateConnections";
 
   constructor(
-    private http: HttpClient,
-    private store: Store
+    readonly http: HttpClient,
+    readonly store: Store
   ) {}
 
   public enableUpdateConnections(

--- a/src/app/update-connections/services/update-connections.service.ts
+++ b/src/app/update-connections/services/update-connections.service.ts
@@ -25,7 +25,10 @@ export class UpdateConnectionsService {
 
   public stateName = "updateConnections";
 
-  constructor(private http: HttpClient, private store: Store) {}
+  constructor(
+    private http: HttpClient,
+    private store: Store
+  ) {}
 
   public enableUpdateConnections(
     enableUpdateConnections: boolean
@@ -49,12 +52,8 @@ export class UpdateConnectionsService {
         action = "remove";
         break;
 
-      case ActionType.HIDE_CONNECTION:
-        action = "hide";
-        break;
-
-      case ActionType.UNHIDE_CONNECTION:
-        action = "unhide";
+      case ActionType.HIDE_DISCREPANCY:
+        action = "discrepancies/hidden";
         break;
     }
 
@@ -64,13 +63,9 @@ export class UpdateConnectionsService {
           `${environment.appUrls.getConnections}/${action}`,
           payload
         )
-        .pipe(catchError(this.errorCallback));
+        .pipe(catchError((err) => throwError(() => err)));
     } else {
-      return this.errorCallback("Action is not defined");
+      return throwError(() => new Error("Action is not defined"));
     }
-  }
-
-  private errorCallback(error: any) {
-    return throwError(error);
   }
 }

--- a/src/app/update-connections/services/update-connections.service.ts
+++ b/src/app/update-connections/services/update-connections.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { environment } from "@environment";
 import { Store } from "@ngxs/store";
@@ -71,7 +71,7 @@ export class UpdateConnectionsService {
           `${environment.appUrls.getConnections}/${action}`,
           payload
         )
-        .pipe(catchError((err: Error) => throwError(() => err)));
+        .pipe(catchError((err: HttpErrorResponse) => throwError(() => err)));
     } else {
       return throwError(() => new Error("Action is not defined"));
     }

--- a/src/app/update-connections/services/update-connections.service.ts
+++ b/src/app/update-connections/services/update-connections.service.ts
@@ -4,7 +4,10 @@ import { environment } from "@environment";
 import { Store } from "@ngxs/store";
 import { BehaviorSubject, Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
-import { IUpdateConnectionResponse } from "src/app/connection/connection.interfaces";
+import {
+  IHideDiscrepancyResponse,
+  IUpdateConnectionResponse
+} from "src/app/connection/connection.interfaces";
 import { CONNECTION_ACTIONS } from "../constants";
 import { EnableUpdateConnections } from "../state/update-connections.actions";
 import { ActionType, IAction } from "../update-connections.interfaces";
@@ -38,6 +41,15 @@ export class UpdateConnectionsService {
     );
   }
 
+  hideDiscrepancy(payload: any): Observable<IHideDiscrepancyResponse> {
+    return this.http
+      .post<IHideDiscrepancyResponse>(
+        `${environment.appUrls.getConnections}/discrepancies/hidden`,
+        payload
+      )
+      .pipe(catchError((err) => throwError(() => err)));
+  }
+
   updateConnection(
     payload: any,
     actionType: ActionType
@@ -50,10 +62,6 @@ export class UpdateConnectionsService {
 
       case ActionType.REMOVE_CONNECTION:
         action = "remove";
-        break;
-
-      case ActionType.HIDE_DISCREPANCY:
-        action = "discrepancies/hidden";
         break;
     }
 

--- a/src/app/update-connections/services/update-connections.service.ts
+++ b/src/app/update-connections/services/update-connections.service.ts
@@ -71,7 +71,7 @@ export class UpdateConnectionsService {
           `${environment.appUrls.getConnections}/${action}`,
           payload
         )
-        .pipe(catchError((err) => throwError(() => err)));
+        .pipe(catchError((err: Error) => throwError(() => err)));
     } else {
       return throwError(() => new Error("Action is not defined"));
     }

--- a/src/app/update-connections/update-connection/update-connection.component.spec.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.spec.ts
@@ -109,7 +109,7 @@ describe("UpdateConnectionComponent", () => {
   xit("form should not have reasons when action is not add / remove", () => {
     // NO HIDE CONNECTION YET
     component.updateConnectionForm.controls[actionText].setValue(
-      ActionType.HIDE_CONNECTION
+      ActionType.HIDE_DISCREPANCY
     );
 
     const reason = component.updateConnectionForm.controls[reasonText];

--- a/src/app/update-connections/update-connection/update-connection.component.spec.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.spec.ts
@@ -1,5 +1,10 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick
+} from "@angular/core/testing";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
@@ -17,6 +22,7 @@ import { UpdateConnectionsState } from "../state/update-connections.state";
 import { UpdateConnectionsService } from "../services/update-connections.service";
 import { AuthService } from "src/app/core/auth/auth.service";
 import { ReferenceState } from "src/app/reference/state/reference.state";
+import { CONNECTION_ACTIONS, HIDE_DISCREPANCY_ACTION } from "../constants";
 
 describe("UpdateConnectionComponent", () => {
   let component: UpdateConnectionComponent;
@@ -106,11 +112,15 @@ describe("UpdateConnectionComponent", () => {
     expect(dbc).toBeDefined();
   });
 
-  it("form should not have reasons when action is not add / remove", () => {
+  it("form should include have reason as freetext when hiding discrepancies", () => {
+    updateConnectionsService.actions$.next([
+      ...CONNECTION_ACTIONS,
+      { ...HIDE_DISCREPANCY_ACTION }
+    ]);
+
     component.updateConnectionForm.controls[actionText].setValue(
       ActionType.HIDE_DISCREPANCY
     );
-
     const reason = component.updateConnectionForm.controls[reasonText];
     expect(reason).toBeDefined();
     expect(component.reasons.length).toBe(0);

--- a/src/app/update-connections/update-connection/update-connection.component.spec.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.spec.ts
@@ -1,10 +1,5 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import {
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  tick
-} from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";

--- a/src/app/update-connections/update-connection/update-connection.component.spec.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.spec.ts
@@ -106,8 +106,7 @@ describe("UpdateConnectionComponent", () => {
     expect(dbc).toBeDefined();
   });
 
-  xit("form should not have reasons when action is not add / remove", () => {
-    // NO HIDE CONNECTION YET
+  it("form should not have reasons when action is not add / remove", () => {
     component.updateConnectionForm.controls[actionText].setValue(
       ActionType.HIDE_DISCREPANCY
     );

--- a/src/app/update-connections/update-connection/update-connection.component.ts
+++ b/src/app/update-connections/update-connection/update-connection.component.ts
@@ -1,5 +1,9 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
-import { UntypedFormControl, UntypedFormGroup, Validators } from "@angular/forms";
+import {
+  UntypedFormControl,
+  UntypedFormGroup,
+  Validators
+} from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { Observable, Subscription } from "rxjs";
 import { AuthService } from "src/app/core/auth/auth.service";
@@ -127,9 +131,9 @@ export class UpdateConnectionComponent implements OnInit {
           }
 
           this.reasonControl.setValue("");
-          this.reasons = this.actions.find(
-            (arm) => arm.action === action
-          )?.reasons;
+          this.reasons =
+            this.actions.find((arm) => arm.action === action)?.reasons || [];
+
           this.reasonControl.updateValueAndValidity();
         }
       })

--- a/src/app/update-connections/update-connections.interfaces.ts
+++ b/src/app/update-connections/update-connections.interfaces.ts
@@ -1,8 +1,7 @@
 export enum ActionType {
   ADD_CONNECTION = "Add connection",
   REMOVE_CONNECTION = "Remove connection",
-  HIDE_DISCREPANCY = "Hide discrepancy",
-  SHOW_DISCREPANCY = "Show discrepancy"
+  HIDE_DISCREPANCY = "Hide discrepancy"
 }
 
 export interface IAction {

--- a/src/app/update-connections/update-connections.interfaces.ts
+++ b/src/app/update-connections/update-connections.interfaces.ts
@@ -1,8 +1,8 @@
 export enum ActionType {
   ADD_CONNECTION = "Add connection",
   REMOVE_CONNECTION = "Remove connection",
-  HIDE_CONNECTION = "Hide connection",
-  UNHIDE_CONNECTION = "Unhide connection"
+  HIDE_DISCREPANCY = "Hide discrepancy",
+  SHOW_DISCREPANCY = "Show discrepancy"
 }
 
 export interface IAction {


### PR DESCRIPTION
* Update connectionFilterType enum to remove redundant values
* Update values to hide/show values in ActionType enum
* Include hide discrepancy as dropdown option in update connections and only show on discrepancies list
* Remove hide discrepancy from option on connection detail page as not able to distinguish between discrepancy and non-discrepancy
* Set payload for hide discrepancy as different from connect/disconnect payload

TIS21-8546