### PR TITLE
feat: show only hidden discrepancies for user dbcs

### DIFF
--- a/src/app/connection/connection.component.html
+++ b/src/app/connection/connection.component.html
@@ -6,7 +6,7 @@
   </div>
 } @else {
   @if (connectionHistory$ | async; as connectionHistory) {
-    @if (hiddenDiscrepancies$ | async; as hiddenDiscrepancies) {
+    @if (hiddenDiscrepanciesForUser$ | async; as hiddenDiscrepancies) {
       <mat-card class="mb-20" appearance="outlined">
         <mat-card-title>Current designated body</mat-card-title>
         <ng-container *ngIf="doctorCurrentDbc$ | async; else NoDBC">

--- a/src/app/connection/connection.component.ts
+++ b/src/app/connection/connection.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { Select, Store } from "@ngxs/store";
-import { Observable, Subscription, combineLatest } from "rxjs";
+import { Observable, Subscription, combineLatest, map } from "rxjs";
 
 import { environment } from "@environment";
 import {
@@ -54,6 +54,7 @@ export class ConnectionComponent implements OnInit, OnDestroy {
   @Select(DetailsSideNavState.traineeDetails)
   traineeDetails$: Observable<IDetailsSideNav>;
 
+  hiddenDiscrepanciesForUser$: Observable<IHiddenDiscrepancy[]>;
   dateFormat = environment.dateFormat;
   connectionsColumnsToDisplay = [
     "newDesignatedBodyCode",
@@ -80,6 +81,7 @@ export class ConnectionComponent implements OnInit, OnDestroy {
   submitting = false;
   programmeOwnerDBC: string;
   updatingDiscrepancyIds: string[] = [];
+  userDesignatedBodies: string[] = [];
   constructor(
     private store: Store,
     private authService: AuthService,
@@ -92,6 +94,17 @@ export class ConnectionComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.userDesignatedBodies = this.authService.userDesignatedBodies;
+    this.hiddenDiscrepanciesForUser$ = this.hiddenDiscrepancies$.pipe(
+      map((discrepancies) =>
+        discrepancies?.filter((discrepancy) =>
+          this.userDesignatedBodies.includes(
+            discrepancy.hiddenForDesignatedBodyCode
+          )
+        )
+      )
+    );
+
     this.subscriptions.add(
       combineLatest({
         gmcNumber: this.gmcNumber$,

--- a/src/app/connection/specs/connection-hidden-discrepancies.component.spec.ts
+++ b/src/app/connection/specs/connection-hidden-discrepancies.component.spec.ts
@@ -52,7 +52,7 @@ describe("ConnectionHiddenDiscrepanciesComponent", () => {
     fixture.detectChanges();
     expect(eventEmitterSpy).toHaveBeenCalledWith({
       discrepancyId: "69cb99444dadd14f27a0d092",
-      hiddenForDesignatedBodyCode: "1-RSSQ05"
+      hiddenForDesignatedBodyCode: "1-1RUZV1D"
     });
   });
 });

--- a/src/app/connection/specs/connection.component.spec.ts
+++ b/src/app/connection/specs/connection.component.spec.ts
@@ -25,6 +25,7 @@ import {
   CONNECTION_ACTIONS,
   HIDE_DISCREPANCY_ACTION
 } from "src/app/update-connections/constants";
+import { AuthService } from "src/app/core/auth/auth.service";
 
 @Pipe({ name: "formatDesignatedBody" })
 class MockFormatDesignatedBodyPipe implements PipeTransform {
@@ -53,6 +54,7 @@ describe("ConnectionComponent", () => {
   let snackBarService: SnackBarService;
   let connectionService: ConnectionService;
   let store: Store;
+  let authService: AuthService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -75,6 +77,7 @@ describe("ConnectionComponent", () => {
       providers: [
         FormatDesignatedBodyPipe,
         ConnectionService,
+        AuthService,
         { provide: MatDialog, useValue: matDialogMock }
       ]
     }).compileComponents();
@@ -86,7 +89,7 @@ describe("ConnectionComponent", () => {
     fixture = TestBed.createComponent(ConnectionComponent);
     store = TestBed.inject(Store);
     connectionService = TestBed.inject(ConnectionService);
-
+    authService = TestBed.inject(AuthService);
     store.reset({
       traineeDetails: {
         item: {
@@ -111,7 +114,7 @@ describe("ConnectionComponent", () => {
       }
     });
     component = fixture.componentInstance;
-
+    authService.userDesignatedBodies = ["1-1RUZV1D"];
     fixture.detectChanges();
   });
 
@@ -226,12 +229,24 @@ describe("ConnectionComponent", () => {
       ActionType.REMOVE_CONNECTION
     );
   });
+
   it("should display hidden discrepancies details component when available", () => {
     expect(
       fixture.debugElement.query(
         By.css("[data-testid='component-hidden-discrepancies']")
       )
     ).toBeTruthy();
+  });
+
+  it("should NOT display hidden discrepancies details component when user DBC does not match", () => {
+    authService.userDesignatedBodies = [];
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(
+        By.css("[data-testid='component-hidden-discrepancies']")
+      )
+    ).toBeFalsy();
   });
 
   it("should NOT display hidden discrepancies details component when NONE available", () => {
@@ -314,7 +329,7 @@ describe("ConnectionComponent", () => {
 
     expect(component.submitting).toBeTruthy();
     expect(updateConnectionService.hideDiscrepancy).toHaveBeenCalledWith({
-      adminDesignatedBodyCodes: [],
+      adminDesignatedBodyCodes: ["1-1RUZV1D"],
       hiddenBy: "",
       reason: "Test reason for hiding discrepancy",
       doctors: [

--- a/src/app/connection/specs/mock-data/connection-details-spec-data.ts
+++ b/src/app/connection/specs/mock-data/connection-details-spec-data.ts
@@ -40,7 +40,7 @@ const hiddenDiscrepancies: IHiddenDiscrepancy[] = [
   {
     id: "69cb99444dadd14f27a0d092",
     gmcId: "123456",
-    hiddenForDesignatedBodyCode: "1-RSSQ05",
+    hiddenForDesignatedBodyCode: "1-1RUZV1D",
     hiddenBy: "test",
     reason:
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eget mi ultrices, aliquam lectus et, faucibus magna.",


### PR DESCRIPTION
In the doctors detail page, only include hidden discrepancy details that overlap with the users assigned DBCs.

TIS21-8285