### PR TITLE
feat: override default error message behaviour

### DIFF
--- a/src/app/shared/material/errorStateMatcher.ts
+++ b/src/app/shared/material/errorStateMatcher.ts
@@ -1,0 +1,8 @@
+import { ErrorStateMatcher } from "@angular/material/core";
+import { FormControl } from "@angular/forms";
+
+export class ShowOnInvalidErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(control: FormControl | null): boolean {
+    return !!(control && control.invalid);
+  }
+}

--- a/src/app/shared/material/material.module.ts
+++ b/src/app/shared/material/material.module.ts
@@ -27,7 +27,8 @@ import {
   MatNativeDateModule,
   MAT_DATE_LOCALE,
   DateAdapter,
-  MAT_DATE_FORMATS
+  MAT_DATE_FORMATS,
+  ErrorStateMatcher
 } from "@angular/material/core";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatStepperModule } from "@angular/material/stepper";
@@ -38,6 +39,7 @@ import {
   MAT_MOMENT_DATE_ADAPTER_OPTIONS,
   MomentDateAdapter
 } from "@angular/material-moment-adapter";
+import { ShowOnInvalidErrorStateMatcher } from "./errorStateMatcher";
 
 export const CUSTOM_DATE_FORMAT = {
   parse: {
@@ -97,7 +99,8 @@ const materialModules = [
     },
     { provide: MAT_DATE_FORMATS, useValue: CUSTOM_DATE_FORMAT },
     { provide: MAT_DATE_LOCALE, useValue: "en-GB" },
-    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }
+    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } },
+    { provide: ErrorStateMatcher, useClass: ShowOnInvalidErrorStateMatcher }
   ]
 })
 export class MaterialModule {}

--- a/src/app/update-connections/update-connection/update-connection.component.html
+++ b/src/app/update-connections/update-connection/update-connection.component.html
@@ -1,5 +1,11 @@
 <mat-card appearance="outlined">
   <mat-card-title>Update connection</mat-card-title>
+  @if (hideDiscrepancySelected) {
+    <mat-card-subtitle
+      >Leave the Hide until date field blank to permanently hide the
+      discrepancy.</mat-card-subtitle
+    >
+  }
   <form [formGroup]="updateConnectionForm">
     <div class="d-grid grid-container-3-col">
       <mat-form-field data-cy="update-connection-action">
@@ -106,7 +112,7 @@
       }
     </div>
 
-    <div class="d-grid grid-container-3-col">
+    <div class="d-grid grid-container-3-col mt-20">
       <div class="d-grid grid-container-3-col">
         @if (canCancel) {
           <button


### PR DESCRIPTION
Set the error message on required fields to show by default rather than waiting until the field is dirty to help clarify which fields are required as asterisk alone is not obvious.

TIS21-8660